### PR TITLE
chore: normalize signal route methods and plugin system enhancements

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -293,9 +293,16 @@ defmodule Jido.Agent do
   - `{path, match_fn, ActionModule}` - With pattern matching
   - `{path, match_fn, ActionModule, priority}` - Full spec
 
+  ## Context
+
+  The context map contains:
+  - `agent_module` - The agent module
+  - `strategy` - The strategy module
+  - `strategy_opts` - Strategy options
+
   ## Examples
 
-      def signal_routes do
+      def signal_routes(_ctx) do
         [
           {"user.created", HandleUserCreatedAction},
           {"counter.increment", IncrementAction},
@@ -303,7 +310,7 @@ defmodule Jido.Agent do
         ]
       end
   """
-  @callback signal_routes() :: [Jido.Signal.Router.route_spec()]
+  @callback signal_routes(ctx :: map()) :: [Jido.Signal.Router.route_spec()]
 
   @doc """
   Serializes the agent for persistence.
@@ -350,7 +357,7 @@ defmodule Jido.Agent do
   @optional_callbacks [
     on_before_cmd: 2,
     on_after_cmd: 3,
-    signal_routes: 0,
+    signal_routes: 1,
     checkpoint: 2,
     restore: 2
   ]
@@ -888,8 +895,8 @@ defmodule Jido.Agent do
   defp __quoted_callback_routes__ do
     quote location: :keep do
       @impl true
-      @spec signal_routes() :: list()
-      def signal_routes, do: []
+      @spec signal_routes(map()) :: list()
+      def signal_routes(_ctx), do: []
     end
   end
 
@@ -950,7 +957,7 @@ defmodule Jido.Agent do
                      on_after_cmd: 3,
                      checkpoint: 2,
                      restore: 2,
-                     signal_routes: 0,
+                     signal_routes: 1,
                      name: 0,
                      description: 0,
                      category: 0,

