### PR TITLE
install credo only in dev and test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -316,7 +316,7 @@ defmodule Jido.MixProject do
       {:abacus, "~> 2.1"},
 
       # Development & Test Dependencies
-      {:credo, "~> 1.7"},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:doctor, "~> 0.21", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},


### PR DESCRIPTION
Currently, it is impossible to have Jido and Credo as dependencies in my project. Credo recommends to only install it in the dev and test environments, but Jido prevents this in its current state. This patch fixes that.

https://hexdocs.pm/credo/1.7.11/installation.html

Relevant error message:

```
Dependencies have diverged:
* credo (Hex package)
  the :only option for dependency credo

  > In mix.exs:
    {:credo, "~> 1.7", [env: :prod, hex: "credo", only: [:dev, :test], runtime: false, repo: "hexpm"]}

  does not match the :only option calculated for

  > In deps/ex_dbug/mix.exs:
    {:credo, "~> 1.7", [env: :prod, hex: "credo", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```

`ex_dbug` is a dependency of Credo and it originates from the Credo dependency in Jido.