### PR TITLE
Replace deprecated jido_dispatch field with Signal extensions

### DIFF
--- a/lib/jido/agent/server_output.ex
+++ b/lib/jido/agent/server_output.ex
@@ -76,7 +76,10 @@ defmodule Jido.Agent.Server.Output do
     level = get_level_for_signal(signal)
 
     # Configure dispatch with the appropriate level
-    base_dispatch = Keyword.get(opts, :dispatch) || signal.jido_dispatch || @default_dispatch
+    # Use extension API instead of deprecated jido_dispatch field
+    base_dispatch =
+      Keyword.get(opts, :dispatch) || Signal.get_extension(signal, "dispatch") || @default_dispatch
+
     dispatch_config = add_level_to_dispatch(base_dispatch, level)
 
     log(

--- a/lib/jido/agent/server_runtime.ex
+++ b/lib/jido/agent/server_runtime.ex
@@ -175,9 +175,10 @@ defmodule Jido.Agent.Server.Runtime do
       with {:ok, processed_result} <-
              ServerCallback.transform_result(state, state.current_signal, result) do
         # Use the signal's dispatch config if present, otherwise use server's default
+        # Use extension API instead of deprecated jido_dispatch field
         dispatch_config =
-          case state.current_signal do
-            %Signal{jido_dispatch: dispatch} when not is_nil(dispatch) ->
+          case Signal.get_extension(state.current_signal, "dispatch") do
+            dispatch when not is_nil(dispatch) ->
               dispatch
 
             _ ->
@@ -215,9 +216,10 @@ defmodule Jido.Agent.Server.Runtime do
         case state.current_signal_type do
           :async ->
             # Use the signal's dispatch config if present, otherwise use server's default
+            # Use extension API instead of deprecated jido_dispatch field
             dispatch_config =
-              case state.current_signal do
-                %Signal{jido_dispatch: dispatch} when not is_nil(dispatch) ->
+              case Signal.get_extension(state.current_signal, "dispatch") do
+                dispatch when not is_nil(dispatch) ->
                   dispatch
 
                 _ ->


### PR DESCRIPTION
## Summary
- Replace usage of deprecated `jido_dispatch` struct field with Signal extension API
- Uses `Signal.put_extension/3` and `Signal.get_extension/2` instead

## Changes
- `lib/jido/agent/server_signal.ex` - Use `Signal.put_extension` to set dispatch config
- `lib/jido/agent/server_output.ex` - Use `Signal.get_extension` to read dispatch config  
- `lib/jido/agent/server_runtime.ex` - Use `Signal.get_extension` in pattern matches

## Why
The `jido_dispatch` field on Signal struct is deprecated and triggers compile warnings. The extension API is the CloudEvents-compliant replacement.