--- a/lib/jido/igniter/templates.ex
+++ b/lib/jido/igniter/templates.ex
@@ -65,7 +65,7 @@ defmodule Jido.Igniter.Templates do
         signal_patterns: [#{patterns_str}]
 
       @impl Jido.Plugin
-      def router(_config) do
+      def signal_routes(_config) do
         []
       end
     end

--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -37,7 +37,7 @@ defmodule Jido.Plugin do
         end
 
         @impl Jido.Plugin
-        def router(config) do
+        def signal_routes(_ctx) do
           [
             {"chat.send", MyApp.Actions.SendMessage},
             {"chat.history", MyApp.Actions.ListHistory}
@@ -70,7 +70,7 @@ defmodule Jido.Plugin do
   - `tags` - List of tag strings (default: []).
   - `capabilities` - List of atoms describing what the plugin provides (default: []).
   - `requires` - List of requirements like `{:config, :token}`, `{:app, :req}`, `{:plugin, :http}` (default: []).
-  - `routes` - List of route tuples like `{"post", ActionModule}` (default: []).
+  - `signal_routes` - List of signal route tuples like `{"post", ActionModule}` (default: []).
   - `schedules` - List of schedule tuples like `{"*/5 * * * *", ActionModule}` (default: []).
   """
 
@@ -128,9 +128,9 @@ defmodule Jido.Plugin do
                                   "Requirements like {:config, :token}, {:app, :req}, {:plugin, :http}."
                               )
                               |> Zoi.default([]),
-                            routes:
+                            signal_routes:
                               Zoi.list(Zoi.any(),
-                                description: "Route tuples like {\"post\", ActionModule}."
+                                description: "Signal route tuples like {\"post\", ActionModule}."
                               )
                               |> Zoi.default([]),
                             schedules:
@@ -187,11 +187,11 @@ defmodule Jido.Plugin do
   @callback mount(agent :: term(), config :: map()) :: {:ok, map() | nil} | {:error, term()}
 
   @doc """
-  Returns the signal router for this plugin.
+  Returns the signal routes for this plugin.
 
-  The router determines how signals are routed to handlers.
+  The signal routes determine how signals are routed to handlers.
   """
-  @callback router(config :: map()) :: term()
+  @callback signal_routes(config :: map()) :: term()
 
   @doc """
   Pre-routing hook called before signal routing in AgentServer.
@@ -471,9 +471,9 @@ defmodule Jido.Plugin do
       @spec requires() :: [tuple()]
       def requires, do: @validated_opts[:requires] || []
 
-      @doc "Returns the routes for this plugin."
-      @spec routes() :: [tuple()]
-      def routes, do: @validated_opts[:routes] || []
+      @doc "Returns the signal routes for this plugin."
+      @spec signal_routes() :: [tuple()]
+      def signal_routes, do: @validated_opts[:signal_routes] || []
 
       @doc "Returns the schedules for this plugin."
       @spec schedules() :: [tuple()]
@@ -516,7 +516,7 @@ defmodule Jido.Plugin do
 
       The manifest provides compile-time metadata for discovery
       and introspection, including capabilities, requirements,
-      routes, and schedules.
+      signal routes, and schedules.
       """
       @spec manifest() :: Manifest.t()
       def manifest do
@@ -534,7 +534,7 @@ defmodule Jido.Plugin do
           schema: schema(),
           config_schema: config_schema(),
           actions: actions(),
-          routes: routes(),
+          signal_routes: signal_routes(),
           schedules: schedules(),
           signal_patterns: signal_patterns(),
           singleton: singleton?()
@@ -568,9 +568,9 @@ defmodule Jido.Plugin do
       def mount(_agent, _config), do: {:ok, %{}}
 
       @doc false
-      @spec router(map()) :: term()
+      @spec signal_routes(map()) :: [tuple()]
       @impl Jido.Plugin
-      def router(_config), do: nil
+      def signal_routes(_config), do: []
 
       @doc false
       @spec handle_signal(term(), map()) ::
@@ -609,30 +609,32 @@ defmodule Jido.Plugin do
   @doc false
   defp generate_defoverridable do
     quote location: :keep do
-      defoverridable mount: 2,
-                     router: 1,
-                     handle_signal: 2,
-                     transform_result: 3,
-                     child_spec: 1,
-                     subscriptions: 2,
-                     on_checkpoint: 2,
-                     on_restore: 2,
-                     name: 0,
-                     state_key: 0,
-                     actions: 0,
-                     description: 0,
-                     category: 0,
-                     vsn: 0,
-                     otp_app: 0,
-                     schema: 0,
-                     config_schema: 0,
-                     signal_patterns: 0,
-                     tags: 0,
-                     capabilities: 0,
-                     requires: 0,
-                     routes: 0,
-                     schedules: 0,
-                     singleton?: 0
+      defoverridable [
+        {:mount, 2},
+        {:signal_routes, 0},
+        {:signal_routes, 1},
+        {:handle_signal, 2},
+        {:transform_result, 3},
+        {:child_spec, 1},
+        {:subscriptions, 2},
+        {:on_checkpoint, 2},
+        {:on_restore, 2},
+        {:name, 0},
+        {:state_key, 0},
+        {:actions, 0},
+        {:description, 0},
+        {:category, 0},
+        {:vsn, 0},
+        {:otp_app, 0},
+        {:schema, 0},
+        {:config_schema, 0},
+        {:signal_patterns, 0},
+        {:tags, 0},
+        {:capabilities, 0},
+        {:requires, 0},
+        {:schedules, 0},
+        {:singleton?, 0}
+      ]
     end
   end
 

--- a/lib/jido/plugin/manifest.ex
+++ b/lib/jido/plugin/manifest.ex
@@ -21,7 +21,7 @@ defmodule Jido.Plugin.Manifest do
   - `schema` - Zoi schema for plugin state
   - `config_schema` - Zoi schema for per-agent config
   - `actions` - List of action modules
-  - `routes` - List of route tuples like `{"post", ActionModule}`
+  - `signal_routes` - List of signal route tuples like `{"post", ActionModule}`
   - `schedules` - List of schedule tuples like `{"*/5 * * * *", ActionModule}`
   - `signal_patterns` - Legacy signal patterns for routing
   - `subscriptions` - Sensor subscriptions provided by this plugin
@@ -51,8 +51,10 @@ defmodule Jido.Plugin.Manifest do
                 Zoi.any(description: "Zoi schema for per-agent config") |> Zoi.optional(),
               actions:
                 Zoi.list(Zoi.atom(), description: "List of action modules") |> Zoi.default([]),
-              routes:
-                Zoi.list(Zoi.any(), description: "Route tuples like {\"post\", ActionModule}")
+              signal_routes:
+                Zoi.list(Zoi.any(),
+                  description: "Signal route tuples like {\"post\", ActionModule}"
+                )
                 |> Zoi.default([]),
               schedules:
                 Zoi.list(Zoi.any(),

--- a/lib/mix/tasks/jido.gen.plugin.ex
+++ b/lib/mix/tasks/jido.gen.plugin.ex
@@ -61,7 +61,7 @@ if Code.ensure_loaded?(Igniter) do
           signal_patterns: [#{patterns_str}]
 
         @impl Jido.Plugin
-        def router(_config) do
+        def signal_routes(_config) do
           []
         end
       end

--- a/test/examples/emit_directive_test.exs
+++ b/test/examples/emit_directive_test.exs
@@ -154,7 +154,7 @@ defmodule JidoExampleTest.EmitDirectiveTest do
         emitted_count: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"create_order", CreateOrderAction},
         {"process_payment", ProcessPaymentAction},

--- a/test/examples/error_handling_test.exs
+++ b/test/examples/error_handling_test.exs
@@ -200,7 +200,7 @@ defmodule JidoExampleTest.ErrorHandlingTest do
         error_context: [type: :atom, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"validate", ValidateAction},
         {"retry", HandleRetryAction},

--- a/test/examples/hierarchical_agents_test.exs
+++ b/test/examples/hierarchical_agents_test.exs
@@ -360,7 +360,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         tasks_completed: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"task.execute", ExecuteTaskAction}
       ]
@@ -377,7 +377,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         completed_jobs: [type: {:list, :string}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"job.assign", HandleJobAssignAction},
         {"jido.agent.child.started", CoordinatorChildStartedAction},
@@ -396,7 +396,7 @@ defmodule JidoExampleTest.HierarchicalAgentsTest do
         last_submitted: [type: :string, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"submit_job", SubmitJobAction},
         {"jido.agent.child.started", OrchestratorChildStartedAction},

--- a/test/examples/observability_test.exs
+++ b/test/examples/observability_test.exs
@@ -149,7 +149,7 @@ defmodule JidoExampleTest.ObservabilityTest do
         async_result: [type: :integer, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"observed_work", ObservedWorkAction},
         {"observed_async", ObservedAsyncAction}

--- a/test/examples/parent_child_test.exs
+++ b/test/examples/parent_child_test.exs
@@ -187,7 +187,7 @@ defmodule JidoExampleTest.ParentChildTest do
         workers_spawned: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"spawn_worker", SpawnWorkerAction},
         {"jido.agent.child.started", HandleChildStartedAction},
@@ -205,7 +205,7 @@ defmodule JidoExampleTest.ParentChildTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"work.request", ProcessWorkAction}
       ]

--- a/test/examples/schedule_directive_test.exs
+++ b/test/examples/schedule_directive_test.exs
@@ -188,7 +188,7 @@ defmodule JidoExampleTest.ScheduleDirectiveTest do
         started_at: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"start_timer", StartTimerAction},
         {"timer.tick", HandleTickAction},

--- a/test/examples/sensor_demo_test.exs
+++ b/test/examples/sensor_demo_test.exs
@@ -3,7 +3,7 @@ defmodule JidoExampleTest.SensorDemoTest do
   Example test demonstrating Jido Sensors and signal routing.
 
   This test converts examples/sensor_demo.exs into a proper ExUnit test that:
-  - Verifies sensor signals are routed through signal_routes/0
+  - Verifies sensor signals are routed through signal_routes/1
   - Verifies webhook injection works correctly
   - Asserts actual state changes (not just "runs without crash")
 
@@ -122,7 +122,7 @@ defmodule JidoExampleTest.SensorDemoTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"sensor.quote", HandleQuoteAction},
         {"webhook.github", HandleGitHubWebhookAction},

--- a/test/examples/signal_routing_test.exs
+++ b/test/examples/signal_routing_test.exs
@@ -1,9 +1,9 @@
 defmodule JidoExampleTest.SignalRoutingTest do
   @moduledoc """
-  Example test demonstrating signal routing via signal_routes/0.
+  Example test demonstrating signal routing via signal_routes/1.
 
   This test shows:
-  - How to define signal_routes/0 to map signal types to actions
+  - How to define signal_routes/1 to map signal types to actions
   - How signals are processed through AgentServer
   - How unhandled signals behave
   - Multiple signal types routed to different actions
@@ -85,7 +85,7 @@ defmodule JidoExampleTest.SignalRoutingTest do
         events: [type: {:list, :map}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", IncrementAction},
         {"set_name", SetNameAction},

--- a/test/examples/spawn_agent_test.exs
+++ b/test/examples/spawn_agent_test.exs
@@ -155,7 +155,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
         worker_results: [type: {:list, :map}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"spawn_worker", SpawnWorkerAction},
         {"jido.agent.child.started", ChildStartedAction},
@@ -174,7 +174,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"do_work", JidoExampleTest.SpawnAgentTest.DoWorkAction}
       ]

--- a/test/examples/tracing_test.exs
+++ b/test/examples/tracing_test.exs
@@ -148,7 +148,7 @@ defmodule JidoExampleTest.TracingTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"start_workflow", StartWorkflowAction},
         {"process_step", ProcessStepAction},

