### PR TITLE
refactor: convert remaining structs to use Zoi schemas

### DIFF
--- a/lib/jido/agent/strategy.ex
+++ b/lib/jido/agent/strategy.ex
@@ -109,14 +109,23 @@ defmodule Jido.Agent.Strategy do
     - `details` - Additional strategy-specific metadata
     """
 
-    @type t :: %__MODULE__{
-            status: Jido.Agent.Strategy.status(),
-            done?: boolean(),
-            result: term() | nil,
-            details: map()
-          }
+    @schema Zoi.struct(
+              __MODULE__,
+              %{
+                status: Zoi.atom(description: "Coarse execution status"),
+                done?: Zoi.boolean(description: "Whether strategy reached terminal state"),
+                result:
+                  Zoi.any(description: "Main output if strategy produces one") |> Zoi.optional(),
+                details:
+                  Zoi.map(Zoi.atom(), Zoi.any(), description: "Strategy-specific metadata")
+                  |> Zoi.default(%{})
+              },
+              coerce: true
+            )
 
-    defstruct [:status, :done?, :result, details: %{}]
+    @type t :: unquote(Zoi.type_spec(@schema))
+    @enforce_keys Zoi.Struct.enforce_keys(@schema)
+    defstruct Zoi.Struct.struct_fields(@schema)
 
     @doc "Returns true if the strategy has reached a terminal state."
     @spec terminal?(t()) :: boolean()
@@ -130,8 +139,23 @@ defmodule Jido.Agent.Strategy do
   # Deprecated: use Snapshot instead
   defmodule Public do
     @moduledoc false
-    defstruct [:status, :done?, :result, meta: %{}]
-    @type t :: Jido.Agent.Strategy.Snapshot.t()
+
+    @schema Zoi.struct(
+              __MODULE__,
+              %{
+                status: Zoi.atom(description: "Execution status"),
+                done?: Zoi.boolean(description: "Whether strategy reached terminal state"),
+                result: Zoi.any(description: "Main output") |> Zoi.optional(),
+                meta:
+                  Zoi.map(Zoi.atom(), Zoi.any(), description: "Additional metadata")
+                  |> Zoi.default(%{})
+              },
+              coerce: true
+            )
+
+    @type t :: unquote(Zoi.type_spec(@schema))
+    @enforce_keys Zoi.Struct.enforce_keys(@schema)
+    defstruct Zoi.Struct.struct_fields(@schema)
   end
 
   @doc """

--- a/lib/jido/agent/strategy/fsm.ex
+++ b/lib/jido/agent/strategy/fsm.ex
@@ -83,19 +83,26 @@ defmodule Jido.Agent.Strategy.FSM do
     this module validates transitions dynamically based on the provided config.
     """
 
-    @type t :: %__MODULE__{
-            status: String.t(),
-            processed_count: non_neg_integer(),
-            last_result: term(),
-            error: term(),
-            transitions: map()
-          }
+    @schema Zoi.struct(
+              __MODULE__,
+              %{
+                status: Zoi.string(description: "Current FSM state") |> Zoi.default("idle"),
+                processed_count:
+                  Zoi.integer(description: "Number of processed commands") |> Zoi.default(0),
+                last_result: Zoi.any(description: "Result of last command") |> Zoi.optional(),
+                error: Zoi.any(description: "Error from last command") |> Zoi.optional(),
+                transitions:
+                  Zoi.map(Zoi.string(), Zoi.list(Zoi.string()),
+                    description: "Allowed state transitions"
+                  )
+                  |> Zoi.default(%{})
+              },
+              coerce: true
+            )
 
-    defstruct status: "idle",
-              processed_count: 0,
-              last_result: nil,
-              error: nil,
-              transitions: %{}
+    @type t :: unquote(Zoi.type_spec(@schema))
+    @enforce_keys Zoi.Struct.enforce_keys(@schema)
+    defstruct Zoi.Struct.struct_fields(@schema)
 
     @doc "Creates a new machine with the given initial state and transitions."
     @spec new(String.t(), map()) :: t()

--- a/lib/jido/skill/spec.ex
+++ b/lib/jido/skill/spec.ex
@@ -6,34 +6,28 @@ defmodule Jido.Skill.Spec do
   including actions, schema, configuration, and signal patterns.
   """
 
-  @type t :: %__MODULE__{
-          module: module(),
-          name: String.t(),
-          state_key: atom(),
-          description: String.t() | nil,
-          category: String.t() | nil,
-          vsn: String.t() | nil,
-          schema: any(),
-          config_schema: any(),
-          config: map(),
-          signal_patterns: [String.t()],
-          tags: [String.t()],
-          actions: [module()]
-        }
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              module: Zoi.atom(description: "Skill module"),
+              name: Zoi.string(description: "Skill name"),
+              state_key: Zoi.atom(description: "Key for skill state in agent"),
+              description: Zoi.string(description: "Skill description") |> Zoi.optional(),
+              category: Zoi.string(description: "Skill category") |> Zoi.optional(),
+              vsn: Zoi.string(description: "Skill version") |> Zoi.optional(),
+              schema: Zoi.any(description: "Skill state schema") |> Zoi.optional(),
+              config_schema: Zoi.any(description: "Skill config schema") |> Zoi.optional(),
+              config:
+                Zoi.map(Zoi.atom(), Zoi.any(), description: "Skill config") |> Zoi.default(%{}),
+              signal_patterns:
+                Zoi.list(Zoi.string(), description: "Signal patterns to match") |> Zoi.default([]),
+              tags: Zoi.list(Zoi.string(), description: "Skill tags") |> Zoi.default([]),
+              actions: Zoi.list(Zoi.atom(), description: "Available actions") |> Zoi.default([])
+            },
+            coerce: true
+          )
 
-  @enforce_keys [:module, :name, :state_key, :actions]
-  defstruct [
-    :module,
-    :name,
-    :state_key,
-    :description,
-    :category,
-    :vsn,
-    :schema,
-    :config_schema,
-    config: %{},
-    signal_patterns: [],
-    tags: [],
-    actions: []
-  ]
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
 end


### PR DESCRIPTION
## Summary

Convert the remaining 4 structs from manual `defstruct` to Zoi schemas for consistency across the codebase.

## Changes

- **Jido.Agent.Strategy.FSM.Machine** - FSM state machine struct
- **Jido.Agent.Strategy.Snapshot** - Strategy snapshot for external inspection
- **Jido.Agent.Strategy.Public** - Deprecated alias (maintains compatibility)
- **Jido.Skill.Spec** - Skill specification struct

## Benefits

- Single source of truth for fields, types, enforced keys, and validation
- Automatic `@enforce_keys` derivation from schema
- Built-in coercion support
- Self-documenting field descriptions

## Verification

- ✅ All 1308 tests pass
- ✅ `mix quality` passes (format, credo, dialyzer)