### PR TITLE
Docs: Correct module alias for Chain in getting-started.livemd

### DIFF
--- a/guides/getting-started.livemd
+++ b/guides/getting-started.livemd
@@ -153,7 +153,7 @@ end
 Now that we have our individual actions, let's see how we can chain them together using Jido's workflow system:
 
 ```elixir
-alias Jido.Workflow.Chain
+alias Jido.Exec.Chain
 
 # Our initial test data
 user_data = %{


### PR DESCRIPTION
This PR updates the `getting-started.livemd` guide to use the correct module alias for action chaining.

The guide previously used `alias Jido.Workflow.Chain`, but the `chain/3` function for executing workflows is located in `Jido.Exec.Chain` in the current codebase.

With this change, the chaining examples in the "Getting Started" guide now work as expected against the `main` branch.

Addresses issue # #23