### PR TITLE
Improve `timeout` across Jido Actions and Runners

### DIFF
--- a/guides/actions/configuration.md
+++ b/guides/actions/configuration.md
@@ -1,0 +1,284 @@
+# Action Configuration
+
+This guide covers how to configure Jido actions for optimal performance and behavior in your application.
+
+## Timeout Configuration
+
+Timeout configuration is one of the most important aspects of action setup, as it determines how long actions can run before being terminated.
+
+### Global Configuration
+
+Set the default timeout for all actions in your application configuration:
+
+```elixir
+# config/config.exs
+config :jido, default_timeout: 60_000  # 60 seconds (default: 30 seconds)
+
+# For production environments, you might want longer timeouts
+# config/prod.exs  
+config :jido, default_timeout: 120_000  # 2 minutes
+```
+
+### Runtime Configuration Levels
+
+Jido supports timeout configuration at multiple levels with clear precedence rules:
+
+#### 1. Direct Execution Timeouts (Highest Precedence)
+
+```elixir
+# Override timeout for specific execution
+{:ok, result} = Jido.Exec.run(MyAction, params, context, timeout: 45_000)
+
+# Disable timeout completely
+{:ok, result} = Jido.Exec.run(MyAction, params, context, timeout: 0)
+```
+
+#### 2. Instruction-Level Timeouts
+
+```elixir
+# Set timeout in instruction options
+instruction = %Jido.Instruction{
+  action: LongRunningAction,
+  params: %{data: large_dataset},
+  opts: [timeout: 300_000]  # 5 minutes for this specific action
+}
+```
+
+#### 3. Runner-Level Timeouts
+
+```elixir
+# Apply timeout to all instructions processed by runner
+{:ok, agent, directives} = Jido.Runner.Simple.run(agent, timeout: 45_000)
+{:ok, agent, directives} = Jido.Runner.Chain.run(agent, timeout: 120_000)
+```
+
+#### 4. Global Configuration (Lowest Precedence)
+
+The global configuration serves as the default when no other timeout is specified.
+
+### Timeout Precedence Example
+
+```elixir
+# Global config: 30 seconds
+config :jido, default_timeout: 30_000
+
+# Runner timeout: 60 seconds (overrides global for instructions without timeout)
+runner_opts = [timeout: 60_000]
+
+instructions = [
+  %Instruction{
+    action: FastAction,
+    opts: [timeout: 5_000]    # Uses 5 seconds (instruction-level wins)
+  },
+  %Instruction{
+    action: NormalAction,
+    opts: []                  # Uses 60 seconds (runner-level)
+  }
+]
+
+# Direct execution override: 10 seconds (highest precedence)
+{:ok, result} = Jido.Exec.run(UrgentAction, params, context, timeout: 10_000)
+```
+
+## Special Timeout Values
+
+### Infinite Timeout
+
+Use `timeout: 0` to disable timeout completely:
+
+```elixir
+# For long-running batch operations
+{:ok, result} = Jido.Exec.run(BatchProcessor, 
+  %{items: millions_of_items}, 
+  %{}, 
+  timeout: 0
+)
+
+# In instruction options
+batch_instruction = %Instruction{
+  action: DataMigration,
+  params: %{migration_id: "2024_01_big_migration"},
+  opts: [timeout: 0]  # No time limit
+}
+```
+
+**⚠️ Warning**: Use infinite timeouts sparingly. They can lead to resource exhaustion and make your system unresponsive.
+
+### Recommended Timeout Values
+
+| Use Case | Recommended Timeout | Example |
+|----------|-------------------|---------|
+| Quick calculations | 5-15 seconds | Math operations, simple validations |
+| API calls | 30-60 seconds | External service calls, HTTP requests |
+| Database operations | 30-120 seconds | Complex queries, bulk inserts |
+| File processing | 2-10 minutes | Image processing, PDF generation |
+| Data migrations | No timeout | Large dataset operations |
+
+## Agent Integration
+
+Agents can configure default timeouts for their runners:
+
+### Simple Agent Configuration
+
+```elixir
+defmodule MyApp.ProcessingAgent do
+  use Jido.Agent,
+    name: "processing_agent",
+    runner: Jido.Runner.Simple
+
+  def start_link(opts \\ []) do
+    # Set default timeout for this agent's runner
+    runner_opts = [timeout: 90_000]  # 90 seconds
+    opts = Keyword.put(opts, :runner_opts, runner_opts)
+    super(opts)
+  end
+end
+```
+
+### Chain Agent Configuration
+
+```elixir
+defmodule MyApp.WorkflowAgent do
+  use Jido.Agent,
+    name: "workflow_agent", 
+    runner: Jido.Runner.Chain
+
+  def start_link(opts \\ []) do
+    # Longer timeout for complex workflows
+    runner_opts = [
+      timeout: 300_000,        # 5 minutes per action
+      merge_results: true,     # Chain results between actions
+      apply_directives?: true  # Apply directives during execution
+    ]
+    opts = Keyword.put(opts, :runner_opts, runner_opts)
+    super(opts)
+  end
+end
+```
+
+## Environment-Specific Configuration
+
+Different environments often require different timeout configurations:
+
+```elixir
+# config/config.exs - Base configuration
+config :jido, default_timeout: 30_000
+
+# config/dev.exs - Development (faster feedback)
+config :jido, default_timeout: 15_000
+
+# config/test.exs - Testing (quick failures)
+config :jido, default_timeout: 5_000
+
+# config/prod.exs - Production (more tolerance)
+config :jido, default_timeout: 120_000
+```
+
+## Runtime Configuration Updates
+
+For dynamic timeout adjustments based on system load or other factors:
+
+```elixir
+defmodule MyApp.AdaptiveTimeout do
+  def get_timeout_for_action(action) do
+    base_timeout = Application.get_env(:jido, :default_timeout, 30_000)
+    
+    case action do
+      # CPU-intensive actions need more time
+      action when action in [ImageProcessor, DataAnalyzer] ->
+        base_timeout * 3
+        
+      # Quick actions can use less time  
+      action when action in [Validator, Formatter] ->
+        div(base_timeout, 2)
+        
+      # Default timeout for unknown actions
+      _ ->
+        base_timeout
+    end
+  end
+end
+
+# Usage
+timeout = MyApp.AdaptiveTimeout.get_timeout_for_action(MyAction)
+{:ok, result} = Jido.Exec.run(MyAction, params, context, timeout: timeout)
+```
+
+## Monitoring and Debugging
+
+### Timeout Logging
+
+Enable timeout-specific logging to monitor action performance:
+
+```elixir
+# Enable debug logging for timeouts
+{:ok, result} = Jido.Exec.run(MyAction, params, context, 
+  timeout: 60_000, 
+  log_level: :debug
+)
+```
+
+### Timeout Telemetry
+
+Monitor timeout patterns using Jido's built-in telemetry:
+
+```elixir
+:telemetry.attach(
+  "timeout-monitor",
+  [:jido, :action, :error],
+  fn name, measurements, metadata, config ->
+    case metadata.result do
+      {:error, %{type: :timeout}} ->
+        Logger.warning("Action timeout: #{metadata.action}", metadata)
+      _ -> :ok
+    end
+  end,
+  nil
+)
+```
+
+## Best Practices
+
+1. **Set appropriate defaults**: Configure global timeouts based on your application's typical action duration
+2. **Use environment-specific configs**: Different environments need different timeout tolerances
+3. **Monitor timeout patterns**: Track which actions frequently timeout and adjust accordingly
+4. **Prefer specific over general**: Use instruction-level timeouts for actions with known special requirements
+5. **Test timeout scenarios**: Include timeout testing in your test suite
+6. **Document timeout decisions**: Explain why specific timeouts were chosen for critical actions
+
+## Troubleshooting
+
+### Common Timeout Issues
+
+**Actions timing out frequently**
+- Increase timeout for that specific action or globally
+- Optimize the action's implementation
+- Check for blocking operations or inefficient algorithms
+
+**Actions running too long**
+- Decrease timeout to fail faster
+- Add progress indicators or chunking for long operations
+- Consider breaking large actions into smaller ones
+
+**Inconsistent timeout behavior**
+- Check timeout precedence rules
+- Verify configuration is loaded correctly
+- Look for runtime timeout overrides
+
+### Debugging Timeout Configuration
+
+```elixir
+# Check current timeout configuration
+current_default = Application.get_env(:jido, :default_timeout)
+IO.puts("Global default timeout: #{current_default}ms")
+
+# Test timeout precedence
+instruction = %Instruction{action: TestAction, opts: [timeout: 5000]}
+IO.puts("Instruction timeout: #{instruction.opts[:timeout]}ms")
+```
+
+## Next Steps
+
+- Learn about [Action Testing](testing.md) including timeout scenarios
+- Explore [Runner Configuration](runners.md) for advanced timeout handling
+- Check out [Workflow Execution](workflows.md) for timeout in complex workflows

