### PR TITLE
refactor: decompose large macros and improve code organization

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,25 @@ import Config
 
 config :jido, default: Jido.DefaultInstance
 
+# Logger configuration for Jido telemetry metadata
+# These metadata keys are used by Jido.Telemetry for structured logging
+config :logger, :default_formatter,
+  format: "[$level] $message $metadata\n",
+  metadata: [
+    :agent_id,
+    :agent_module,
+    :action,
+    :directive_count,
+    :directive_type,
+    :duration_μs,
+    :error,
+    :instruction_count,
+    :queue_size,
+    :result,
+    :signal_type,
+    :strategy
+  ]
+
 # Git hooks and git_ops configuration for conventional commits
 # Only enabled in dev environment (git_ops is a dev-only dependency)
 if config_env() == :dev do

--- a/lib/jido.ex
+++ b/lib/jido.ex
@@ -1,6 +1,8 @@
 defmodule Jido do
   use Supervisor
 
+  alias Jido.Agent.WorkerPool
+
   @moduledoc """
   自動 (Jido) - A foundational framework for building autonomous, distributed agent systems in Elixir.
 
@@ -201,7 +203,7 @@ defmodule Jido do
     ]
 
     pool_children =
-      Jido.Agent.WorkerPool.build_pool_child_specs(name, Keyword.get(opts, :agent_pools, []))
+      WorkerPool.build_pool_child_specs(name, Keyword.get(opts, :agent_pools, []))
 
     Supervisor.init(base_children ++ pool_children, strategy: :one_for_one)
   end

--- a/lib/jido/agent/state_ops.ex
+++ b/lib/jido/agent/state_ops.ex
@@ -17,6 +17,7 @@ defmodule Jido.Agent.StateOps do
   """
 
   alias Jido.Agent
+  alias Jido.Agent.State
   alias Jido.Agent.StateOp
 
   @doc """
@@ -26,7 +27,7 @@ defmodule Jido.Agent.StateOps do
   """
   @spec apply_result(Agent.t(), map()) :: Agent.t()
   def apply_result(%Agent{} = agent, result) when is_map(result) do
-    new_state = Jido.Agent.State.merge(agent.state, result)
+    new_state = State.merge(agent.state, result)
     %{agent | state: new_state}
   end
 