--- a/test/jido/agent/signal_handling_test.exs
+++ b/test/jido/agent/signal_handling_test.exs
@@ -34,7 +34,7 @@ defmodule JidoTest.Agent.SignalHandlingTest do
         messages: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"decrement", TestActions.DecrementAction},
@@ -54,7 +54,7 @@ defmodule JidoTest.Agent.SignalHandlingTest do
         last_action_type: [type: :string, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"decrement", TestActions.DecrementAction}
@@ -178,7 +178,7 @@ defmodule JidoTest.Agent.SignalHandlingTest do
 
         alias JidoTest.TestActions
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [
             {"increment", TestActions.IncrementAction}
           ]

--- a/test/jido/agent/strategy_fsm_test.exs
+++ b/test/jido/agent/strategy_fsm_test.exs
@@ -83,7 +83,7 @@ defmodule JidoTest.Agent.StrategyFSMTest do
       strategy: Jido.Agent.Strategy.FSM,
       schema: [value: [type: :integer, default: 0]]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule CustomFSMAgent do
@@ -100,7 +100,7 @@ defmodule JidoTest.Agent.StrategyFSMTest do
          }},
       schema: []
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule NoAutoTransitionAgent do
@@ -117,7 +117,7 @@ defmodule JidoTest.Agent.StrategyFSMTest do
          }},
       schema: []
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   describe "FSM.Machine" do