--- a/guides/actions/overview.md
+++ b/guides/actions/overview.md
@@ -222,6 +222,7 @@ end
 
 ## Next Steps
 
+- Learn about [Action Configuration](configuration.md) including timeout settings
 - Learn about [Action Workflows](workflows.html)
 - Explore [Testing Actions](testing.html)
 - Understand [Action Directives](directives.html)
@@ -229,6 +230,7 @@ end
 
 ## See Also
 
+- [Action Configuration](configuration.md)
 - [Signal Overview](../signals/overview.livemd)
 - [Agent Overview](../agents/overview.md)
 - [Action Testing](testing.md)

--- a/guides/actions/workflows.md
+++ b/guides/actions/workflows.md
@@ -55,9 +55,12 @@ Workflow.run(%Instruction{} = instruction)
 
 ### Timeouts
 
-By default, Actions have a 5 second timeout. You can customize this:
+By default, Actions have a 30 second timeout. You can customize this globally or per-action:
 
 ```elixir
+# Global configuration (in config.exs)
+config :jido, default_timeout: 60_000  # 60 seconds
+
 # Disable timeout completely
 Workflow.run(MyAction, %{}, %{}, timeout: 0)
 

--- a/guides/getting-started.livemd
+++ b/guides/getting-started.livemd
@@ -263,6 +263,29 @@ case Chain.chain([FormatUser, EnrichUserData, NotifyUser], invalid_data) do
 end
 ```
 
