### PR TITLE
Update type specifications in Jido.Agent callbacks

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -1210,8 +1210,10 @@ defmodule Jido.Agent do
   # Server Callbacks
   @callback start_link(opts :: keyword()) :: {:ok, pid()} | {:error, any()}
   @callback child_spec(opts :: keyword()) :: Supervisor.child_spec()
-  @callback mount(agent :: t(), opts :: keyword()) :: {:ok, map()} | {:error, any()}
-  @callback shutdown(agent :: t(), reason :: any()) :: {:ok, map()} | {:error, any()}
+  @callback mount(state :: Jido.Agent.Server.State.t(), opts :: keyword()) ::
+              {:ok, Jido.Agent.Server.State.t()} | {:error, term()}
+  @callback shutdown(state :: Jido.Agent.Server.State.t(), reason :: term()) ::
+              {:ok, Jido.Agent.Server.State.t()} | {:error, term()}
   @callback handle_signal(signal :: Signal.t(), agent :: t()) ::
               {:ok, Signal.t()} | {:error, any()}
   @callback transform_result(


### PR DESCRIPTION
Fixes #62

- Refined the type specifications for the `mount` and `shutdown` callbacks in the Jido.Agent module to use the `Jido.Agent.Server.State.t()` type, enhancing clarity and type safety.
- Updated the return types to reflect the new state structure, ensuring consistency across the module.

These changes improve the robustness of the Jido framework by providing clearer contracts for agent behavior.