### PR TITLE
Test DSL Part I: add spawn_agent/1 and send_signal/3

### DIFF
--- a/test/jido/agent/server_test.exs
+++ b/test/jido/agent/server_test.exs
@@ -335,6 +335,13 @@ defmodule Jido.Agent.ServerTest do
       spawn_agent(JidoTest.TestAgents.FullFeaturedAgent)
       |> send_signal("system.startup", %{version: "1.0.0"})
       |> send_signal("config.loaded", %{env: "test"})
-    end
+    result =
+        spawn_agent(JidoTest.TestAgents.FullFeaturedAgent)
+        |> send_signal("system.startup", %{version: "1.0.0"})
+        |> send_signal("config.loaded", %{env: "test"})
+
+      assert result.agent.__struct__ == JidoTest.TestAgents.FullFeaturedAgent
+      assert is_pid(result.server_pid)
+      assert Process.alive?(result.server_pid)
   end
 end

--- a/test/jido/agent/server_test.exs
+++ b/test/jido/agent/server_test.exs
@@ -366,5 +366,17 @@ defmodule Jido.Agent.ServerTest do
       {:ok, state} = GenServer.call(result.server_pid, {:signal, state_signal})
       assert state.status == :idle
     end
+
+    test "spawn_agent validates agent modules properly" do
+      # Should raise error for non-agent modules
+      assert_raise ArgumentError, ~r/does not implement the Jido.Agent behavior/, fn ->
+        spawn_agent(String)
+      end
+
+      # Should raise error for non-existent modules  
+      assert_raise ArgumentError, ~r/could not be loaded/, fn ->
+        spawn_agent(NonExistentModule)
+      end
+    end
   end
 end

--- a/test/jido/agent/server_test.exs
+++ b/test/jido/agent/server_test.exs
@@ -332,16 +332,17 @@ defmodule Jido.Agent.ServerTest do
     end
 
     test "works with different agent types" do
-      spawn_agent(JidoTest.TestAgents.FullFeaturedAgent)
-      |> send_signal("system.startup", %{version: "1.0.0"})
-      |> send_signal("config.loaded", %{env: "test"})
-    result =
-        spawn_agent(JidoTest.TestAgents.FullFeaturedAgent)
+      custom_agent = JidoTest.TestAgents.FullFeaturedAgent
+
+      result =
+        custom_agent
+        |> spawn_agent()
         |> send_signal("system.startup", %{version: "1.0.0"})
         |> send_signal("config.loaded", %{env: "test"})
 
-      assert result.agent.__struct__ == JidoTest.TestAgents.FullFeaturedAgent
+      assert result.agent.__struct__ == custom_agent
       assert is_pid(result.server_pid)
       assert Process.alive?(result.server_pid)
+    end
   end
 end

--- a/test/support/agent_case.ex
+++ b/test/support/agent_case.ex
@@ -78,8 +78,22 @@ defmodule JidoTest.AgentCase do
   end
 
   defp validate_agent_module!(module) do
-    unless is_atom(module) and function_exported?(module, :new, 1) do
-      raise ArgumentError, "Expected agent module with new/1 function, got: #{inspect(module)}"
+    unless is_atom(module) do
+      raise ArgumentError, "Expected agent module, got: #{inspect(module)}"
+    end
+
+    try do
+      test_agent = module.new("test_#{System.unique_integer()}")
+
+      unless is_struct(test_agent) do
+        raise "new/1 did not return a struct"
+      end
+    rescue
+      UndefinedFunctionError ->
+        reraise ArgumentError, "Agent module #{inspect(module)} does not implement new/1"
+
+      e ->
+        reraise ArgumentError, "Agent module #{inspect(module)} new/1 failed: #{inspect(e)}"
     end
   end
 