--- a/test/jido/agent_plugin_integration_test.exs
+++ b/test/jido/agent_plugin_integration_test.exs
@@ -503,7 +503,7 @@ defmodule JidoTest.AgentPluginIntegrationTest do
         state_key: :slack_cap,
         actions: [JidoTest.AgentPluginIntegrationTest.SimpleAction],
         capabilities: [:messaging, :channel_management],
-        routes: [
+        signal_routes: [
           {"post", JidoTest.AgentPluginIntegrationTest.SimpleAction},
           {"channels.list", JidoTest.AgentPluginIntegrationTest.SimpleAction}
         ]
@@ -516,7 +516,7 @@ defmodule JidoTest.AgentPluginIntegrationTest do
         state_key: :openai_cap,
         actions: [JidoTest.AgentPluginIntegrationTest.SimpleAction],
         capabilities: [:chat, :embeddings, :messaging],
-        routes: [
+        signal_routes: [
           {"chat", JidoTest.AgentPluginIntegrationTest.SimpleAction},
           {"embeddings", JidoTest.AgentPluginIntegrationTest.SimpleAction}
         ]

--- a/test/jido/agent_pool_test.exs
+++ b/test/jido/agent_pool_test.exs
@@ -28,7 +28,7 @@ defmodule JidoTest.AgentPoolTest do
         last_count: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"get_count", GetCountAction}

--- a/test/jido/agent_server/agent_server_coverage_test.exs
+++ b/test/jido/agent_server/agent_server_coverage_test.exs
@@ -29,7 +29,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         counter: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"increment", JidoTest.TestActions.IncrementAction}]
     end
   end
@@ -45,7 +45,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         intercepted_action: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"increment", JidoTest.TestActions.IncrementAction}]
     end
 
@@ -69,7 +69,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         after_called: [type: :boolean, default: false]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"increment", JidoTest.TestActions.IncrementAction}]
     end
 
@@ -89,7 +89,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         after_called: [type: :boolean, default: false]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"increment", JidoTest.TestActions.IncrementAction}]
     end
 
@@ -133,7 +133,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         directive_count: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"many_directives", ManyDirectivesAction}]
     end
   end
@@ -180,7 +180,7 @@ defmodule JidoTest.AgentServerCoverageTest do
         error: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"complete", CompleteAction},
         {"fail", FailAction},

--- a/test/jido/agent_server/agent_server_stop_log_test.exs
+++ b/test/jido/agent_server/agent_server_stop_log_test.exs
@@ -20,7 +20,7 @@ defmodule JidoTest.AgentServerStopLogTest do
     @moduledoc false
     use Jido.Agent, name: "test_agent", schema: []
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"stop_test", StopTestAction}]
     end
   end

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -60,7 +60,7 @@ defmodule JidoTest.AgentServerTest do
 
     alias JidoTest.TestActions
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"decrement", TestActions.DecrementAction},
@@ -430,7 +430,7 @@ defmodule JidoTest.AgentServerTest do
           name: "slow_agent",
           schema: [value: [type: :integer, default: 0]]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [{"slow", SlowAction}]
         end
       end
@@ -499,7 +499,7 @@ defmodule JidoTest.AgentServerTest do
             pings: [type: :integer, default: 0]
           ]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [
             {"start_schedule", StartScheduleAction},
             {"scheduled.ping", ScheduledPingAction}
@@ -556,7 +556,7 @@ defmodule JidoTest.AgentServerTest do
             events: [type: {:list, :any}, default: []]
           ]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [
             {"schedule_many", ScheduleManyAction},
             {"tick", TickAction}
@@ -605,7 +605,7 @@ defmodule JidoTest.AgentServerTest do
             received: [type: :any, default: nil]
           ]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [
             {"schedule_atom", ScheduleAtomAction},
             {"jido.scheduled", JidoScheduledAction}
@@ -803,7 +803,7 @@ defmodule JidoTest.AgentServerTest do
           name: "counter_agent",
           schema: [drain_count: [type: :integer, default: 0]]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [{"slow", SlowAction2}]
         end
       end

--- a/test/jido/agent_server/cron_integration_test.exs
+++ b/test/jido/agent_server/cron_integration_test.exs
@@ -52,7 +52,7 @@ defmodule JidoTest.AgentServer.CronIntegrationTest do
         ticks: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"register_cron", RegisterCronAction},
         {"cancel_cron", CancelCronAction},

--- a/test/jido/agent_server/hierarchy_test.exs
+++ b/test/jido/agent_server/hierarchy_test.exs
@@ -59,7 +59,7 @@ defmodule JidoTest.AgentServer.HierarchyTest do
         child_events: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"jido.agent.child.exit", ChildExitAction},
         {"child_exit", ChildExitAction},
@@ -77,7 +77,7 @@ defmodule JidoTest.AgentServer.HierarchyTest do
         orphan_events: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"jido.agent.orphaned", OrphanedAction},
         {"orphaned", OrphanedAction}