+## Configuration
+
+### Global Timeout Settings
+
+By default, Jido actions have a 30-second timeout. You can configure this globally in your application:
+
+```elixir
+# config/config.exs
+config :jido, default_timeout: 60_000  # 60 seconds
+```
+
+### Per-Action Timeouts
+
+You can also set timeouts for individual actions:
+
+```elixir
+# Run with a custom timeout
+{:ok, result} = Jido.Exec.run(FormatUser, %{name: "Alice", email: "alice@example.com", age: 30}, %{}, timeout: 10_000)
+
+# Disable timeout completely for long-running operations
+{:ok, result} = Jido.Exec.run(LongRunningAction, params, %{}, timeout: 0)
+```
+
 ## Next Steps
 
 Now that you understand the basics of Jido actions and workflows, you can:
@@ -271,5 +294,6 @@ Now that you understand the basics of Jido actions and workflows, you can:
 2. Build more complex workflows with branching and conditions
 3. Add error compensation and rollback handling
 4. Create agents that use these actions
+5. Configure timeouts and other execution options for your use case
 
 The complete Jido documentation has more examples and advanced features to explore!

--- a/lib/jido/exec.ex
+++ b/lib/jido/exec.ex
@@ -286,6 +286,7 @@ defmodule Jido.Exec do
   """
   @spec await(async_ref(), timeout()) :: {:ok, map()} | {:error, Error.t()}
   def await(%{ref: ref, pid: pid}, timeout \\ @default_timeout) do
+    timeout = if timeout == 0, do: :infinity, else: timeout
     dbug("Awaiting async action result", ref: ref, pid: pid, timeout: timeout)
 
     receive do

--- a/lib/jido/exec.ex
+++ b/lib/jido/exec.ex
@@ -36,6 +36,18 @@ defmodule Jido.Exec do
       # ... do other work ...
       result = Jido.Exec.await(async_ref)
 
+  ## Configuration
+
+  The default timeout for action execution can be configured using the Application environment:
+
+      config :jido, default_timeout: 60_000  # 60 seconds
+
+  If not configured, the default timeout is 30 seconds (30,000 milliseconds).
+
+  Special timeout values:
+  - `timeout: 0` - Disables timeout completely, actions run without time limits
+  - Any positive integer - Sets timeout in milliseconds
+
   """
 
   use Private
@@ -49,7 +61,7 @@ defmodule Jido.Exec do
 
   import Jido.Util, only: [cond_log: 3]
 
-  @default_timeout 5000
+  @default_timeout Application.compile_env(:jido, :default_timeout, 30_000)
   @default_max_retries 1
   @initial_backoff 250
 
