### PR TITLE
fix: harden async handling and stabilize tests

### DIFF
--- a/lib/jido/agent/instance_manager.ex
+++ b/lib/jido/agent/instance_manager.ex
@@ -190,8 +190,15 @@ defmodule Jido.Agent.InstanceManager do
   @spec lookup(manager_name(), key()) :: {:ok, pid()} | :error
   def lookup(manager, key) do
     case Registry.lookup(registry_name(manager), key) do
-      [{pid, _}] -> {:ok, pid}
-      [] -> :error
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          {:ok, pid}
+        else
+          :error
+        end
+
+      [] ->
+        :error
     end
   end
 

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -466,7 +466,13 @@ defmodule Jido.AgentServer do
   @spec attach(server(), pid()) :: :ok | {:error, term()}
   def attach(server, owner_pid \\ self()) do
     with {:ok, pid} <- resolve_server(server) do
-      GenServer.call(pid, {:attach, owner_pid})
+      try do
+        GenServer.call(pid, {:attach, owner_pid})
+      catch
+        :exit, {:noproc, _} -> {:error, :not_found}
+        :exit, {:timeout, _} -> {:error, :timeout}
+        :exit, reason -> {:error, reason}
+      end
     end
   end
 
@@ -486,7 +492,13 @@ defmodule Jido.AgentServer do
   @spec detach(server(), pid()) :: :ok | {:error, term()}
   def detach(server, owner_pid \\ self()) do
     with {:ok, pid} <- resolve_server(server) do
-      GenServer.call(pid, {:detach, owner_pid})
+      try do
+        GenServer.call(pid, {:detach, owner_pid})
+      catch
+        :exit, {:noproc, _} -> {:error, :not_found}
+        :exit, {:timeout, _} -> {:error, :timeout}
+        :exit, reason -> {:error, reason}
+      end
     end
   end
 

--- a/lib/jido/await.ex
+++ b/lib/jido/await.ex
@@ -205,6 +205,10 @@ defmodule Jido.Await do
       {:await_result, ref, server, {:ok, result}} ->
         collect_all(Map.delete(waiters, ref), Map.put(acc, server, result), deadline)
 
+      {:await_result, ref, _server, {:error, :timeout}} ->
+        kill_waiters(Map.delete(waiters, ref))
+        {:error, :timeout}
+
       {:await_result, ref, server, {:error, reason}} ->
         kill_waiters(Map.delete(waiters, ref))
         {:error, {server, reason}}
@@ -267,6 +271,10 @@ defmodule Jido.Await do
       {:await_result, ref, server, {:ok, result}} ->
         kill_waiters(Map.delete(waiters, ref))
         {:ok, {server, result}}
+
+      {:await_result, ref, _server, {:error, :timeout}} ->
+        kill_waiters(Map.delete(waiters, ref))
+        {:error, :timeout}
 
       {:await_result, ref, server, {:error, reason}} ->
         kill_waiters(Map.delete(waiters, ref))

--- a/test/jido/agent/instance_manager_test.exs
+++ b/test/jido/agent/instance_manager_test.exs
@@ -132,7 +132,6 @@ defmodule JidoTest.Agent.InstanceManagerTest do
       {:ok, manager: manager_name}
     end
 
-    @tag :flaky
     test "stop/2 terminates agent", %{manager: manager} do
       {:ok, pid} = InstanceManager.get(manager, "stop-key")
       assert Process.alive?(pid)

--- a/test/jido/agent_server/agent_server_stop_log_test.exs
+++ b/test/jido/agent_server/agent_server_stop_log_test.exs
@@ -1,0 +1,54 @@
+defmodule JidoTest.AgentServerStopLogTest do
+  use JidoTest.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.AgentServer
+  alias Jido.Agent.Directive
+  alias Jido.Signal
+
+  defmodule StopTestAction do
+    @moduledoc false
+    use Jido.Action, name: "stop_test", schema: []
+
+    def run(_params, _context) do
+      {:ok, %{}, [%Directive.Stop{reason: :normal}]}
+    end
+  end
+
+  defmodule TestAgent do
+    @moduledoc false
+    use Jido.Agent, name: "test_agent", schema: []
+
+    def signal_routes do
+      [{"stop_test", StopTestAction}]
+    end
+  end
+
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :warning)
+
+    on_exit(fn ->
+      Logger.configure(level: previous_level)
+    end)
+
+    :ok
+  end
+
+  test "Stop directive with normal reason logs warning", %{jido: jido} do
+    log =
+      capture_log(fn ->
+        {:ok, pid} = AgentServer.start_link(agent: TestAgent, jido: jido)
+        ref = Process.monitor(pid)
+
+        signal = Signal.new!("stop_test", %{}, source: "/test")
+        AgentServer.cast(pid, signal)
+
+        assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      end)
+
+    assert log =~ "received {:stop, :normal"
+    assert log =~ "This is a HARD STOP"
+  end
+end

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -321,31 +321,6 @@ defmodule JidoTest.AgentServerTest do
 
       assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
     end
