### PR TITLE
Fix/skill child_spec/1

### DIFF
--- a/lib/jido/agent/server_skills.ex
+++ b/lib/jido/agent/server_skills.ex
@@ -102,10 +102,7 @@ defmodule Jido.Agent.Server.Skills do
             # Validate routes
             if is_list(new_routes) do
               # Get child_spec from the skill
-              skill_child_spec = skill.child_spec(validated_opts)
-
-              new_child_specs =
-                if is_list(skill_child_spec), do: skill_child_spec, else: [skill_child_spec]
+              new_child_specs = List.wrap(skill.child_spec(validated_opts))
 
               dbug("Got skill child specs", child_specs: new_child_specs)
 

--- a/lib/jido/agent/server_skills.ex
+++ b/lib/jido/agent/server_skills.ex
@@ -102,7 +102,11 @@ defmodule Jido.Agent.Server.Skills do
             # Validate routes
             if is_list(new_routes) do
               # Get child_spec from the skill
-              new_child_specs = [skill.child_spec(validated_opts)]
+              skill_child_spec = skill.child_spec(validated_opts)
+
+              new_child_specs =
+                if is_list(skill_child_spec), do: skill_child_spec, else: [skill_child_spec]
+
               dbug("Got skill child specs", child_specs: new_child_specs)
 
               # Continue processing with updated accumulators

--- a/test/support/test_skills.ex
+++ b/test/support/test_skills.ex
@@ -300,6 +300,22 @@ defmodule JidoTest.TestSkills do
     end
   end
 
+  defmodule MockSkillWithListChildSpecs do
+    @moduledoc false
+    use Jido.Skill,
+      name: "mock_skill_with_list_child_specs",
+      description: "Mock skill with list of child specs",
+      opts_key: :mock_skill_with_list_child_specs
+
+    @impl true
+    def child_spec(_opts \\ []) do
+      [
+        {Task, [fn -> :ok end]},
+        {Agent, [fn -> %{} end]}
+      ]
+    end
+  end
+
   # Mock skill with router function
   defmodule MockSkillWithRouter do
     @moduledoc """


### PR DESCRIPTION
fixes a bug where Skill.build would not correctly handle the case where a skill defines a multiple children 