### PR TITLE
Fix/convert child spec

### DIFF
--- a/lib/jido/agent/server_process.ex
+++ b/lib/jido/agent/server_process.ex
@@ -233,10 +233,18 @@ defmodule Jido.Agent.Server.Process do
   end
 
   defp convert_child_spec({module, args}) when is_atom(module) and is_list(args) do
+    start_args =
+      if Keyword.keyword?(args) do
+        # Wrap keyword list in a list
+        [args]
+      else
+        args
+      end
+
     {:ok,
      %{
        id: module,
-       start: {module, :start_link, args},
+       start: {module, :start_link, start_args},
        type: :worker,
        restart: :permanent
      }}


### PR DESCRIPTION
This PR fixes a bug in server_process.ex where the convert_child_spec/1 function does not properly handle the case where a keyword list should be passed to the child start_link function.

A test was also added    