-
-    test "Stop directive with normal reason logs warning", %{jido: jido} do
-      import ExUnit.CaptureLog
-
-      # Temporarily enable warning logs for this test
-      previous_level = Logger.level()
-      Logger.configure(level: :warning)
-
-      log =
-        capture_log(fn ->
-          {:ok, pid} = AgentServer.start_link(agent: TestAgent, jido: jido)
-          ref = Process.monitor(pid)
-
-          signal = Signal.new!("stop_test", %{}, source: "/test")
-          AgentServer.cast(pid, signal)
-
-          assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
-        end)
-
-      # Restore previous log level
-      Logger.configure(level: previous_level)
-
-      assert log =~ "received {:stop, :normal"
-      assert log =~ "This is a HARD STOP"
-    end
   end
 
   describe "unknown signals" do

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -373,8 +373,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       assert {:ok, ^state_with_child} =
                DirectiveExec.exec(stop_directive, input_signal, state_with_child)
 
-      Process.sleep(50)
-      refute Process.alive?(child_pid)
+      refute_eventually(Process.alive?(child_pid))
     end
 
     test "returns ok when child tag not found", %{state: state, input_signal: input_signal} do

--- a/test/jido/agent_server/hierarchy_test.exs
+++ b/test/jido/agent_server/hierarchy_test.exs
@@ -257,7 +257,7 @@ defmodule JidoTest.AgentServer.HierarchyTest do
 
       [event] = child_state.agent.state.orphan_events
       assert event.parent_id == "parent-orphan-1"
-      assert event.reason == :normal
+      assert event.reason in [:normal, :noproc]
 
       GenServer.stop(child_pid)
     end

--- a/test/jido/await_coverage_test.exs
+++ b/test/jido/await_coverage_test.exs
@@ -186,7 +186,7 @@ defmodule JidoTest.AwaitCoverageTest do
 
       result = Await.any([pid1, pid2], 50)
 
-      assert match?({:error, :timeout}, result) or match?({:error, {_, :timeout}}, result)
+      assert {:error, :timeout} = result
 
       GenServer.stop(pid1)
       GenServer.stop(pid2)

--- a/test/jido/await_test.exs
+++ b/test/jido/await_test.exs
@@ -216,9 +216,7 @@ defmodule JidoTest.AwaitTest do
         AgentServer.start_link(agent: AwaitAgent, id: "await-any-timeout-2", jido: jido)
 
       result = Await.any([pid1, pid2], 50)
-      # When an individual server times out, we get {:error, {server, :timeout}}
-      # When no messages arrive at all, we get {:error, :timeout}
-      assert match?({:error, :timeout}, result) or match?({:error, {_, :timeout}}, result)
+      assert {:error, :timeout} = result
 
       GenServer.stop(pid1)
       GenServer.stop(pid2)

--- a/test/jido/observe/observe_coverage_test.exs
+++ b/test/jido/observe/observe_coverage_test.exs
@@ -15,9 +15,14 @@ defmodule JidoTest.ObserveCoverageTest do
   alias Jido.Observe
 
   setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
     original_config = Application.get_env(:jido, :observability)
 
     on_exit(fn ->
+      Logger.configure(level: previous_level)
+
       if original_config do
         Application.put_env(:jido, :observability, original_config)
       else

--- a/test/jido/observe/observe_test.exs
+++ b/test/jido/observe/observe_test.exs
@@ -10,6 +10,17 @@ defmodule JidoTest.ObserveTest do
   alias Jido.Observe.Log
   alias Jido.Observe.NoopTracer
 
+  setup do
+    previous_level = Logger.level()
+    Logger.configure(level: :debug)
+
+    on_exit(fn ->
+      Logger.configure(level: previous_level)
+    end)
+
+    :ok
+  end
+
   describe "with_span/3" do
     setup do
       test_pid = self()


### PR DESCRIPTION
## Summary
- Normalize await timeout errors and make InstanceManager attach/detach/lookup resilient to race exits
- Replace timing sleeps with eventual assertions and accept valid orphan reasons
- Make log-capture tests independent of global LOG_LEVEL (dedicated stop-log test + per-test Logger level)

## Why
Tests were failing under non-debug log levels and on timing-sensitive races (attach/stop/drain). This isolates logging config from test expectations and removes racey timing assumptions.

## Testing
- mix test