--- a/test/jido/agent_server/plugin_signal_hooks_test.exs
+++ b/test/jido/agent_server/plugin_signal_hooks_test.exs
@@ -88,7 +88,7 @@ defmodule JidoTest.AgentServer.PluginSignalHooksTest do
       schema: [counter: [type: :integer, default: 0]],
       plugins: [JidoTest.AgentServer.PluginSignalHooksTest.DefaultHandleSignalPlugin]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"counter.increment", JidoTest.AgentServer.PluginSignalHooksTest.IncrementAction}]
     end
   end
@@ -104,7 +104,7 @@ defmodule JidoTest.AgentServer.PluginSignalHooksTest do
       ],
       plugins: [JidoTest.AgentServer.PluginSignalHooksTest.OverridePlugin]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"counter.increment", JidoTest.AgentServer.PluginSignalHooksTest.IncrementAction},
         {"counter.override", JidoTest.AgentServer.PluginSignalHooksTest.IncrementAction}
@@ -120,7 +120,7 @@ defmodule JidoTest.AgentServer.PluginSignalHooksTest do
       schema: [counter: [type: :integer, default: 0]],
       plugins: [JidoTest.AgentServer.PluginSignalHooksTest.ErrorPlugin]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"counter.increment", JidoTest.AgentServer.PluginSignalHooksTest.IncrementAction},
         {"counter.error", JidoTest.AgentServer.PluginSignalHooksTest.IncrementAction}

--- a/test/jido/agent_server/plugin_transform_test.exs
+++ b/test/jido/agent_server/plugin_transform_test.exs
@@ -67,7 +67,7 @@ defmodule JidoTest.AgentServer.PluginTransformTest do
       schema: [value: [type: :integer, default: 0]],
       plugins: [JidoTest.AgentServer.PluginTransformTest.DefaultTransformPlugin]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"value.set", JidoTest.AgentServer.PluginTransformTest.SetValueAction}]
     end
   end
@@ -80,7 +80,7 @@ defmodule JidoTest.AgentServer.PluginTransformTest do
       schema: [value: [type: :integer, default: 0]],
       plugins: [JidoTest.AgentServer.PluginTransformTest.MetadataTransformPlugin]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"value.set", JidoTest.AgentServer.PluginTransformTest.SetValueAction}]
     end
   end
@@ -96,7 +96,7 @@ defmodule JidoTest.AgentServer.PluginTransformTest do
         JidoTest.AgentServer.PluginTransformTest.TimestampTransformPlugin
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"value.set", JidoTest.AgentServer.PluginTransformTest.SetValueAction}]
     end
   end

--- a/test/jido/agent_server/status_test.exs
+++ b/test/jido/agent_server/status_test.exs
@@ -25,7 +25,7 @@ defmodule JidoTest.AgentServer.StatusTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"test_increment", TestActions.IncrementAction},
         {"test.complete", CompleteAction}

--- a/test/jido/agent_server/strategy_init_test.exs
+++ b/test/jido/agent_server/strategy_init_test.exs
@@ -65,7 +65,7 @@ defmodule JidoTest.AgentServer.StrategyInitTest do
         counter: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"test", JidoTest.AgentServer.StrategyInitTest.NoopAction}
       ]
@@ -81,7 +81,7 @@ defmodule JidoTest.AgentServer.StrategyInitTest do
         value: [type: :integer, default: 0]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule DefaultStrategyAgent do
@@ -92,7 +92,7 @@ defmodule JidoTest.AgentServer.StrategyInitTest do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   describe "strategy.init/2 lifecycle" do

--- a/test/jido/agent_server/telemetry_test.exs
+++ b/test/jido/agent_server/telemetry_test.exs
@@ -33,7 +33,7 @@ defmodule JidoTest.AgentServer.TelemetryTest do
         counter: [type: :integer, default: 0]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"emit_directive", EmitDirectiveAction},

--- a/test/jido/agent_server/trace_propagation_test.exs
+++ b/test/jido/agent_server/trace_propagation_test.exs
@@ -26,7 +26,7 @@ defmodule JidoTest.AgentServer.TracePropagationTest do
         received_signals: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", TestActions.IncrementAction},
         {"emit", EmitAction}

--- a/test/jido/await_coverage_test.exs
+++ b/test/jido/await_coverage_test.exs
@@ -55,7 +55,7 @@ defmodule JidoTest.AwaitCoverageTest do
         last_answer: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"complete", CompletingAction}]
     end
   end
@@ -70,7 +70,7 @@ defmodule JidoTest.AwaitCoverageTest do
         error: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"never_complete", NeverCompletesAction},
         {"complete", CompletingAction},

--- a/test/jido/await_test.exs
+++ b/test/jido/await_test.exs
@@ -58,7 +58,7 @@ defmodule JidoTest.AwaitTest do
         error: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"complete", CompletingAction},
         {"fail", FailingAction},
@@ -77,7 +77,7 @@ defmodule JidoTest.AwaitTest do
         last_answer: [type: :any, default: nil]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [{"complete", CompletingAction}]
     end
   end