@@ -255,7 +267,7 @@ defmodule Jido.Exec do
   ## Parameters
 
   - `async_ref`: The reference returned by `run_async/4`.
-  - `timeout`: Maximum time (in ms) to wait for the result (default: 5000).
+  - `timeout`: Maximum time (in ms) to wait for the result (default: #{@default_timeout}).
 
   ## Returns
 
@@ -273,7 +285,7 @@ defmodule Jido.Exec do
       {:error, %Jido.Error{type: :timeout, message: "Async action timed out after 100ms"}}
   """
   @spec await(async_ref(), timeout()) :: {:ok, map()} | {:error, Error.t()}
-  def await(%{ref: ref, pid: pid}, timeout \\ 5000) do
+  def await(%{ref: ref, pid: pid}, timeout \\ @default_timeout) do
     dbug("Awaiting async action result", ref: ref, pid: pid, timeout: timeout)
 
     receive do
@@ -689,9 +701,9 @@ defmodule Jido.Exec do
         timeout =
           Keyword.get(opts, :timeout) ||
             case compensation_opts do
-              opts when is_list(opts) -> Keyword.get(opts, :timeout, 5_000)
+              opts when is_list(opts) -> Keyword.get(opts, :timeout, @default_timeout)
               %{timeout: timeout} -> timeout
-              _ -> 5_000
+              _ -> @default_timeout
             end
 
         dbug("Starting compensation", action: action, timeout: timeout)

--- a/test/jido/runner/chain_runner_test.exs
+++ b/test/jido/runner/chain_runner_test.exs
@@ -405,13 +405,15 @@ defmodule Jido.Runner.ChainTest do
           action: Add,
           params: %{value: 0, amount: 1},
           context: %{},
-          opts: [timeout: 5000]  # Instruction-specific timeout
+          # Instruction-specific timeout
+          opts: [timeout: 5000]
         },
         %Instruction{
           action: Add,
           params: %{value: 1, amount: 1},
           context: %{},
-          opts: []  # No timeout in this instruction
+          # No timeout in this instruction
+          opts: []
         }
       ]
 
@@ -429,13 +431,15 @@ defmodule Jido.Runner.ChainTest do
           action: Add,
           params: %{value: 0, amount: 1},
           context: %{},
-          opts: []  # No timeout in instruction
+          # No timeout in instruction
+          opts: []
         },
         %Instruction{
           action: Add,
           params: %{value: 1, amount: 1},
           context: %{},
-          opts: []  # No timeout in instruction
+          # No timeout in instruction
+          opts: []
         }
       ]
 
@@ -453,13 +457,15 @@ defmodule Jido.Runner.ChainTest do
           action: Add,
           params: %{value: 0, amount: 1},
           context: %{},
-          opts: [timeout: 5000, retry: true]  # Instruction has some opts
+          # Instruction has some opts
+          opts: [timeout: 5000, retry: true]
         },
         %Instruction{
           action: Add,
           params: %{value: 1, amount: 1},
           context: %{},
-          opts: [timeout: 2000]  # Different timeout
+          # Different timeout
+          opts: [timeout: 2000]
         }
       ]
 
@@ -467,9 +473,9 @@ defmodule Jido.Runner.ChainTest do
       agent = %{agent | pending_instructions: :queue.from_list(instructions)}
 
       # Runner provides different opts, should be merged with instruction opts taking precedence
-      assert {:ok, updated_agent, []} = 
-        Chain.run(agent, timeout: 1000, log_level: :debug, apply_directives?: false)
-      
+      assert {:ok, updated_agent, []} =
+               Chain.run(agent, timeout: 1000, log_level: :debug, apply_directives?: false)
+
       assert updated_agent.result == %{value: 2}
       # Each instruction should have received merged opts with instruction opts taking precedence
     end
@@ -480,7 +486,8 @@ defmodule Jido.Runner.ChainTest do
           action: Add,
           params: %{value: 0, amount: 1},
           context: %{},
-          opts: [timeout: 0]  # Disable timeout for this instruction
+          # Disable timeout for this instruction
+          opts: [timeout: 0]
         }
       ]
 

--- a/test/jido/runner/simple_runner_test.exs
+++ b/test/jido/runner/simple_runner_test.exs
@@ -327,7 +327,8 @@ defmodule Jido.Runner.SimpleTest do
         action: Add,
         params: %{value: 0, amount: 1},
         context: %{},
-        opts: [timeout: 5000]  # Instruction-specific timeout
+        # Instruction-specific timeout
+        opts: [timeout: 5000]
       }
 
       agent = FullFeaturedAgent.new("test-agent")
@@ -343,7 +344,8 @@ defmodule Jido.Runner.SimpleTest do
         action: Add,
         params: %{value: 0, amount: 1},
         context: %{},
-        opts: []  # No timeout in instruction
+        # No timeout in instruction
+        opts: []
       }
 
       agent = FullFeaturedAgent.new("test-agent")
@@ -359,16 +361,17 @@ defmodule Jido.Runner.SimpleTest do
         action: Add,
         params: %{value: 0, amount: 1},
         context: %{},
-        opts: [timeout: 5000, retry: true]  # Instruction has some opts
+        # Instruction has some opts
+        opts: [timeout: 5000, retry: true]
       }
 
       agent = FullFeaturedAgent.new("test-agent")
       agent = %{agent | pending_instructions: :queue.from_list([instruction])}
 
       # Runner provides different opts
-      assert {:ok, %FullFeaturedAgent{} = updated_agent, []} = 
-        Simple.run(agent, timeout: 1000, log_level: :debug, apply_directives?: false)
-      
+      assert {:ok, %FullFeaturedAgent{} = updated_agent, []} =
+               Simple.run(agent, timeout: 1000, log_level: :debug, apply_directives?: false)
+
       assert updated_agent.result == %{value: 1}
       # The instruction should have received merged opts with instruction opts taking precedence
     end

--- a/test/jido/runner/simple_runner_test.exs
+++ b/test/jido/runner/simple_runner_test.exs
@@ -321,5 +321,56 @@ defmodule Jido.Runner.SimpleTest do
       assert enqueued.action == :next_action
       assert enqueued.params == %{value: 42}
     end
+
+    test "merges runner timeout with instruction opts (instruction opts take precedence)" do
+      instruction = %Instruction{
+        action: Add,
+        params: %{value: 0, amount: 1},
+        context: %{},
+        opts: [timeout: 5000]  # Instruction-specific timeout
+      }
+
+      agent = FullFeaturedAgent.new("test-agent")
+      agent = %{agent | pending_instructions: :queue.from_list([instruction])}
+
+      # Runner provides a different timeout, but instruction timeout should win
+      assert {:ok, %FullFeaturedAgent{} = updated_agent, []} = Simple.run(agent, timeout: 1000)
+      assert updated_agent.result == %{value: 1}
+    end
+
+    test "uses runner timeout when instruction has no timeout" do
+      instruction = %Instruction{
+        action: Add,
+        params: %{value: 0, amount: 1},
+        context: %{},
+        opts: []  # No timeout in instruction
+      }
+
+      agent = FullFeaturedAgent.new("test-agent")
+      agent = %{agent | pending_instructions: :queue.from_list([instruction])}
+
+      # Runner timeout should be used
+      assert {:ok, %FullFeaturedAgent{} = updated_agent, []} = Simple.run(agent, timeout: 1000)
+      assert updated_agent.result == %{value: 1}
+    end
+
+    test "merges all opts correctly" do
+      instruction = %Instruction{
+        action: Add,
+        params: %{value: 0, amount: 1},
+        context: %{},
+        opts: [timeout: 5000, retry: true]  # Instruction has some opts
+      }
+
+      agent = FullFeaturedAgent.new("test-agent")
+      agent = %{agent | pending_instructions: :queue.from_list([instruction])}
+
+      # Runner provides different opts
+      assert {:ok, %FullFeaturedAgent{} = updated_agent, []} = 
+        Simple.run(agent, timeout: 1000, log_level: :debug, apply_directives?: false)
+      
+      assert updated_agent.result == %{value: 1}
+      # The instruction should have received merged opts with instruction opts taking precedence
+    end
   end
 end


### PR DESCRIPTION
- Introduced global and per-action timeout settings in the documentation.
- Updated guides to reflect timeout precedence rules and special timeout values.
- Enhanced runner implementations to support timeout merging with instruction options.
- Added tests to verify correct timeout handling in both simple and chain runners.

This update improves the configurability and robustness of action execution in Jido, allowing users to tailor timeout settings to their specific use cases.