@@ -42,7 +43,7 @@ defmodule Jido.Agent.StateOps do
   def apply_state_ops(%Agent{} = agent, effects) do
     Enum.reduce(effects, {agent, []}, fn
       %StateOp.SetState{attrs: attrs}, {a, directives} ->
-        new_state = Jido.Agent.State.merge(a.state, attrs)
+        new_state = State.merge(a.state, attrs)
         {%{a | state: new_state}, directives}
 
       %StateOp.ReplaceState{state: new_state}, {a, directives} ->

--- a/lib/jido/agent/strategy.ex
+++ b/lib/jido/agent/strategy.ex
@@ -76,6 +76,7 @@ defmodule Jido.Agent.Strategy do
   `:__strategy__`. Use `Jido.Agent.Strategy.State` helpers to manage it.
   """
 
+  alias Jido.Action.Tool, as: ActionTool
   alias Jido.Agent
   alias Jido.Agent.Strategy.State, as: StratState
 
@@ -354,7 +355,7 @@ defmodule Jido.Agent.Strategy do
         end
 
       is_list(schema) ->
-        Jido.Action.Tool.convert_params_using_schema(params, schema)
+        ActionTool.convert_params_using_schema(params, schema)
 
       true ->
         atomized
@@ -377,11 +378,9 @@ defmodule Jido.Agent.Strategy do
   defp atomize_string_keys(other), do: other
 
   defp safe_to_atom(str) when is_binary(str) do
-    try do
-      String.to_existing_atom(str)
-    rescue
-      ArgumentError -> String.to_atom(str)
-    end
+    String.to_existing_atom(str)
+  rescue
+    ArgumentError -> String.to_atom(str)
   end
 
   defmacro __using__(_opts) do
@@ -401,7 +400,7 @@ defmodule Jido.Agent.Strategy do
       @impl true
       @spec snapshot(Jido.Agent.t(), Jido.Agent.Strategy.context()) ::
               Jido.Agent.Strategy.Snapshot.t()
-      def snapshot(agent, _ctx), do: Jido.Agent.Strategy.default_snapshot(agent)
+      def snapshot(agent, _ctx), do: unquote(__MODULE__).default_snapshot(agent)
 
       defoverridable init: 2, tick: 2, snapshot: 2
     end

--- a/lib/jido/agent/strategy/fsm.ex
+++ b/lib/jido/agent/strategy/fsm.ex
@@ -155,15 +155,7 @@ defmodule Jido.Agent.Strategy.FSM do
       {:ok, machine} ->
         {agent, machine, directives} = process_instructions(agent, machine, instructions)
 
-        machine =
-          if auto_transition do
-            case Machine.transition(machine, initial_state) do
-              {:ok, m} -> m
-              {:error, _} -> machine
-            end
-          else
-            machine
-          end
+        machine = maybe_auto_transition(machine, auto_transition, initial_state)
 
         agent = StratState.put(agent, %{state | machine: machine})
         {agent, directives}
@@ -182,6 +174,15 @@ defmodule Jido.Agent.Strategy.FSM do
 
       {new_agent, new_machine, acc_directives ++ new_directives}
     end)
+  end
+
+  defp maybe_auto_transition(machine, false, _initial_state), do: machine
+
+  defp maybe_auto_transition(machine, true, initial_state) do
+    case Machine.transition(machine, initial_state) do
+      {:ok, m} -> m
+      {:error, _} -> machine
+    end
   end
 
   defp run_instruction(agent, machine, %Instruction{} = instruction) do

--- a/lib/jido/agent_server/error_policy.ex
+++ b/lib/jido/agent_server/error_policy.ex
@@ -13,6 +13,7 @@ defmodule Jido.AgentServer.ErrorPolicy do
 
   alias Jido.Agent.Directive.Error, as: ErrorDirective
   alias Jido.AgentServer.State
+  alias Jido.Signal.Dispatch, as: SignalDispatch
 
   @type result :: {:ok, State.t()} | {:stop, term(), State.t()}
 
@@ -61,12 +62,12 @@ defmodule Jido.AgentServer.ErrorPolicy do
   defp emit_error_signal(error, context, state, dispatch_cfg) do
     signal = build_error_signal(error, context, state)
 
-    if Code.ensure_loaded?(Jido.Signal.Dispatch) do
+    if Code.ensure_loaded?(SignalDispatch) do
       task_supervisor =
         if state.jido, do: Jido.task_supervisor_name(state.jido), else: Jido.TaskSupervisor
 
       Task.Supervisor.start_child(task_supervisor, fn ->
-        Jido.Signal.Dispatch.dispatch(signal, dispatch_cfg)
+        SignalDispatch.dispatch(signal, dispatch_cfg)
       end)
     else
       Logger.warning("Jido.Signal.Dispatch not available, skipping error signal emit")

--- a/lib/jido/igniter/templates.ex
+++ b/lib/jido/igniter/templates.ex
@@ -53,10 +53,7 @@ defmodule Jido.Igniter.Templates do
           signal_patterns :: [String.t()]
         ) :: String.t()
   def skill_template(module, name, state_key, signal_patterns) do
-    patterns_str =
-      signal_patterns
-      |> Enum.map(&~s("#{&1}"))
-      |> Enum.join(", ")
+    patterns_str = Enum.map_join(signal_patterns, ", ", &~s("#{&1}"))
 
     """
     defmodule #{module} do

--- a/lib/jido/observe.ex
+++ b/lib/jido/observe.ex
@@ -78,7 +78,9 @@ defmodule Jido.Observe do
 
   require Logger
 
+  alias Jido.Observe.Log
   alias Jido.Observe.SpanCtx
+  alias Jido.Tracing.Context, as: TracingContext
 
   @type event_prefix :: [atom()]
   @type metadata :: map()
@@ -287,7 +289,7 @@ defmodule Jido.Observe do
   """
   @spec log(Logger.level(), Logger.message(), keyword()) :: :ok
   def log(level, message, metadata \\ []) do
-    Jido.Observe.Log.log(level, message, metadata)
+    Log.log(level, message, metadata)
   end
 
   @doc """
@@ -409,8 +411,8 @@ defmodule Jido.Observe do
   end
 
   defp correlation_metadata do
-    if Code.ensure_loaded?(Jido.Tracing.Context) do
-      Jido.Tracing.Context.to_telemetry_metadata()
+    if Code.ensure_loaded?(TracingContext) do
+      TracingContext.to_telemetry_metadata()
     else
       %{}
     end

--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -48,6 +48,8 @@ defmodule Jido.Sensor.Runtime do
 
   require Logger
 
+  alias Jido.Signal.Dispatch
+
   @type server :: pid() | atom() | {:via, module(), term()}
 
   @doc """
@@ -293,8 +295,8 @@ defmodule Jido.Sensor.Runtime do
         send(agent_ref, {:signal, signal})
 
       agent_ref != nil ->
-        if Code.ensure_loaded?(Jido.Signal.Dispatch) do
-          Jido.Signal.Dispatch.dispatch(signal, agent_ref)
+        if Code.ensure_loaded?(Dispatch) do
+          Dispatch.dispatch(signal, agent_ref)
         else
           Logger.warning("Jido.Signal.Dispatch not available, cannot deliver signal")
         end

--- a/lib/jido/skill/instance.ex
+++ b/lib/jido/skill/instance.ex
@@ -26,6 +26,8 @@ defmodule Jido.Skill.Instance do
       Instance.new({MySkill, as: :sales, token: "sales-token"})
   """
 
+  alias Jido.Skill.Config
+
   @schema Zoi.struct(
             __MODULE__,
             %{
@@ -83,7 +85,7 @@ defmodule Jido.Skill.Instance do
     base_state_key = manifest.state_key
     base_name = manifest.name
 
-    resolved_config = Jido.Skill.Config.resolve_config!(module, overrides)
+    resolved_config = Config.resolve_config!(module, overrides)
 
     state_key = derive_state_key(base_state_key, as_opt)
     route_prefix = derive_route_prefix(base_name, as_opt)

--- a/lib/jido/skill/requirements.ex
+++ b/lib/jido/skill/requirements.ex
@@ -136,12 +136,10 @@ defmodule Jido.Skill.Requirements do
   @spec format_error(%{String.t() => [requirement()]}) :: String.t()
   def format_error(missing_by_skill) do
     parts =
-      missing_by_skill
-      |> Enum.map(fn {skill_name, requirements} ->
-        reqs_str = requirements |> Enum.map(&inspect/1) |> Enum.join(", ")
+      Enum.map_join(missing_by_skill, "; ", fn {skill_name, requirements} ->
+        reqs_str = Enum.map_join(requirements, ", ", &inspect/1)
         "#{skill_name} requires #{reqs_str}"
       end)
-      |> Enum.join("; ")
 
     "Missing requirements for skills: #{parts}"
   end

--- a/lib/jido/util.ex
+++ b/lib/jido/util.ex
@@ -18,6 +18,8 @@ defmodule Jido.Util do
   but they can also be useful for developers building applications with Jido.
   """
 
+  alias Jido.Signal.ID, as: SignalID
+
   require OK
   require Logger
 
@@ -27,7 +29,7 @@ defmodule Jido.Util do
   Generates a unique ID.
   """
   @spec generate_id() :: String.t()
-  def generate_id, do: Jido.Signal.ID.generate!()
+  def generate_id, do: SignalID.generate!()
 
   @doc """
   Converts a string to a binary.

--- a/lib/mix/tasks/jido.gen.agent.ex
+++ b/lib/mix/tasks/jido.gen.agent.ex
@@ -19,6 +19,9 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
+    alias Igniter.Project.Module, as: IgniterModule
+    alias Jido.Igniter.Helpers
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -40,12 +43,12 @@ if Code.ensure_loaded?(Igniter) do
       positional = igniter.args.positional
 
       module_name = positional[:module]
-      module = Igniter.Project.Module.parse(module_name)
-      name = Jido.Igniter.Helpers.module_to_name(module_name)
+      module = IgniterModule.parse(module_name)
+      name = Helpers.module_to_name(module_name)
 
       skills =
         options[:skills]
-        |> Jido.Igniter.Helpers.parse_list()
+        |> Helpers.parse_list()
         |> Enum.map(&String.to_atom/1)
 
       skills_opt =
@@ -66,7 +69,7 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       test_module_name = "JidoTest.#{module_name |> String.replace(~r/^.*?\./, "")}"
-      test_module = Igniter.Project.Module.parse(test_module_name)
+      test_module = IgniterModule.parse(test_module_name)
 
       agent_alias = module |> Module.split() |> List.last()
 
@@ -91,8 +94,8 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       igniter
-      |> Igniter.Project.Module.create_module(module, contents)
-      |> Igniter.Project.Module.create_module(test_module, test_contents, location: :test)
+      |> IgniterModule.create_module(module, contents)
+      |> IgniterModule.create_module(test_module, test_contents, location: :test)
     end
   end
 end

--- a/lib/mix/tasks/jido.gen.sensor.ex
+++ b/lib/mix/tasks/jido.gen.sensor.ex
@@ -19,6 +19,9 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
+    alias Igniter.Project.Module, as: IgniterModule
+    alias Jido.Igniter.Helpers
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -40,8 +43,8 @@ if Code.ensure_loaded?(Igniter) do
       positional = igniter.args.positional
 
       module_name = positional[:module]
-      module = Igniter.Project.Module.parse(module_name)
-      name = Jido.Igniter.Helpers.module_to_name(module_name)
+      module = IgniterModule.parse(module_name)
+      name = Helpers.module_to_name(module_name)
       interval = options[:interval]
 
       contents = """
@@ -68,7 +71,7 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       test_module_name = "JidoTest.#{module_name |> String.replace(~r/^.*?\./, "")}"
-      test_module = Igniter.Project.Module.parse(test_module_name)
+      test_module = IgniterModule.parse(test_module_name)
 
       sensor_alias = module |> Module.split() |> List.last()
 
@@ -97,8 +100,8 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       igniter
-      |> Igniter.Project.Module.create_module(module, contents)
-      |> Igniter.Project.Module.create_module(test_module, test_contents, location: :test)
+      |> IgniterModule.create_module(module, contents)
+      |> IgniterModule.create_module(test_module, test_contents, location: :test)
     end
   end
 end

--- a/lib/mix/tasks/jido.gen.skill.ex
+++ b/lib/mix/tasks/jido.gen.skill.ex
@@ -19,6 +19,9 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
+    alias Igniter.Project.Module, as: IgniterModule
+    alias Jido.Igniter.Helpers
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -40,16 +43,13 @@ if Code.ensure_loaded?(Igniter) do
       positional = igniter.args.positional
 
       module_name = positional[:module]
-      module = Igniter.Project.Module.parse(module_name)
-      name = Jido.Igniter.Helpers.module_to_name(module_name)
+      module = IgniterModule.parse(module_name)
+      name = Helpers.module_to_name(module_name)
       state_key = name
 
-      signal_patterns = Jido.Igniter.Helpers.parse_list(options[:signals])
+      signal_patterns = Helpers.parse_list(options[:signals])
 
-      patterns_str =
-        signal_patterns
-        |> Enum.map(&~s("#{&1}"))
-        |> Enum.join(", ")
+      patterns_str = Enum.map_join(signal_patterns, ", ", &~s("#{&1}"))
 
       contents = """
       defmodule #{inspect(module)} do
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       test_module_name = "JidoTest.#{module_name |> String.replace(~r/^.*?\./, "")}"
-      test_module = Igniter.Project.Module.parse(test_module_name)
+      test_module = IgniterModule.parse(test_module_name)
 
       skill_alias = module |> Module.split() |> List.last()
 
@@ -95,8 +95,8 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       igniter
-      |> Igniter.Project.Module.create_module(module, contents)
-      |> Igniter.Project.Module.create_module(test_module, test_contents, location: :test)
+      |> IgniterModule.create_module(module, contents)
+      |> IgniterModule.create_module(test_module, test_contents, location: :test)
     end
   end
 end

--- a/lib/mix/tasks/jido.install.ex
+++ b/lib/mix/tasks/jido.install.ex
@@ -27,6 +27,9 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
+    alias Igniter.Project.Application
+    alias Igniter.Project.Config
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -48,11 +51,11 @@ if Code.ensure_loaded?(Igniter) do
     @impl Igniter.Mix.Task
     def igniter(igniter) do
       options = igniter.args.options
-      app_name = Igniter.Project.Application.app_name(igniter)
+      app_name = Application.app_name(igniter)
 
       igniter =
         igniter
-        |> Igniter.Project.Config.configure_new(
+        |> Config.configure_new(
           "config.exs",
           :jido,
           [:default_bus],
@@ -63,7 +66,7 @@ if Code.ensure_loaded?(Igniter) do
         if options[:no_supervisor] do
           igniter
         else
-          Igniter.Project.Application.add_new_child(
+          Application.add_new_child(
             igniter,
             {Jido.Bus.InMemory, name: :jido_bus},
             after: [Ecto.Repo, Phoenix.PubSub]

--- a/test/examples/emit_directive_test.exs
+++ b/test/examples/emit_directive_test.exs
@@ -15,9 +15,9 @@ defmodule JidoExampleTest.EmitDirectiveTest do
   @moduletag :example
   @moduletag timeout: 15_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Emit domain events
@@ -196,7 +196,7 @@ defmodule JidoExampleTest.EmitDirectiveTest do
       eventually(
         fn ->
           signals = SignalCollector.get_signals(collector)
-          length(signals) >= 1
+          signals != []
         end,
         timeout: 2_000
       )

--- a/test/examples/error_handling_test.exs
+++ b/test/examples/error_handling_test.exs
@@ -28,9 +28,9 @@ defmodule JidoExampleTest.ErrorHandlingTest do
   @moduletag :example
   @moduletag timeout: 15_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Error handling patterns

--- a/test/examples/hierarchical_agents_test.exs
+++ b/test/examples/hierarchical_agents_test.exs
@@ -54,10 +54,10 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
   @moduletag :example
   @moduletag timeout: 30_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.Agent.StateOp
   alias Jido.AgentServer
+  alias Jido.Signal
   alias Jido.Tracing.Trace
 
   # ===========================================================================
@@ -510,7 +510,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         fn ->
           case AgentServer.state(orchestrator_pid) do
             {:ok, %{agent: %{state: %{completed_jobs: jobs}}}} ->
-              length(jobs) >= 1
+              jobs != []
 
             _ ->
               false
@@ -560,8 +560,8 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
       eventually(
         fn ->
           case AgentServer.state(orchestrator_pid) do
-            {:ok, %{agent: %{state: %{completed_jobs: jobs}}}} ->
-              length(jobs) >= 2
+            {:ok, %{agent: %{state: %{completed_jobs: [_, _ | _]}}}} ->
+              true
 
             _ ->
               false
@@ -609,7 +609,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         fn ->
           case AgentServer.state(orchestrator_pid) do
             {:ok, %{agent: %{state: %{completed_jobs: jobs}}}} ->
-              length(jobs) >= 1
+              jobs != []
 
             _ ->
               false
@@ -619,7 +619,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
       )
 
       {:ok, final_state} = AgentServer.state(orchestrator_pid)
-      assert length(final_state.agent.state.completed_jobs) >= 1
+      assert final_state.agent.state.completed_jobs != []
     end
   end
 
@@ -648,7 +648,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         fn ->
           case AgentServer.state(orchestrator_pid) do
             {:ok, %{agent: %{state: %{completed_jobs: jobs}}}} ->
-              length(jobs) >= 1
+              jobs != []
 
             _ ->
               false
@@ -695,7 +695,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         fn ->
           case AgentServer.state(orchestrator_pid) do
             {:ok, %{agent: %{state: %{completed_jobs: jobs}}}} ->
-              length(jobs) >= 1
+              jobs != []
 
             _ ->
               false

--- a/test/examples/observability_test.exs
+++ b/test/examples/observability_test.exs
@@ -16,9 +16,9 @@ defmodule JidoExampleTest.ObservabilityTest do
   @moduletag :example
   @moduletag timeout: 15_000
 
+  alias Jido.AgentServer
   alias Jido.Observe
   alias Jido.Signal
-  alias Jido.AgentServer
   alias Jido.Tracing.Context, as: TraceContext
 
   # ===========================================================================
@@ -317,7 +317,7 @@ defmodule JidoExampleTest.ObservabilityTest do
 
       eventually(fn ->
         events = TelemetryCollector.get_events(collector)
-        length(events) >= 1
+        events != []
       end)
 
       [{event, measurements, metadata}] = TelemetryCollector.get_events(collector)

--- a/test/examples/parent_child_test.exs
+++ b/test/examples/parent_child_test.exs
@@ -42,10 +42,10 @@ defmodule JidoExampleTest.ParentChildTest do
   @moduletag :example
   @moduletag timeout: 25_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.Agent.StateOp
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Worker operations
@@ -264,7 +264,7 @@ defmodule JidoExampleTest.ParentChildTest do
         fn ->
           case AgentServer.state(coordinator_pid) do
             {:ok, %{agent: %{state: %{completed_responses: responses}}}} ->
-              length(responses) >= 1
+              responses != []
 
             _ ->
               false
@@ -299,7 +299,7 @@ defmodule JidoExampleTest.ParentChildTest do
         fn ->
           case AgentServer.state(coordinator_pid) do
             {:ok, %{agent: %{state: %{completed_responses: responses}}}} ->
-              length(responses) >= 1
+              responses != []
 
             _ ->
               false
@@ -345,7 +345,7 @@ defmodule JidoExampleTest.ParentChildTest do
         fn ->
           case AgentServer.state(coordinator_pid) do
             {:ok, %{agent: %{state: %{completed_responses: responses}}}} ->
-              length(responses) >= 3
+              match?([_, _, _ | _], responses)
 
             _ ->
               false
@@ -392,7 +392,7 @@ defmodule JidoExampleTest.ParentChildTest do
         fn ->
           case AgentServer.state(coordinator_pid) do
             {:ok, %{agent: %{state: %{completed_responses: responses}}}} ->
-              length(responses) >= 3
+              match?([_, _, _ | _], responses)
 
             _ ->
               false

--- a/test/examples/schedule_directive_test.exs
+++ b/test/examples/schedule_directive_test.exs
@@ -15,9 +15,9 @@ defmodule JidoExampleTest.ScheduleDirectiveTest do
   @moduletag :example
   @moduletag timeout: 20_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Schedule-based patterns

--- a/test/examples/sensor_demo_test.exs
+++ b/test/examples/sensor_demo_test.exs
@@ -14,8 +14,8 @@ defmodule JidoExampleTest.SensorDemoTest do
   @moduletag :example
   @moduletag timeout: 30_000
 
-  alias Jido.Signal
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Handle sensor and webhook signals
@@ -139,8 +139,8 @@ defmodule JidoExampleTest.SensorDemoTest do
     @moduledoc false
     use GenServer
 
-    alias Jido.Signal
     alias Jido.AgentServer
+    alias Jido.Signal
 
     @quotes [
       "The best way to predict the future is to create it.",
@@ -199,8 +199,8 @@ defmodule JidoExampleTest.SensorDemoTest do
 
   defmodule WebhookHelper do
     @moduledoc false
-    alias Jido.Signal
     alias Jido.AgentServer
+    alias Jido.Signal
 
     def emit_github_event(agent_target, event_type, payload) do
       signal =
@@ -257,7 +257,7 @@ defmodule JidoExampleTest.SensorDemoTest do
           agent_pid,
           fn state ->
             quotes = state.agent.state.quotes
-            length(quotes) >= 2
+            match?([_, _ | _], quotes)
           end,
           timeout: 5_000,
           interval: 50
@@ -298,7 +298,7 @@ defmodule JidoExampleTest.SensorDemoTest do
           agent_pid,
           fn state ->
             events = state.agent.state.events
-            length(events) >= 2
+            match?([_, _ | _], events)
           end,
           timeout: 5_000,
           interval: 50
@@ -338,7 +338,7 @@ defmodule JidoExampleTest.SensorDemoTest do
       # Wait for some quotes, then inject webhooks
       eventually_state(
         agent_pid,
-        fn state -> length(state.agent.state.quotes) >= 1 end,
+        fn state -> state.agent.state.quotes != [] end,
         timeout: 3_000,
         interval: 50
       )

--- a/test/examples/signal_routing_test.exs
+++ b/test/examples/signal_routing_test.exs
@@ -15,8 +15,8 @@ defmodule JidoExampleTest.SignalRoutingTest do
   @moduletag :example
   @moduletag timeout: 15_000
 
-  alias Jido.Signal
   alias Jido.AgentServer
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Handle different signal types

--- a/test/examples/spawn_agent_test.exs
+++ b/test/examples/spawn_agent_test.exs
@@ -25,10 +25,10 @@ defmodule JidoExampleTest.SpawnAgentTest do
   @moduletag :example
   @moduletag timeout: 20_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.AgentServer
   alias Jido.AgentServer.ParentRef
+  alias Jido.Signal
 
   # ===========================================================================
   # ACTIONS: Parent actions for spawning and managing children
@@ -241,7 +241,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
       child_info = await_child(parent_pid, :notified_worker)
 
       eventually_state(parent_pid, fn state ->
-        length(state.agent.state.child_started_events) > 0
+        state.agent.state.child_started_events != []
       end)
 
       {:ok, state} = AgentServer.state(parent_pid)
@@ -321,7 +321,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
       assert child_agent.state.last_task == "process data"
 
       eventually_state(parent_pid, fn state ->
-        length(state.agent.state.worker_results) > 0
+        state.agent.state.worker_results != []
       end)
 
       {:ok, parent_state} = AgentServer.state(parent_pid)

--- a/test/examples/tracing_test.exs
+++ b/test/examples/tracing_test.exs
@@ -22,9 +22,9 @@ defmodule JidoExampleTest.TracingTest do
   @moduletag :example
   @moduletag timeout: 15_000
 
-  alias Jido.Signal
   alias Jido.Agent.Directive
   alias Jido.AgentServer
+  alias Jido.Signal
   alias Jido.Tracing.Trace
 
   # ===========================================================================
@@ -180,7 +180,7 @@ defmodule JidoExampleTest.TracingTest do
 
       eventually(fn ->
         signals = TracedSignalCollector.get_signals(collector)
-        length(signals) >= 1
+        signals != []
       end)
 
       [emitted] = TracedSignalCollector.get_signals(collector)
@@ -214,7 +214,7 @@ defmodule JidoExampleTest.TracingTest do
 
       eventually(fn ->
         signals = TracedSignalCollector.get_signals(collector)
-        length(signals) >= 3
+        match?([_, _, _ | _], signals)
       end)
 
       signals = TracedSignalCollector.get_signals(collector)
@@ -251,7 +251,7 @@ defmodule JidoExampleTest.TracingTest do
 
       eventually(fn ->
         signals = TracedSignalCollector.get_signals(collector)
-        length(signals) >= 1
+        signals != []
       end)
 
       [emitted] = TracedSignalCollector.get_signals(collector)
@@ -281,7 +281,7 @@ defmodule JidoExampleTest.TracingTest do
 
       eventually(fn ->
         signals = TracedSignalCollector.get_signals(collector)
-        length(signals) >= 1
+        signals != []
       end)
 
       [emitted] = TracedSignalCollector.get_signals(collector)

--- a/test/jido/agent/agent_test.exs
+++ b/test/jido/agent/agent_test.exs
@@ -2,8 +2,8 @@ defmodule JidoTest.AgentTest do
   use ExUnit.Case, async: true
 
   alias Jido.Agent
-  alias JidoTest.TestAgents
   alias JidoTest.TestActions
+  alias JidoTest.TestAgents
 
   describe "module definition" do
     test "defines metadata accessors" do
@@ -253,7 +253,7 @@ defmodule JidoTest.AgentTest do
     end
 
     test "Agent.new/1 returns error for invalid id type" do
-      {:error, error} = Agent.new(%{id: 12345})
+      {:error, error} = Agent.new(%{id: 12_345})
       assert error.message == "Agent validation failed"
     end
 

--- a/test/jido/agent/directive_test.exs
+++ b/test/jido/agent/directive_test.exs
@@ -2,6 +2,7 @@ defmodule JidoTest.Agent.DirectiveTest do
   use ExUnit.Case, async: true
 
   alias Jido.Agent.Directive
+  alias Jido.AgentServer.ParentRef
 
   describe "emit/2" do
     test "creates Emit directive without dispatch" do
@@ -157,7 +158,7 @@ defmodule JidoTest.Agent.DirectiveTest do
       parent_pid = self()
 
       parent_ref =
-        Jido.AgentServer.ParentRef.new!(%{pid: parent_pid, id: "parent-123", tag: :child})
+        ParentRef.new!(%{pid: parent_pid, id: "parent-123", tag: :child})
 
       agent = %{state: %{__parent__: parent_ref}}
       signal = %{type: "child.result"}
@@ -172,7 +173,7 @@ defmodule JidoTest.Agent.DirectiveTest do
       parent_pid = self()
 
       parent_ref =
-        Jido.AgentServer.ParentRef.new!(%{pid: parent_pid, id: "parent-123", tag: :child})
+        ParentRef.new!(%{pid: parent_pid, id: "parent-123", tag: :child})
 
       agent = %{state: %{__parent__: parent_ref}}
 

--- a/test/jido/agent/instance_manager_test.exs
+++ b/test/jido/agent/instance_manager_test.exs
@@ -7,6 +7,7 @@ defmodule JidoTest.Agent.InstanceManagerTest do
   @moduletag :integration
 
   alias Jido.Agent.InstanceManager
+  alias Jido.Agent.Store.ETS
   alias Jido.AgentServer
 
   # Use module attribute for manager naming to avoid atom leaks
@@ -344,7 +345,7 @@ defmodule JidoTest.Agent.InstanceManagerTest do
       # Verify state was persisted to ETS
       store_key = {TestAgent, "stop-persist-key"}
 
-      case Jido.Agent.Store.ETS.get(store_key, table: table) do
+      case ETS.get(store_key, table: table) do
         {:ok, persisted} ->
           # Persisted data should contain the counter
           assert persisted.state.counter == 42

--- a/test/jido/agent/state_ops_test.exs
+++ b/test/jido/agent/state_ops_test.exs
@@ -2,9 +2,9 @@ defmodule JidoTest.Agent.StateOpsTest do
   use ExUnit.Case, async: true
 
   alias Jido.Agent
-  alias Jido.Agent.StateOps
-  alias Jido.Agent.StateOp
   alias Jido.Agent.Directive
+  alias Jido.Agent.StateOp
+  alias Jido.Agent.StateOps
 
   describe "apply_result/2" do
     test "merges result into agent state" do

--- a/test/jido/agent_server/agent_server_coverage_test.exs
+++ b/test/jido/agent_server/agent_server_coverage_test.exs
@@ -18,6 +18,7 @@ defmodule JidoTest.AgentServerCoverageTest do
 
   alias Jido.AgentServer
   alias Jido.Signal
+  alias JidoTest.TestAgents.Counter
 
   # Simple test agent with defaults
   defmodule SimpleTestAgent do
@@ -201,7 +202,7 @@ defmodule JidoTest.AgentServerCoverageTest do
     test "via tuple that exists works", %{jido: jido} do
       {:ok, _pid} =
         AgentServer.start_link(
-          agent: JidoTest.TestAgents.Counter,
+          agent: Counter,
           id: "via-test-exists",
           jido: jido
         )
@@ -269,20 +270,20 @@ defmodule JidoTest.AgentServerCoverageTest do
 
   describe "pre-built struct with agent_module option" do
     test "uses explicit agent_module for cmd routing", %{jido: jido} do
-      agent = JidoTest.TestAgents.Counter.new(id: "prebuilt-struct-test")
+      agent = Counter.new(id: "prebuilt-struct-test")
       agent = %{agent | state: Map.put(agent.state, :counter, 50)}
 
       {:ok, pid} =
         AgentServer.start_link(
           agent: agent,
-          agent_module: JidoTest.TestAgents.Counter,
+          agent_module: Counter,
           jido: jido
         )
 
       {:ok, state} = AgentServer.state(pid)
       assert state.id == "prebuilt-struct-test"
       assert state.agent.state.counter == 50
-      assert state.agent_module == JidoTest.TestAgents.Counter
+      assert state.agent_module == Counter
 
       signal = Signal.new!("increment", %{}, source: "/test")
       {:ok, updated_agent} = AgentServer.call(pid, signal)
@@ -400,7 +401,7 @@ defmodule JidoTest.AgentServerCoverageTest do
     test "alive? returns true for existing via tuple", %{jido: jido} do
       {:ok, _pid} =
         AgentServer.start_link(
-          agent: JidoTest.TestAgents.Counter,
+          agent: Counter,
           id: "alive-via-test",
           jido: jido
         )

--- a/test/jido/agent_server/agent_server_stop_log_test.exs
+++ b/test/jido/agent_server/agent_server_stop_log_test.exs
@@ -3,8 +3,8 @@ defmodule JidoTest.AgentServerStopLogTest do
 
   import ExUnit.CaptureLog
 
-  alias Jido.AgentServer
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
   alias Jido.Signal
 
   defmodule StopTestAction do

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -3,9 +3,9 @@ defmodule JidoTest.AgentServerTest do
 
   @moduletag :capture_log
 
+  alias Jido.Agent.Directive
   alias Jido.AgentServer
   alias Jido.AgentServer.State
-  alias Jido.Agent.Directive
   alias Jido.Signal
   alias JidoTest.TestActions
 

--- a/test/jido/agent_server/cron_integration_test.exs
+++ b/test/jido/agent_server/cron_integration_test.exs
@@ -4,8 +4,8 @@ defmodule JidoTest.AgentServer.CronIntegrationTest do
   @moduletag :integration
   @moduletag capture_log: true
 
-  alias Jido.AgentServer
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
   alias Jido.Signal
 
   defmodule CronCountAction do

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -2,7 +2,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
   use JidoTest.Case, async: true
 
   alias Jido.Agent.Directive
-  alias Jido.AgentServer.{DirectiveExec, State, Options}
+  alias Jido.AgentServer.{DirectiveExec, Options, State}
   alias Jido.Signal
 
   defmodule TestAgent do

--- a/test/jido/agent_server/error_policy_test.exs
+++ b/test/jido/agent_server/error_policy_test.exs
@@ -4,7 +4,7 @@ defmodule JidoTest.AgentServer.ErrorPolicyTest do
   @moduletag :capture_log
 
   alias Jido.Agent.Directive
-  alias Jido.AgentServer.{ErrorPolicy, State, Options}
+  alias Jido.AgentServer.{ErrorPolicy, Options, State}
 
   defmodule TestAgent do
     @moduledoc false

--- a/test/jido/agent_server/hierarchy_test.exs
+++ b/test/jido/agent_server/hierarchy_test.exs
@@ -3,9 +3,10 @@ defmodule JidoTest.AgentServer.HierarchyTest do
 
   @moduletag capture_log: true
 
-  alias Jido.AgentServer
-  alias Jido.AgentServer.{ParentRef, State}
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
+  alias Jido.AgentServer.ChildInfo
+  alias Jido.AgentServer.{ParentRef, State}
   alias Jido.Signal
 
   # Actions for ParentAgent
@@ -278,7 +279,7 @@ defmodule JidoTest.AgentServer.HierarchyTest do
       ref = Process.monitor(child_pid)
 
       child_info =
-        Jido.AgentServer.ChildInfo.new!(%{
+        ChildInfo.new!(%{
           pid: child_pid,
           ref: ref,
           module: ChildAgent,
@@ -320,7 +321,7 @@ defmodule JidoTest.AgentServer.HierarchyTest do
       ref = Process.monitor(child_pid)
 
       child_info =
-        Jido.AgentServer.ChildInfo.new!(%{
+        ChildInfo.new!(%{
           pid: child_pid,
           ref: ref,
           module: ChildAgent,

--- a/test/jido/agent_server/signal_router_test.exs
+++ b/test/jido/agent_server/signal_router_test.exs
@@ -3,6 +3,7 @@ defmodule JidoTest.AgentServer.SignalRouterTest do
 
   alias Jido.AgentServer.SignalRouter
   alias Jido.AgentServer.State
+  alias Jido.AgentServer.State.Lifecycle
   alias Jido.Signal.Router, as: JidoRouter
 
   # =============================================================================
@@ -226,7 +227,7 @@ defmodule JidoTest.AgentServer.SignalRouterTest do
   defp build_test_state(agent_module) do
     agent = agent_module.new(%{id: "test-#{System.unique_integer([:positive])}"})
 
-    {:ok, lifecycle} = Jido.AgentServer.State.Lifecycle.new([])
+    {:ok, lifecycle} = Lifecycle.new([])
 
     attrs = %{
       id: agent.id,

--- a/test/jido/agent_server/skill_subscriptions_test.exs
+++ b/test/jido/agent_server/skill_subscriptions_test.exs
@@ -1,6 +1,8 @@
 defmodule JidoTest.AgentServer.SkillSubscriptionsTest do
   use JidoTest.Case, async: false
 
+  alias Jido.Sensor.Runtime
+
   @moduletag :capture_log
 
   # ---------------------------------------------------------------------------
@@ -297,7 +299,7 @@ defmodule JidoTest.AgentServer.SkillSubscriptionsTest do
 
       [{_tag, child_info}] = sensor_children
 
-      Jido.Sensor.Runtime.event(child_info.pid, {:trigger, :test_value})
+      Runtime.event(child_info.pid, {:trigger, :test_value})
 
       Process.sleep(50)
 

--- a/test/jido/agent_server/strategy_init_test.exs
+++ b/test/jido/agent_server/strategy_init_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.AgentServer.StrategyInitTest do
   use JidoTest.Case, async: true
 
-  alias Jido.AgentServer
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
   alias Jido.Signal
 
   defmodule TrackingStrategy do

--- a/test/jido/agent_server/telemetry_test.exs
+++ b/test/jido/agent_server/telemetry_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.AgentServer.TelemetryTest do
   use JidoTest.Case, async: false
 
-  alias Jido.AgentServer
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
   alias Jido.Signal
   alias JidoTest.TestActions
 

--- a/test/jido/agent_server/trace_propagation_test.exs
+++ b/test/jido/agent_server/trace_propagation_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.AgentServer.TracePropagationTest do
   use JidoTest.Case, async: false
 
-  alias Jido.AgentServer
   alias Jido.Agent.Directive
+  alias Jido.AgentServer
   alias Jido.Signal
   alias Jido.Tracing.Trace
   alias JidoTest.TestActions

--- a/test/jido/agent_skill_integration_test.exs
+++ b/test/jido/agent_skill_integration_test.exs
@@ -1,6 +1,7 @@
 defmodule JidoTest.AgentSkillIntegrationTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Agent.Schema
   alias Jido.Skill.Spec
 
   # =============================================================================
@@ -224,7 +225,7 @@ defmodule JidoTest.AgentSkillIntegrationTest do
       schema = SingleSkillAgent.schema()
 
       assert is_struct(schema)
-      keys = Jido.Agent.Schema.known_keys(schema)
+      keys = Schema.known_keys(schema)
       assert :counter_skill in keys
     end
 
@@ -608,7 +609,7 @@ defmodule JidoTest.AgentSkillIntegrationTest do
   describe "schema merging" do
     test "merged schema contains skill state_keys" do
       schema = MixedSchemaAgent.schema()
-      keys = Jido.Agent.Schema.known_keys(schema)
+      keys = Schema.known_keys(schema)
 
       assert :counter_skill in keys
     end

--- a/test/jido/await_coverage_test.exs
+++ b/test/jido/await_coverage_test.exs
@@ -5,8 +5,8 @@ defmodule JidoTest.AwaitCoverageTest do
   """
   use JidoTest.Case, async: false
 
-  alias Jido.Await
   alias Jido.AgentServer
+  alias Jido.Await
   alias Jido.Signal
 
   defmodule NeverCompletesAction do

--- a/test/jido/await_test.exs
+++ b/test/jido/await_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.AwaitTest do
   use JidoTest.Case, async: false
 
-  alias Jido.Await
   alias Jido.AgentServer
+  alias Jido.Await
   alias Jido.Signal
 
   defmodule CompletingAction do

--- a/test/jido/discovery_test.exs
+++ b/test/jido/discovery_test.exs
@@ -149,7 +149,7 @@ defmodule JidoTest.DiscoveryTest do
     test "returns action for valid slug" do
       actions = Discovery.list_actions(limit: 1)
 
-      if length(actions) > 0 do
+      if actions != [] do
         [action | _] = actions
         found = Discovery.get_action_by_slug(action.slug)
         assert found != nil
@@ -172,7 +172,7 @@ defmodule JidoTest.DiscoveryTest do
     test "returns agent for valid slug" do
       agents = Discovery.list_agents(limit: 1)
 
-      if length(agents) > 0 do
+      if agents != [] do
         [agent | _] = agents
         found = Discovery.get_agent_by_slug(agent.slug)
         assert found != nil

--- a/test/jido/error_coverage_test.exs
+++ b/test/jido/error_coverage_test.exs
@@ -2,6 +2,7 @@ defmodule JidoTest.ErrorCoverageTest do
   use JidoTest.Case, async: true
 
   alias Jido.Error
+  alias Jido.Error.Internal.UnknownError
 
   describe "error constructors with map options" do
     test "validation_error accepts map opts" do
@@ -253,7 +254,7 @@ defmodule JidoTest.ErrorCoverageTest do
     end
 
     test "UnknownError returns :internal" do
-      error = Error.Internal.UnknownError.exception(message: "Unknown")
+      error = UnknownError.exception(message: "Unknown")
       result = Error.to_map(error)
       assert result.type == :internal
     end

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -264,7 +264,7 @@ defmodule JidoTest.ErrorTest do
       stacktrace = Error.capture_stacktrace()
 
       assert is_list(stacktrace)
-      assert length(stacktrace) > 0
+      assert stacktrace != []
     end
   end
 end

--- a/test/jido/skill/routes_test.exs
+++ b/test/jido/skill/routes_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.Skill.RoutesTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Skill.Routes
   alias Jido.Skill.Instance
+  alias Jido.Skill.Routes
 
   defmodule TestAction1 do
     @moduledoc false

--- a/test/jido/skill/schedules_test.exs
+++ b/test/jido/skill/schedules_test.exs
@@ -1,8 +1,9 @@
 defmodule JidoTest.Skill.SchedulesTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Skill.Schedules
   alias Jido.Skill.Instance
+  alias Jido.Skill.Routes
+  alias Jido.Skill.Schedules
 
   defmodule RefreshTokenAction do
     @moduledoc false
@@ -168,7 +169,7 @@ defmodule JidoTest.Skill.SchedulesTest do
   describe "schedule_route_priority/0" do
     test "returns a negative priority lower than default skill routes" do
       priority = Schedules.schedule_route_priority()
-      default_priority = Jido.Skill.Routes.default_priority()
+      default_priority = Routes.default_priority()
 
       assert priority < default_priority
       assert priority == -20

--- a/test/jido/telemetry_test.exs
+++ b/test/jido/telemetry_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.TelemetryTest do
   use ExUnit.Case, async: false
 
-  alias Jido.Telemetry
   alias Jido.Agent
+  alias Jido.Telemetry
 
   defmodule TestAgent do
     @moduledoc false

--- a/test/jido/tracing/trace_test.exs
+++ b/test/jido/tracing/trace_test.exs
@@ -1,8 +1,8 @@
 defmodule JidoTest.Tracing.TraceTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Tracing.Trace
   alias Jido.Signal
+  alias Jido.Tracing.Trace
 
   describe "new_root/0" do
     test "creates trace with fresh trace_id and span_id" do

--- a/test/support/eventually.ex
+++ b/test/support/eventually.ex
@@ -65,14 +65,16 @@ defmodule JidoTest.Eventually do
   """
   def eventually_state(pid, fun, opts \\ []) do
     eventually(
-      fn ->
-        case Jido.AgentServer.state(pid) do
-          {:ok, state} -> if fun.(state), do: state, else: false
-          _ -> false
-        end
-      end,
+      fn -> check_state(pid, fun) end,
       opts
     )
+  end
+
+  defp check_state(pid, fun) do
+    case Jido.AgentServer.state(pid) do
+      {:ok, state} -> if fun.(state), do: state, else: false
+      _ -> false
+    end
   end
 
   @doc """

--- a/test/support/test_agents.ex
+++ b/test/support/test_agents.ex
@@ -81,6 +81,8 @@ defmodule JidoTest.TestAgents do
     @moduledoc false
     @behaviour Jido.Agent.Strategy
 
+    alias Jido.Agent.Strategy.Direct
+
     @impl true
     def init(agent, _ctx), do: {agent, []}
 
@@ -91,7 +93,7 @@ defmodule JidoTest.TestAgents do
     def cmd(agent, action, ctx) do
       count = Map.get(agent.state, :strategy_count, 0)
       agent = %{agent | state: Map.put(agent.state, :strategy_count, count + 1)}
-      Jido.Agent.Strategy.Direct.cmd(agent, action, ctx)
+      Direct.cmd(agent, action, ctx)
     end
   end
 


### PR DESCRIPTION
## Summary
- refactor Agent and Skill macros into smaller helper functions to reduce nesting and clarify compile/runtime separation
- extract complex conditionals into private helpers and standardize aliases for readability
- adjust lifecycle/timer behavior, InstanceManager restart policy, and logger metadata config
- apply small idiomatic Elixir cleanups in tests and utilities

## Testing
- not run