--- a/test/support/agent_case.ex
+++ b/test/support/agent_case.ex
@@ -1,0 +1,95 @@
+defmodule JidoTest.AgentCase do
+  @moduledoc """
+  DSL for testing Jido agents with pipeline syntax.
+
+  ## Quick Start
+
+      test "user registration flow" do
+        spawn_agent(MyAgent)
+        |> send_signal("user.registered", %{id: 123})
+        |> send_signal("profile.completed", %{name: "John"})
+        |> send_signal("email.verified")
+      end
+
+  ## Available Functions
+
+  - `spawn_agent/2` - Spawn an agent with automatic cleanup
+  - `send_signal/3` - Send a signal and return context for chaining
+
+  """
+
+  alias Jido.Agent.Server
+  alias Jido.Signal
+
+  @type agent_context :: %{agent: struct(), server_pid: pid()}
+  @type agent_or_context :: agent_context() | struct()
+
+  @doc """
+  Spawn an agent for testing with automatic cleanup.
+
+  Returns a context that can be chained with `send_signal/3`.
+  """
+  @spec spawn_agent(module(), keyword()) :: agent_context()
+  def spawn_agent(agent_module \\ JidoTest.TestAgents.BasicAgent, opts \\ []) do
+    validate_agent_module!(agent_module)
+
+    agent = agent_module.new("test_agent_#{System.unique_integer([:positive])}")
+
+    {:ok, server_pid} =
+      Server.start_link(
+        [
+          agent: agent,
+          id: agent.id,
+          mode: :step,
+          registry: Jido.Registry
+        ] ++ opts
+      )
+
+    context = %{agent: agent, server_pid: server_pid}
+    ExUnit.Callbacks.on_exit(fn -> stop_test_agent(context) end)
+    context
+  end
+
+  @doc """
+  Send a signal to an agent and return context for chaining.
+  """
+  @spec send_signal(agent_or_context(), String.t(), map()) :: agent_context()
+  def send_signal(context, signal_type, data \\ %{})
+
+  def send_signal(%{agent: agent, server_pid: server_pid} = context, signal_type, data)
+      when is_binary(signal_type) and is_map(data) do
+    validate_process!(server_pid)
+
+    {:ok, signal} = Signal.new(%{type: signal_type, data: data, source: "test", target: agent.id})
+    {:ok, _} = Server.cast(server_pid, signal)
+
+    context
+  end
+
+  def send_signal(agent, signal_type, data) when is_struct(agent) do
+    # Handle direct agent struct - look up server by agent ID
+    case Jido.resolve_pid(agent.id) do
+      {:ok, server_pid} ->
+        send_signal(%{agent: agent, server_pid: server_pid}, signal_type, data)
+
+      {:error, _reason} ->
+        raise "Agent server not found for ID: #{agent.id}"
+    end
+  end
+
+  defp validate_agent_module!(module) do
+    unless is_atom(module) and function_exported?(module, :new, 1) do
+      raise ArgumentError, "Expected agent module with new/1 function, got: #{inspect(module)}"
+    end
+  end
+
+  defp validate_process!(pid) do
+    unless Process.alive?(pid) do
+      raise RuntimeError, "Agent process is not alive"
+    end
+  end
+
+  defp stop_test_agent(%{server_pid: server_pid}) do
+    if Process.alive?(server_pid), do: GenServer.stop(server_pid, :normal, 1000)
+  end
+end

--- a/test/support/agent_case.ex
+++ b/test/support/agent_case.ex
@@ -90,10 +90,16 @@ defmodule JidoTest.AgentCase do
       end
     rescue
       UndefinedFunctionError ->
-        reraise ArgumentError, "Agent module #{inspect(module)} does not implement new/1"
+        reraise ArgumentError.exception(
+                  "Agent module #{inspect(module)} does not implement new/1"
+                ),
+                __STACKTRACE__
 
       e ->
-        reraise ArgumentError, "Agent module #{inspect(module)} new/1 failed: #{inspect(e)}"
+        reraise ArgumentError.exception(
+                  "Agent module #{inspect(module)} new/1 failed: #{inspect(e)}"
+                ),
+                __STACKTRACE__
     end
   end
 

--- a/test/support/jido_case.ex
+++ b/test/support/jido_case.ex
@@ -1,6 +1,8 @@
 defmodule JidoTest.Case do
   @moduledoc """
   Test case helper module providing common test functionality for Jido tests.
+
+  Includes agent DSL functionality for testing agent workflows.
   """
 
   use ExUnit.CaseTemplate
@@ -8,9 +10,9 @@ defmodule JidoTest.Case do
   using do
     quote do
       # Import test helpers
-
       import JidoTest.Case
       import JidoTest.Helpers.Assertions
+      import JidoTest.AgentCase
 
       @moduletag :capture_log
     end


### PR DESCRIPTION
This pull request introduces the ability to chain signal calls to an agent, addressing issue #68.

This will let us spawn an agent (if none provided, we use the BasicAgent) and after each send_signal/3 call we get the context back so we can keep chaining more signals. 

It's not meant to close #68 as we have other DSL functions to implement which can be better addressed in separate PRs given their own complexity.