--- a/test/jido/integration/hibernate_thaw_test.exs
+++ b/test/jido/integration/hibernate_thaw_test.exs
@@ -15,7 +15,7 @@ defmodule JidoTest.Integration.HibernateThawTest do
       ]
 
     @impl true
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defp unique_table do

--- a/test/jido/persist_test.exs
+++ b/test/jido/persist_test.exs
@@ -17,7 +17,7 @@ defmodule JidoTest.PersistTest do
       ]
 
     @impl true
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule CustomAgent do
@@ -33,7 +33,7 @@ defmodule JidoTest.PersistTest do
       schema: [value: [type: :string, default: ""]]
 
     @impl true
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defp unique_table do

--- a/test/jido/plugin/manifest_test.exs
+++ b/test/jido/plugin/manifest_test.exs
@@ -32,7 +32,7 @@ defmodule JidoTest.Plugin.ManifestTest do
       assert manifest.capabilities == []
       assert manifest.requires == []
       assert manifest.actions == []
-      assert manifest.routes == []
+      assert manifest.signal_routes == []
       assert manifest.schedules == []
       assert manifest.signal_patterns == []
     end
@@ -75,7 +75,7 @@ defmodule JidoTest.Plugin.ManifestTest do
         schema: schema,
         config_schema: config_schema,
         actions: [SomeAction, AnotherAction],
-        routes: [{"post", SomeAction}, {"get", AnotherAction}],
+        signal_routes: [{"post", SomeAction}, {"get", AnotherAction}],
         schedules: [{"*/5 * * * *", SomeAction}],
         signal_patterns: ["plugin.*"]
       }
@@ -92,7 +92,7 @@ defmodule JidoTest.Plugin.ManifestTest do
       assert manifest.schema == schema
       assert manifest.config_schema == config_schema
       assert manifest.actions == [SomeAction, AnotherAction]
-      assert manifest.routes == [{"post", SomeAction}, {"get", AnotherAction}]
+      assert manifest.signal_routes == [{"post", SomeAction}, {"get", AnotherAction}]
       assert manifest.schedules == [{"*/5 * * * *", SomeAction}]
       assert manifest.signal_patterns == ["plugin.*"]
     end

--- a/test/jido/plugin/plugin_lifecycle_test.exs
+++ b/test/jido/plugin/plugin_lifecycle_test.exs
@@ -111,7 +111,7 @@ defmodule JidoTest.PluginLifecycleTest do
     end
 
     @impl Jido.Plugin
-    def router(_config) do
+    def signal_routes(_config) do
       [
         {"chat.message", JidoTest.PluginLifecycleTest.AddMessageAction},
         {"chat.clear", JidoTest.PluginLifecycleTest.ClearMessagesAction},
@@ -389,7 +389,7 @@ defmodule JidoTest.PluginLifecycleTest do
           name: "no_plugin_agent",
           schema: [counter: [type: :integer, default: 0]]
 
-        def signal_routes do
+        def signal_routes(_ctx) do
           [{"test.action", JidoTest.PluginLifecycleTest.NoPluginAction}]
         end
       end

--- a/test/jido/plugin/plugin_test.exs
+++ b/test/jido/plugin/plugin_test.exs
@@ -30,7 +30,10 @@ defmodule JidoTest.PluginTest do
       tags: ["test", "full"],
       capabilities: [:messaging, :notifications],
       requires: [{:config, :api_key}, {:app, :req}],
-      routes: [{"post", JidoTest.PluginTestAction}, {"get", JidoTest.PluginTestAnotherAction}],
+      signal_routes: [
+        {"post", JidoTest.PluginTestAction},
+        {"get", JidoTest.PluginTestAnotherAction}
+      ],
       schedules: [{"*/5 * * * *", JidoTest.PluginTestAction}]
   end
 
@@ -47,7 +50,7 @@ defmodule JidoTest.PluginTest do
     end
 
     @impl Jido.Plugin
-    def router(_config), do: [:custom_router]
+    def signal_routes(_config), do: [:custom_router]
 
     @impl Jido.Plugin
     def handle_signal(signal, context) do
@@ -104,7 +107,7 @@ defmodule JidoTest.PluginTest do
       assert BasicPlugin.tags() == []
       assert BasicPlugin.capabilities() == []
       assert BasicPlugin.requires() == []
-      assert BasicPlugin.routes() == []
+      assert BasicPlugin.signal_routes() == []
       assert BasicPlugin.schedules() == []
     end
   end
@@ -124,7 +127,7 @@ defmodule JidoTest.PluginTest do
       assert FullPlugin.capabilities() == [:messaging, :notifications]
       assert FullPlugin.requires() == [{:config, :api_key}, {:app, :req}]
 
-      assert FullPlugin.routes() == [
+      assert FullPlugin.signal_routes() == [
                {"post", JidoTest.PluginTestAction},
                {"get", JidoTest.PluginTestAnotherAction}
              ]
@@ -293,9 +296,9 @@ defmodule JidoTest.PluginTest do
       assert result == {:ok, %{}}
     end
 
-    test "default router/1 returns nil" do
-      result = BasicPlugin.router(%{})
-      assert result == nil
+    test "default signal_routes/1 returns empty list" do
+      result = BasicPlugin.signal_routes(%{})
+      assert result == []
     end
 
     test "default handle_signal/2 returns {:ok, nil}" do
@@ -329,8 +332,8 @@ defmodule JidoTest.PluginTest do
       assert result == {:error, :mount_failed}
     end
 
-    test "custom router/1 returns custom router" do
-      result = CustomCallbackPlugin.router(%{some: :config})
+    test "custom signal_routes/1 returns custom routes" do
+      result = CustomCallbackPlugin.signal_routes(%{some: :config})
       assert result == [:custom_router]
     end
 
@@ -392,7 +395,7 @@ defmodule JidoTest.PluginTest do
       assert manifest.tags == []
       assert manifest.capabilities == []
       assert manifest.requires == []
-      assert manifest.routes == []
+      assert manifest.signal_routes == []
       assert manifest.schedules == []
     end
 
@@ -414,7 +417,7 @@ defmodule JidoTest.PluginTest do
       assert manifest.capabilities == [:messaging, :notifications]
       assert manifest.requires == [{:config, :api_key}, {:app, :req}]
 
-      assert manifest.routes == [
+      assert manifest.signal_routes == [
                {"post", JidoTest.PluginTestAction},
                {"get", JidoTest.PluginTestAnotherAction}
              ]
@@ -467,10 +470,10 @@ defmodule JidoTest.PluginTest do
       assert FullPlugin.requires() == [{:config, :api_key}, {:app, :req}]
     end
 
-    test "routes/0 returns correct values" do
-      assert BasicPlugin.routes() == []
+    test "signal_routes/0 returns correct values" do
+      assert BasicPlugin.signal_routes() == []
 
-      assert FullPlugin.routes() == [
+      assert FullPlugin.signal_routes() == [
                {"post", JidoTest.PluginTestAction},
                {"get", JidoTest.PluginTestAnotherAction}
              ]
@@ -488,7 +491,7 @@ defmodule JidoTest.PluginTest do
       assert BasicPlugin.state_key() == :basic
       assert BasicPlugin.actions() == [JidoTest.PluginTestAction]
       assert BasicPlugin.signal_patterns() == []
-      assert BasicPlugin.router(%{}) == nil
+      assert BasicPlugin.signal_routes(%{}) == []
     end
 
     test "plugin_spec still works correctly" do

--- a/test/jido/plugin/routes_test.exs
+++ b/test/jido/plugin/routes_test.exs
@@ -40,7 +40,7 @@ defmodule JidoTest.Plugin.RoutesTest do
       name: "plugin_with_routes",
       state_key: :plugin_routes,
       actions: [TestAction1, TestAction2],
-      routes: [
+      signal_routes: [
         {"post", TestAction1},
         {"list", TestAction2}
       ]
@@ -52,7 +52,7 @@ defmodule JidoTest.Plugin.RoutesTest do
       name: "plugin_with_opts",
       state_key: :plugin_opts,
       actions: [TestAction1, TestAction2],
-      routes: [
+      signal_routes: [
         {"post", TestAction1, priority: 5},
         {"list", TestAction2, on_conflict: :replace}
       ]
@@ -142,7 +142,7 @@ defmodule JidoTest.Plugin.RoutesTest do
       assert {"multi_action.pattern1", TestAction2, []} in routes
     end
 
-    test "returns empty when plugin has custom router/1 callback" do
+    test "returns empty when plugin has custom signal_routes/1 callback" do
       defmodule PluginWithCustomRouter do
         @moduledoc false
         use Jido.Plugin,
@@ -152,7 +152,7 @@ defmodule JidoTest.Plugin.RoutesTest do
           signal_patterns: ["ignored.*"]
 
         @impl Jido.Plugin
-        def router(_config) do
+        def signal_routes(_config) do
           [{"custom.route", TestAction1}]
         end
       end
@@ -164,7 +164,7 @@ defmodule JidoTest.Plugin.RoutesTest do
       assert routes == []
     end
 
-    test "falls back to patterns when router/1 returns nil" do
+    test "falls back to patterns when signal_routes/1 returns empty list" do
       defmodule PluginWithNilRouter do
         @moduledoc false
         use Jido.Plugin,
@@ -174,7 +174,7 @@ defmodule JidoTest.Plugin.RoutesTest do
           signal_patterns: ["fallback.*"]
 
         @impl Jido.Plugin
-        def router(_config), do: nil
+        def signal_routes(_config), do: []
       end
 
       instance = Instance.new(PluginWithNilRouter)

--- a/test/jido/telemetry_test.exs
+++ b/test/jido/telemetry_test.exs
@@ -12,7 +12,7 @@ defmodule JidoTest.TelemetryTest do
         counter: [type: :integer, default: 0]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   describe "start_link/1" do

--- a/test/jido/thread/strategy_integration_test.exs
+++ b/test/jido/thread/strategy_integration_test.exs
@@ -40,7 +40,7 @@ defmodule JidoTest.Thread.StrategyIntegrationTest do
       strategy: Jido.Agent.Strategy.Direct,
       schema: [value: [type: :integer, default: 0]]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule DirectThreadAgent do
@@ -50,7 +50,7 @@ defmodule JidoTest.Thread.StrategyIntegrationTest do
       strategy: {Jido.Agent.Strategy.Direct, thread?: true},
       schema: [value: [type: :integer, default: 0]]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule FSMTestAgent do
@@ -60,7 +60,7 @@ defmodule JidoTest.Thread.StrategyIntegrationTest do
       strategy: StrategyFSM,
       schema: [value: [type: :integer, default: 0]]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule FSMThreadAgent do
@@ -70,7 +70,7 @@ defmodule JidoTest.Thread.StrategyIntegrationTest do
       strategy: {StrategyFSM, thread?: true},
       schema: [value: [type: :integer, default: 0]]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   describe "Direct strategy without thread?" do

--- a/test/support/test_agents.ex
+++ b/test/support/test_agents.ex
@@ -13,7 +13,7 @@ defmodule JidoTest.TestAgents do
     use Jido.Agent,
       name: "minimal_agent"
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule Counter do
@@ -35,7 +35,7 @@ defmodule JidoTest.TestAgents do
         messages: [type: {:list, :any}, default: []]
       ]
 
-    def signal_routes do
+    def signal_routes(_ctx) do
       [
         {"increment", JidoTest.TestActions.IncrementAction},
         {"decrement", JidoTest.TestActions.DecrementAction},
@@ -59,7 +59,7 @@ defmodule JidoTest.TestAgents do
         status: [type: :atom, default: :idle]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule Hook do
@@ -70,7 +70,7 @@ defmodule JidoTest.TestAgents do
         counter: [type: :integer, default: 0]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
 
     def on_after_cmd(agent, _action, directives) do
       {:ok, %{agent | state: Map.put(agent.state, :hook_called, true)}, directives}
@@ -122,7 +122,7 @@ defmodule JidoTest.TestAgents do
       name: "custom_strategy_agent",
       strategy: JidoTest.TestAgents.CountingStrategy
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule StrategyWithOpts do
@@ -131,7 +131,7 @@ defmodule JidoTest.TestAgents do
       name: "strategy_opts_agent",
       strategy: {JidoTest.TestAgents.CountingStrategy, max_depth: 5}
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule ZoiSchema do
@@ -144,7 +144,7 @@ defmodule JidoTest.TestAgents do
           count: Zoi.integer() |> Zoi.default(0)
         })
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule WithCustomStrategy do
@@ -156,7 +156,7 @@ defmodule JidoTest.TestAgents do
         value: [type: :integer, default: 0]
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule TestPluginWithRoutes do
@@ -165,7 +165,7 @@ defmodule JidoTest.TestAgents do
       name: "test_routes_plugin",
       state_key: :test_routes,
       actions: [JidoTest.PluginTestAction],
-      routes: [
+      signal_routes: [
         {"post", JidoTest.PluginTestAction},
         {"list", JidoTest.PluginTestAction}
       ]
@@ -177,7 +177,7 @@ defmodule JidoTest.TestAgents do
       name: "priority_plugin",
       state_key: :priority,
       actions: [JidoTest.PluginTestAction],
-      routes: [
+      signal_routes: [
         {"action", JidoTest.PluginTestAction, priority: 5}
       ]
   end
@@ -188,7 +188,7 @@ defmodule JidoTest.TestAgents do
       name: "agent_with_plugin_routes",
       plugins: [JidoTest.TestAgents.TestPluginWithRoutes]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 
   defmodule AgentWithMultiInstancePlugins do
@@ -200,6 +200,6 @@ defmodule JidoTest.TestAgents do
         {JidoTest.TestAgents.TestPluginWithRoutes, as: :sales}
       ]
 
-    def signal_routes, do: []
+    def signal_routes(_ctx), do: []
   end
 end


### PR DESCRIPTION
## Summary

Normalizes `signal_routes/0` to `signal_routes/1` (accepting a context parameter), renames Skill → Plugin across docs and code, and adds plugin system enhancements including singleton enforcement and checkpoint hooks.

## Changes

- refactor: update `signal_routes` to accept context parameter
- docs: rename Skill → Plugin across all guides, README, mix.exs, and lib
- feat(agent): wire plugin checkpoint hooks into agent `checkpoint/2`
- feat(thread): implement checkpoint hooks in Thread.Plugin
- feat(plugin): add `on_checkpoint/2` and `on_restore/2` callbacks
- refactor(agent): simplify default `checkpoint/2` to pass full state
- feat(plugin): add Thread as first default singleton plugin
- feat(plugin): add default plugin auto-inclusion system
- feat(plugin): add compile-time singleton enforcement in agent macro
- feat(plugin): add singleton flag to plugin config schema
