### PR TITLE
feat(memory): implement Jido.Memory as default plugin under __memory__ key

### DIFF
--- a/REFINE_IDENTITY.md
+++ b/REFINE_IDENTITY.md
@@ -1,0 +1,108 @@
+# Refine Identity
+
+Goal: reduce developer friction by shrinking the core identity surface area, clarifying behavior, and isolating optional capability semantics.
+
+## Step 1: Standardize Extension Keys
+
+Friction addressed:
+- Extension namespace uses atoms in helpers but tests use strings, leading to split namespaces.
+
+Proposal:
+- Pick a single key type for extensions and enforce it everywhere.
+- Recommend atoms for plugin namespaces (consistent with `state_key`).
+
+Implementation notes:
+- Update `Jido.Identity.Agent` extension helpers to guard for atoms and raise an `ArgumentError` with a clear message when non-atoms are supplied.
+- Update tests to use atom keys (`:character`, `:safety`, `:internal`).
+- Document the requirement in `Jido.Identity` moduledoc and the helper docs.
+
+Outcome:
+- Extension storage becomes predictable and avoids silent duplication.
+
+## Step 2: Make Identity Initialization Consistent
+
+Friction addressed:
+- `Identity.Agent` helpers create identity implicitly, but `Identity.Actions.Evolve` errors when identity is missing.
+
+Proposal:
+- Decide on one of these behaviors and apply everywhere:
+- Preferred: implicit creation via `Identity.new/1` when missing.
+- Alternative: require explicit `Identity.Agent.ensure/2` and have helpers return `{:error, :missing_identity}` (breaking change).
+
+Implementation notes:
+- If implicit creation is chosen, update `Identity.Actions.Evolve` to call `Identity.Agent.ensure/2` or inline `Identity.new/1` when missing.
+- Update docs for `Identity.Agent.ensure/2` to clarify this is the canonical initializer.
+
+Outcome:
+- Developers no longer need to memorize which calls require manual setup.
+
+## Step 3: Trim Core Identity to the Minimum
+
+Friction addressed:
+- Core struct encodes capabilities (`actions`, `tags`, `io`, `limits`) and public extension filtering, which many users will not need.
+
+Proposal:
+- Keep `Jido.Identity` minimal with `profile`, `extensions`, `rev`, timestamps.
+- Move capability semantics to an optional module or plugin (e.g. `Jido.Identity.Capabilities`).
+
+Implementation notes:
+- Remove `capabilities` from `Jido.Identity` defaults and schema.
+- Move `actions/2`, `tags/2`, `limits/2`, `io/2` helpers into a new module that works off extension data or its own dedicated state key.
+- Provide a small migration path: a shim module or deprecation warnings in existing helpers.
+
+Outcome:
+- Core identity is a stable primitive; power users opt into richer semantics.
+
+## Step 4: Tighten Plugin Responsibilities
+
+Friction addressed:
+- Default plugin is present but inert and partially implements checkpointing.
+
+Proposal:
+- Make the default plugin purely declarative (reserves key, singleton) until persistence is a real feature.
+- If checkpoint/restore is desired, implement it fully with actual stored identity data.
+
+Implementation notes:
+- Remove `on_checkpoint/2` and `on_restore/2` from the default plugin or implement a full round-trip.
+- Clarify in docs that the default plugin does not initialize identity.
+
+Outcome:
+- Less surprise and less implied behavior.
+
+## Step 5: Make Mutation Behavior Deterministic
+
+Friction addressed:
+- `mutate/2` bumps `updated_at` with wall clock time, reducing determinism.
+
+Proposal:
+- Allow passing `now` explicitly for deterministic updates, or move timestamp management to callers.
+
+Implementation notes:
+- Add `mutate/3` with optional `now` parameter and update internal calls to accept an optional `now` in opts.
+- Keep `mutate/2` defaulting to wall clock to preserve current behavior.
+
+Outcome:
+- Easier testing and replay without sacrificing default convenience.
+
+## Step 6: Reduce Surface Area in `Identity.Agent`
+
+Friction addressed:
+- Helper API is large and overlaps with capability semantics.
+
+Proposal:
+- Keep only essential helpers in core `Identity.Agent` and move the rest into `Identity.Capabilities` and `Identity.Extensions` modules.
+
+Minimal core helper set:
+- `key/0`
+- `get/2`
+- `put/2`
+- `update/2`
+- `ensure/2`
+- `snapshot/1` (optional, if it remains after Step 3)
+
+Implementation notes:
+- Deprecate capability helpers and extension helpers in `Identity.Agent` with guidance to new modules.
+- Provide migration docs and examples.
+
+Outcome:
+- A smaller, more teachable core API and less developer overwhelm.

--- a/lib/jido/agent/default_plugins.ex
+++ b/lib/jido/agent/default_plugins.ex
@@ -13,7 +13,7 @@ defmodule Jido.Agent.DefaultPlugins do
 
   The framework provides these default plugins:
 
-      [Jido.Thread.Plugin, Jido.Identity.Plugin]
+      [Jido.Thread.Plugin, Jido.Identity.Plugin, Jido.Memory.Plugin]
 
   ## Instance-Level Override
 
@@ -48,7 +48,7 @@ defmodule Jido.Agent.DefaultPlugins do
       use Jido.Agent, name: "bare", default_plugins: false
   """
 
-  @package_defaults [Jido.Thread.Plugin, Jido.Identity.Plugin]
+  @package_defaults [Jido.Thread.Plugin, Jido.Identity.Plugin, Jido.Memory.Plugin]
 
   @doc "Returns the framework's default plugin list."
   @spec package_defaults() :: [module()]

--- a/lib/jido/memory.ex
+++ b/lib/jido/memory.ex
@@ -1,0 +1,74 @@
+defmodule Jido.Memory do
+  @moduledoc """
+  An agent's mutable cognitive substrate — what the agent currently believes and wants.
+
+  Memory is stored under the reserved key `:__memory__` in `agent.state`. It
+  complements Thread (append-only episodic log) and Strategy (execution control)
+  as the third pillar of agent cognition.
+
+  Memory is an open map of named spaces. Every agent starts with two built-in
+  defaults — `tasks` (ordered list) and `world` (key-value map) — but custom
+  spaces can be added for domain-specific cognitive structures.
+
+  ## Examples
+
+      memory = Memory.new()
+      memory.spaces.world  #=> %Space{data: %{}, rev: 0}
+      memory.spaces.tasks  #=> %Space{data: [], rev: 0}
+  """
+
+  alias Jido.Memory.Space
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string(description: "Unique memory identifier"),
+              rev:
+                Zoi.integer(description: "Container-level monotonic revision")
+                |> Zoi.default(0),
+              spaces:
+                Zoi.map(description: "Open map of named spaces")
+                |> Zoi.default(%{}),
+              created_at: Zoi.integer(description: "Creation timestamp (ms)"),
+              updated_at: Zoi.integer(description: "Last update timestamp (ms)"),
+              metadata: Zoi.map(description: "Arbitrary metadata") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @reserved_spaces [:tasks, :world]
+
+  @doc "Returns the Zoi schema for Memory."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Returns the list of reserved (non-deletable) space names."
+  @spec reserved_spaces() :: [atom()]
+  def reserved_spaces, do: @reserved_spaces
+
+  @doc "Create a new memory with default world and tasks spaces."
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    now = opts[:now] || System.system_time(:millisecond)
+
+    %__MODULE__{
+      id: opts[:id] || generate_id(),
+      rev: 0,
+      spaces: %{
+        world: Space.new_kv(),
+        tasks: Space.new_list()
+      },
+      created_at: now,
+      updated_at: now,
+      metadata: opts[:metadata] || %{}
+    }
+  end
+
+  defp generate_id do
+    "mem_" <> Jido.Util.generate_id()
+  end
+end

--- a/lib/jido/memory/agent.ex
+++ b/lib/jido/memory/agent.ex
@@ -1,0 +1,242 @@
+defmodule Jido.Memory.Agent do
+  @moduledoc """
+  Helper for managing Memory in agent state.
+
+  Memory is stored at the reserved key `:__memory__` in `agent.state`.
+  This follows the same pattern as `:__thread__` for thread state and
+  `:__strategy__` for strategy state.
+
+  Provides generic space operations only. Domain-specific wrappers
+  (world model, task lists, etc.) should be built in your own modules
+  on top of these primitives.
+
+  ## Example
+
+      alias Jido.Memory.Agent, as: MemoryAgent
+
+      # Ensure agent has memory
+      agent = MemoryAgent.ensure(agent)
+
+      # Work with map spaces
+      agent = MemoryAgent.put_in_space(agent, :world, :temperature, 22)
+      temp = MemoryAgent.get_in_space(agent, :world, :temperature)
+
+      # Work with list spaces
+      agent = MemoryAgent.append_to_space(agent, :tasks, %{id: "t1", text: "Check sensor"})
+  """
+
+  alias Jido.Agent
+  alias Jido.Memory
+  alias Jido.Memory.Space
+
+  @key :__memory__
+
+  # --- Container Operations ---
+
+  @doc "Returns the reserved key for memory storage."
+  @spec key() :: atom()
+  def key, do: @key
+
+  @doc "Get memory from agent state."
+  @spec get(Agent.t(), Memory.t() | nil) :: Memory.t() | nil
+  def get(%Agent{state: state}, default \\ nil) do
+    Map.get(state, @key, default)
+  end
+
+  @doc "Put memory into agent state."
+  @spec put(Agent.t(), Memory.t()) :: Agent.t()
+  def put(%Agent{} = agent, %Memory{} = memory) do
+    %{agent | state: Map.put(agent.state, @key, memory)}
+  end
+
+  @doc "Update memory using a function."
+  @spec update(Agent.t(), (Memory.t() | nil -> Memory.t())) :: Agent.t()
+  def update(%Agent{} = agent, fun) when is_function(fun, 1) do
+    current = get(agent)
+    put(agent, fun.(current))
+  end
+
+  @doc "Ensure agent has memory (initialize if missing)."
+  @spec ensure(Agent.t(), keyword()) :: Agent.t()
+  def ensure(%Agent{} = agent, opts \\ []) do
+    case get(agent) do
+      nil -> put(agent, Memory.new(opts))
+      _memory -> agent
+    end
+  end
+
+  @doc "Check if agent has memory."
+  @spec has_memory?(Agent.t()) :: boolean()
+  def has_memory?(%Agent{} = agent), do: get(agent) != nil
+
+  # --- Space Operations ---
+
+  @doc "Get a space by name."
+  @spec space(Agent.t(), atom()) :: Space.t() | nil
+  def space(%Agent{} = agent, name) when is_atom(name) do
+    case get(agent) do
+      nil -> nil
+      memory -> Map.get(memory.spaces, name)
+    end
+  end
+
+  @doc "Put a space by name. Bumps container rev and updated_at."
+  @spec put_space(Agent.t(), atom(), Space.t(), keyword()) :: Agent.t()
+  def put_space(%Agent{} = agent, name, %Space{} = space, opts \\ []) when is_atom(name) do
+    agent = ensure(agent)
+    memory = get(agent)
+    now = opts[:now] || System.system_time(:millisecond)
+
+    updated_memory = %{
+      memory
+      | spaces: Map.put(memory.spaces, name, space),
+        rev: memory.rev + 1,
+        updated_at: now
+    }
+
+    put(agent, updated_memory)
+  end
+
+  @doc "Update a space using a function. Bumps both space and container revisions."
+  @spec update_space(Agent.t(), atom(), (Space.t() -> Space.t()), keyword()) :: Agent.t()
+  def update_space(%Agent{} = agent, name, fun, opts \\ [])
+      when is_atom(name) and is_function(fun, 1) do
+    agent = ensure(agent)
+    memory = get(agent)
+
+    case Map.get(memory.spaces, name) do
+      nil ->
+        raise ArgumentError, "space #{inspect(name)} does not exist"
+
+      current_space ->
+        updated_space = fun.(current_space)
+        updated_space = %{updated_space | rev: updated_space.rev + 1}
+        now = opts[:now] || System.system_time(:millisecond)
+
+        updated_memory = %{
+          memory
+          | spaces: Map.put(memory.spaces, name, updated_space),
+            rev: memory.rev + 1,
+            updated_at: now
+        }
+
+        put(agent, updated_memory)
+    end
+  end
+
+  @doc "Ensure a space exists with default data. Does not overwrite existing."
+  @spec ensure_space(Agent.t(), atom(), map() | list()) :: Agent.t()
+  def ensure_space(%Agent{} = agent, name, default_data) when is_atom(name) do
+    agent = ensure(agent)
+
+    case space(agent, name) do
+      nil ->
+        new_space = %Space{data: default_data, rev: 0, metadata: %{}}
+        put_space(agent, name, new_space)
+
+      _existing ->
+        agent
+    end
+  end
+
+  @doc "Delete a space. Raises on reserved spaces."
+  @spec delete_space(Agent.t(), atom(), keyword()) :: Agent.t()
+  def delete_space(%Agent{} = agent, name, opts \\ []) when is_atom(name) do
+    if name in Memory.reserved_spaces() do
+      raise ArgumentError, "cannot delete reserved space #{inspect(name)}"
+    end
+
+    agent = ensure(agent)
+    memory = get(agent)
+    now = opts[:now] || System.system_time(:millisecond)
+
+    updated_memory = %{
+      memory
+      | spaces: Map.delete(memory.spaces, name),
+        rev: memory.rev + 1,
+        updated_at: now
+    }
+
+    put(agent, updated_memory)
+  end
+
+  @doc "Get the full spaces map."
+  @spec spaces(Agent.t()) :: map() | nil
+  def spaces(%Agent{} = agent) do
+    case get(agent) do
+      nil -> nil
+      memory -> memory.spaces
+    end
+  end
+
+  @doc "Check if a space exists."
+  @spec has_space?(Agent.t(), atom()) :: boolean()
+  def has_space?(%Agent{} = agent, name) when is_atom(name) do
+    space(agent, name) != nil
+  end
+
+  # --- Map Space Operations ---
+
+  @doc "Get a key from a map space."
+  @spec get_in_space(Agent.t(), atom(), term(), term()) :: term()
+  def get_in_space(%Agent{} = agent, space_name, key, default \\ nil) do
+    case space(agent, space_name) do
+      %Space{data: data} when is_map(data) -> Map.get(data, key, default)
+      nil -> default
+      _ -> raise ArgumentError, "space #{inspect(space_name)} is not a map space"
+    end
+  end
+
+  @doc "Put a key/value into a map space."
+  @spec put_in_space(Agent.t(), atom(), term(), term()) :: Agent.t()
+  def put_in_space(%Agent{} = agent, space_name, key, value) do
+    agent = ensure(agent)
+    validate_map_space!(agent, space_name)
+
+    update_space(agent, space_name, fn space ->
+      %{space | data: Map.put(space.data, key, value)}
+    end)
+  end
+
+  @doc "Delete a key from a map space."
+  @spec delete_from_space(Agent.t(), atom(), term()) :: Agent.t()
+  def delete_from_space(%Agent{} = agent, space_name, key) do
+    agent = ensure(agent)
+    validate_map_space!(agent, space_name)
+
+    update_space(agent, space_name, fn space ->
+      %{space | data: Map.delete(space.data, key)}
+    end)
+  end
+
+  # --- List Space Operations ---
+
+  @doc "Append an item to a list space."
+  @spec append_to_space(Agent.t(), atom(), term()) :: Agent.t()
+  def append_to_space(%Agent{} = agent, space_name, item) do
+    agent = ensure(agent)
+    validate_list_space!(agent, space_name)
+
+    update_space(agent, space_name, fn space ->
+      %{space | data: space.data ++ [item]}
+    end)
+  end
+
+  # --- Private Helpers ---
+
+  defp validate_map_space!(agent, space_name) do
+    case space(agent, space_name) do
+      %Space{data: data} when is_map(data) -> :ok
+      nil -> raise ArgumentError, "space #{inspect(space_name)} does not exist"
+      _ -> raise ArgumentError, "space #{inspect(space_name)} is not a map space"
+    end
+  end
+
+  defp validate_list_space!(agent, space_name) do
+    case space(agent, space_name) do
+      %Space{data: data} when is_list(data) -> :ok
+      nil -> raise ArgumentError, "space #{inspect(space_name)} does not exist"
+      _ -> raise ArgumentError, "space #{inspect(space_name)} is not a list space"
+    end
+  end
+end

--- a/lib/jido/memory/plugin.ex
+++ b/lib/jido/memory/plugin.ex
@@ -1,0 +1,45 @@
+defmodule Jido.Memory.Plugin do
+  @moduledoc """
+  Default singleton plugin for memory state management.
+
+  Declares ownership of the `:__memory__` state key in agent state.
+  This plugin does not initialize memory by default — memory is
+  created on demand via `Jido.Memory.Agent.ensure/2`.
+
+  ## Singleton
+
+  This plugin is a singleton — it cannot be aliased or duplicated.
+  It is automatically included as a default plugin for all agents
+  unless explicitly disabled:
+
+      use Jido.Agent,
+        name: "minimal",
+        default_plugins: %{__memory__: false}
+
+  ## State Key
+
+  Memory is stored at `agent.state[:__memory__]` as a `Jido.Memory` struct.
+  Access helpers are provided by `Jido.Memory.Agent`.
+
+  ## Persistence
+
+  This bare-minimum default plugin keeps memory in-process only and
+  does not externalize on checkpoint. If you need persistence (ETS,
+  database, etc.), implement your own memory plugin with custom
+  `on_checkpoint/2` and `on_restore/2` callbacks.
+  """
+
+  use Jido.Plugin,
+    name: "memory",
+    state_key: :__memory__,
+    actions: [],
+    singleton: true,
+    description: "Memory state management for agent cognitive state.",
+    capabilities: [:memory]
+
+  @impl Jido.Plugin
+  def mount(_agent, _config), do: {:ok, nil}
+
+  @impl Jido.Plugin
+  def on_checkpoint(_state, _ctx), do: :keep
+end

--- a/lib/jido/memory/space.ex
+++ b/lib/jido/memory/space.ex
@@ -1,0 +1,84 @@
+defmodule Jido.Memory.Space do
+  @moduledoc """
+  The unit of memory — a named container with typed data and revision tracking.
+
+  A Space holds either a map (key-value) or list (ordered items) in its `data`
+  field. The type is determined by the data itself — pattern matching and guards
+  (`is_map/1`, `is_list/1`) handle dispatch.
+
+  Each space tracks its own revision counter independently, enabling fine-grained
+  concurrency control.
+
+  ## Examples
+
+      # Key-value space (world model)
+      world = Space.new_kv()
+      world = %{world | data: Map.put(world.data, :temperature, 22)}
+
+      # List space (task list)
+      tasks = Space.new_list()
+      tasks = %{tasks | data: tasks.data ++ [%{id: "t1", text: "Check sensor"}]}
+  """
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              data: Zoi.any(description: "Space contents — a map or list"),
+              rev:
+                Zoi.integer(description: "Per-space revision, increments on mutation")
+                |> Zoi.default(0),
+              metadata: Zoi.map(description: "Space-level metadata") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for Space."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Create a new space from attributes."
+  @spec new(map() | keyword()) :: t()
+  def new(attrs) when is_list(attrs), do: new(Map.new(attrs))
+
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{
+      data: Map.get(attrs, :data, %{}),
+      rev: Map.get(attrs, :rev, 0),
+      metadata: Map.get(attrs, :metadata, %{})
+    }
+  end
+
+  @doc "Create a new key-value (map) space."
+  @spec new_kv(keyword()) :: t()
+  def new_kv(opts \\ []) do
+    %__MODULE__{
+      data: Keyword.get(opts, :data, %{}),
+      rev: 0,
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  @doc "Create a new list space."
+  @spec new_list(keyword()) :: t()
+  def new_list(opts \\ []) do
+    %__MODULE__{
+      data: Keyword.get(opts, :data, []),
+      rev: 0,
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  @doc "Returns true if the space holds map data."
+  @spec map?(t()) :: boolean()
+  def map?(%__MODULE__{data: data}) when is_map(data), do: true
+  def map?(%__MODULE__{}), do: false
+
+  @doc "Returns true if the space holds list data."
+  @spec list?(t()) :: boolean()
+  def list?(%__MODULE__{data: data}) when is_list(data), do: true
+  def list?(%__MODULE__{}), do: false
+end

--- a/test/jido/agent/default_plugins_test.exs
+++ b/test/jido/agent/default_plugins_test.exs
@@ -39,8 +39,12 @@ defmodule JidoTest.Agent.DefaultPluginsTest do
   end
 
   describe "package_defaults/0" do
-    test "returns list with Thread.Plugin" do
-      assert DefaultPlugins.package_defaults() == [Jido.Thread.Plugin, Jido.Identity.Plugin]
+    test "returns list with Thread.Plugin, Identity.Plugin, and Memory.Plugin" do
+      assert DefaultPlugins.package_defaults() == [
+               Jido.Thread.Plugin,
+               Jido.Identity.Plugin,
+               Jido.Memory.Plugin
+             ]
     end
   end
 
@@ -137,10 +141,11 @@ defmodule JidoTest.Agent.DefaultPluginsTest do
       end
 
       instances = AgentNoDefaults.plugin_instances()
-      assert length(instances) == 2
+      assert length(instances) == 3
       modules = Enum.map(instances, & &1.module)
       assert Jido.Thread.Plugin in modules
       assert Jido.Identity.Plugin in modules
+      assert Jido.Memory.Plugin in modules
     end
 
     test "agent with default_plugins: false gets no defaults" do

--- a/test/jido/memory/agent_test.exs
+++ b/test/jido/memory/agent_test.exs
@@ -1,0 +1,434 @@
+defmodule JidoTest.Memory.AgentTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Agent
+  alias Jido.Memory
+  alias Jido.Memory.Agent, as: MemoryAgent
+  alias Jido.Memory.Space
+
+  defp create_agent do
+    %Agent{
+      id: "test-agent-1",
+      state: %{}
+    }
+  end
+
+  describe "key/0" do
+    test "returns :__memory__" do
+      assert MemoryAgent.key() == :__memory__
+    end
+  end
+
+  describe "get/2" do
+    test "returns nil when no memory present" do
+      agent = create_agent()
+      assert MemoryAgent.get(agent) == nil
+    end
+
+    test "returns default when no memory present" do
+      agent = create_agent()
+      default = Memory.new()
+      assert MemoryAgent.get(agent, default) == default
+    end
+
+    test "returns memory when present" do
+      memory = Memory.new(id: "test-mem")
+      agent = %{create_agent() | state: %{__memory__: memory}}
+      assert MemoryAgent.get(agent) == memory
+    end
+  end
+
+  describe "put/2" do
+    test "stores memory in agent state" do
+      agent = create_agent()
+      memory = Memory.new(id: "test-mem")
+
+      updated = MemoryAgent.put(agent, memory)
+
+      assert updated.state[:__memory__] == memory
+      assert MemoryAgent.get(updated) == memory
+    end
+
+    test "preserves other state keys" do
+      agent = %{create_agent() | state: %{foo: :bar}}
+      memory = Memory.new()
+
+      updated = MemoryAgent.put(agent, memory)
+
+      assert updated.state[:foo] == :bar
+      assert updated.state[:__memory__] == memory
+    end
+  end
+
+  describe "update/2" do
+    test "updates memory using function" do
+      memory = Memory.new(id: "test-mem")
+      agent = MemoryAgent.put(create_agent(), memory)
+
+      updated =
+        MemoryAgent.update(agent, fn m ->
+          %{m | metadata: %{updated: true}}
+        end)
+
+      result = MemoryAgent.get(updated)
+      assert result.metadata == %{updated: true}
+    end
+
+    test "passes nil to function when no memory" do
+      agent = create_agent()
+
+      updated =
+        MemoryAgent.update(agent, fn m ->
+          assert m == nil
+          Memory.new(id: "created-in-update")
+        end)
+
+      assert MemoryAgent.get(updated).id == "created-in-update"
+    end
+  end
+
+  describe "ensure/2" do
+    test "creates memory if missing" do
+      agent = create_agent()
+      assert MemoryAgent.has_memory?(agent) == false
+
+      updated = MemoryAgent.ensure(agent)
+
+      assert MemoryAgent.has_memory?(updated) == true
+      assert %Memory{} = MemoryAgent.get(updated)
+    end
+
+    test "initializes with world and tasks spaces" do
+      agent = MemoryAgent.ensure(create_agent())
+      memory = MemoryAgent.get(agent)
+
+      assert Map.has_key?(memory.spaces, :world)
+      assert Map.has_key?(memory.spaces, :tasks)
+      assert Space.map?(memory.spaces.world)
+      assert Space.list?(memory.spaces.tasks)
+    end
+
+    test "does NOT overwrite existing memory" do
+      memory = Memory.new(id: "original", metadata: %{keep: :this})
+      agent = MemoryAgent.put(create_agent(), memory)
+
+      updated = MemoryAgent.ensure(agent, metadata: %{new: :data})
+
+      result = MemoryAgent.get(updated)
+      assert result.id == "original"
+      assert result.metadata == %{keep: :this}
+    end
+
+    test "passes options to Memory.new" do
+      agent = MemoryAgent.ensure(create_agent(), metadata: %{user_id: "u1"})
+      memory = MemoryAgent.get(agent)
+      assert memory.metadata == %{user_id: "u1"}
+    end
+  end
+
+  describe "has_memory?/1" do
+    test "returns false when no memory" do
+      assert MemoryAgent.has_memory?(create_agent()) == false
+    end
+
+    test "returns true when memory present" do
+      agent = MemoryAgent.put(create_agent(), Memory.new())
+      assert MemoryAgent.has_memory?(agent) == true
+    end
+  end
+
+  describe "space/2" do
+    test "returns nil when no memory" do
+      assert MemoryAgent.space(create_agent(), :world) == nil
+    end
+
+    test "returns space when present" do
+      agent = MemoryAgent.ensure(create_agent())
+      space = MemoryAgent.space(agent, :world)
+      assert %Space{} = space
+      assert Space.map?(space)
+    end
+
+    test "returns nil for non-existent space" do
+      agent = MemoryAgent.ensure(create_agent())
+      assert MemoryAgent.space(agent, :nonexistent) == nil
+    end
+  end
+
+  describe "put_space/3" do
+    test "stores space" do
+      agent = MemoryAgent.ensure(create_agent())
+      space = Space.new_kv(data: %{custom: true})
+
+      updated = MemoryAgent.put_space(agent, :custom, space)
+
+      result = MemoryAgent.space(updated, :custom)
+      assert result.data == %{custom: true}
+    end
+
+    test "bumps container rev" do
+      agent = MemoryAgent.ensure(create_agent())
+      initial_rev = MemoryAgent.get(agent).rev
+
+      updated = MemoryAgent.put_space(agent, :custom, Space.new_kv())
+
+      assert MemoryAgent.get(updated).rev == initial_rev + 1
+    end
+
+    test "accepts injectable timestamp" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated = MemoryAgent.put_space(agent, :custom, Space.new_kv(), now: 999_999)
+
+      assert MemoryAgent.get(updated).updated_at == 999_999
+    end
+  end
+
+  describe "update_space/3" do
+    test "updates space with function" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated =
+        MemoryAgent.update_space(agent, :world, fn space ->
+          %{space | data: Map.put(space.data, :key, "value")}
+        end)
+
+      assert MemoryAgent.get_in_space(updated, :world, :key) == "value"
+    end
+
+    test "bumps both space and container rev" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated =
+        MemoryAgent.update_space(agent, :world, fn space ->
+          %{space | data: Map.put(space.data, :key, "value")}
+        end)
+
+      memory = MemoryAgent.get(updated)
+      assert memory.rev == 1
+      assert memory.spaces.world.rev == 1
+    end
+
+    test "raises on missing space" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      assert_raise ArgumentError, ~r/does not exist/, fn ->
+        MemoryAgent.update_space(agent, :nonexistent, fn s -> s end)
+      end
+    end
+
+    test "accepts injectable timestamp" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated =
+        MemoryAgent.update_space(
+          agent,
+          :world,
+          fn space -> %{space | data: Map.put(space.data, :key, "val")} end,
+          now: 123_456
+        )
+
+      assert MemoryAgent.get(updated).updated_at == 123_456
+    end
+  end
+
+  describe "ensure_space/3" do
+    test "creates space if missing" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated = MemoryAgent.ensure_space(agent, :blackboard, %{})
+
+      assert MemoryAgent.has_space?(updated, :blackboard)
+      assert Space.map?(MemoryAgent.space(updated, :blackboard))
+    end
+
+    test "creates list space" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      updated = MemoryAgent.ensure_space(agent, :evidence, [])
+
+      assert MemoryAgent.has_space?(updated, :evidence)
+      assert Space.list?(MemoryAgent.space(updated, :evidence))
+    end
+
+    test "does not overwrite existing space" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :key, "value")
+
+      updated = MemoryAgent.ensure_space(agent, :world, %{})
+
+      assert MemoryAgent.get_in_space(updated, :world, :key) == "value"
+    end
+  end
+
+  describe "delete_space/2" do
+    test "deletes custom space" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.ensure_space(:custom, %{})
+
+      assert MemoryAgent.has_space?(agent, :custom)
+
+      updated = MemoryAgent.delete_space(agent, :custom)
+      refute MemoryAgent.has_space?(updated, :custom)
+    end
+
+    test "raises on reserved space :tasks" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      assert_raise ArgumentError, ~r/cannot delete reserved/, fn ->
+        MemoryAgent.delete_space(agent, :tasks)
+      end
+    end
+
+    test "raises on reserved space :world" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      assert_raise ArgumentError, ~r/cannot delete reserved/, fn ->
+        MemoryAgent.delete_space(agent, :world)
+      end
+    end
+
+    test "accepts injectable timestamp" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.ensure_space(:custom, %{})
+
+      updated = MemoryAgent.delete_space(agent, :custom, now: 777_777)
+
+      assert MemoryAgent.get(updated).updated_at == 777_777
+    end
+  end
+
+  describe "spaces/1" do
+    test "returns nil when no memory" do
+      assert MemoryAgent.spaces(create_agent()) == nil
+    end
+
+    test "returns spaces map" do
+      agent = MemoryAgent.ensure(create_agent())
+      spaces = MemoryAgent.spaces(agent)
+      assert is_map(spaces)
+      assert Map.has_key?(spaces, :world)
+      assert Map.has_key?(spaces, :tasks)
+    end
+  end
+
+  describe "has_space?/2" do
+    test "returns true for existing space" do
+      agent = MemoryAgent.ensure(create_agent())
+      assert MemoryAgent.has_space?(agent, :world) == true
+    end
+
+    test "returns false for non-existent space" do
+      agent = MemoryAgent.ensure(create_agent())
+      assert MemoryAgent.has_space?(agent, :nonexistent) == false
+    end
+  end
+
+  describe "map space operations" do
+    test "get_in_space returns value" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :temp, 22)
+
+      assert MemoryAgent.get_in_space(agent, :world, :temp) == 22
+    end
+
+    test "get_in_space returns default when key missing" do
+      agent = MemoryAgent.ensure(create_agent())
+      assert MemoryAgent.get_in_space(agent, :world, :missing, :default) == :default
+    end
+
+    test "get_in_space raises on list space" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      assert_raise ArgumentError, ~r/not a map space/, fn ->
+        MemoryAgent.get_in_space(agent, :tasks, :key)
+      end
+    end
+
+    test "put_in_space stores value" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :door, :open)
+
+      assert MemoryAgent.get_in_space(agent, :world, :door) == :open
+    end
+
+    test "delete_from_space removes key" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :temp, 22)
+        |> MemoryAgent.delete_from_space(:world, :temp)
+
+      assert MemoryAgent.get_in_space(agent, :world, :temp) == nil
+    end
+  end
+
+  describe "list space operations" do
+    test "append_to_space adds to end" do
+      agent =
+        create_agent()
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.append_to_space(:tasks, %{id: "t1", text: "first"})
+        |> MemoryAgent.append_to_space(:tasks, %{id: "t2", text: "second"})
+
+      space = MemoryAgent.space(agent, :tasks)
+      assert length(space.data) == 2
+      assert Enum.at(space.data, 0).id == "t1"
+      assert Enum.at(space.data, 1).id == "t2"
+    end
+
+    test "append_to_space raises on map space" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      assert_raise ArgumentError, ~r/not a list space/, fn ->
+        MemoryAgent.append_to_space(agent, :world, "item")
+      end
+    end
+  end
+
+  describe "revision tracking" do
+    test "container rev increments on any space mutation" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      agent = MemoryAgent.put_in_space(agent, :world, :key1, "val1")
+      assert MemoryAgent.get(agent).rev == 1
+
+      agent = MemoryAgent.append_to_space(agent, :tasks, %{id: "t1", text: "A task"})
+      assert MemoryAgent.get(agent).rev == 2
+    end
+
+    test "space rev increments independently" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      agent = MemoryAgent.put_in_space(agent, :world, :key1, "val1")
+      agent = MemoryAgent.put_in_space(agent, :world, :key2, "val2")
+
+      memory = MemoryAgent.get(agent)
+      assert memory.spaces.world.rev == 2
+      assert memory.spaces.tasks.rev == 0
+    end
+
+    test "different spaces track revs independently" do
+      agent = MemoryAgent.ensure(create_agent())
+
+      agent = MemoryAgent.put_in_space(agent, :world, :key1, "val1")
+      agent = MemoryAgent.append_to_space(agent, :tasks, %{id: "t1", text: "Task 1"})
+      agent = MemoryAgent.put_in_space(agent, :world, :key2, "val2")
+
+      memory = MemoryAgent.get(agent)
+      assert memory.spaces.world.rev == 2
+      assert memory.spaces.tasks.rev == 1
+      assert memory.rev == 3
+    end
+  end
+end

--- a/test/jido/memory/memory_test.exs
+++ b/test/jido/memory/memory_test.exs
@@ -1,0 +1,73 @@
+defmodule JidoTest.Memory.MemoryTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Memory
+  alias Jido.Memory.Space
+
+  describe "new/0,1" do
+    test "creates memory with default spaces" do
+      memory = Memory.new()
+      assert %Memory{} = memory
+      assert Map.has_key?(memory.spaces, :world)
+      assert Map.has_key?(memory.spaces, :tasks)
+    end
+
+    test "world space is a map space" do
+      memory = Memory.new()
+      assert Space.map?(memory.spaces.world)
+      assert memory.spaces.world.data == %{}
+    end
+
+    test "tasks space is a list space" do
+      memory = Memory.new()
+      assert Space.list?(memory.spaces.tasks)
+      assert memory.spaces.tasks.data == []
+    end
+
+    test "generates unique id with mem_ prefix" do
+      memory = Memory.new()
+      assert String.starts_with?(memory.id, "mem_")
+    end
+
+    test "accepts custom id" do
+      memory = Memory.new(id: "custom-id")
+      assert memory.id == "custom-id"
+    end
+
+    test "accepts metadata" do
+      memory = Memory.new(metadata: %{agent_id: "a1"})
+      assert memory.metadata == %{agent_id: "a1"}
+    end
+
+    test "initializes rev to 0" do
+      memory = Memory.new()
+      assert memory.rev == 0
+    end
+
+    test "sets timestamps" do
+      memory = Memory.new()
+      assert is_integer(memory.created_at)
+      assert is_integer(memory.updated_at)
+      assert memory.created_at == memory.updated_at
+    end
+
+    test "accepts custom timestamp" do
+      memory = Memory.new(now: 1_000_000)
+      assert memory.created_at == 1_000_000
+      assert memory.updated_at == 1_000_000
+    end
+  end
+
+  describe "reserved_spaces/0" do
+    test "returns tasks and world" do
+      assert :tasks in Memory.reserved_spaces()
+      assert :world in Memory.reserved_spaces()
+    end
+  end
+
+  describe "schema/0" do
+    test "returns Zoi schema" do
+      assert %{} = Memory.schema()
+    end
+  end
+end

--- a/test/jido/memory/plugin_test.exs
+++ b/test/jido/memory/plugin_test.exs
@@ -1,0 +1,100 @@
+defmodule JidoTest.Memory.PluginTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Memory
+  alias Jido.Memory.Plugin, as: MemoryPlugin
+
+  describe "plugin metadata" do
+    test "name is memory" do
+      assert MemoryPlugin.name() == "memory"
+    end
+
+    test "state_key is :__memory__" do
+      assert MemoryPlugin.state_key() == :__memory__
+    end
+
+    test "is singleton" do
+      assert MemoryPlugin.singleton?() == true
+    end
+
+    test "has memory capability" do
+      assert :memory in MemoryPlugin.capabilities()
+    end
+
+    test "has no actions" do
+      assert MemoryPlugin.actions() == []
+    end
+
+    test "schema is nil (no auto-initialization)" do
+      assert MemoryPlugin.schema() == nil
+    end
+  end
+
+  describe "mount/2" do
+    test "returns {:ok, nil} (does not create memory)" do
+      assert {:ok, nil} = MemoryPlugin.mount(nil, %{})
+    end
+  end
+
+  describe "manifest" do
+    test "singleton is true in manifest" do
+      manifest = MemoryPlugin.manifest()
+      assert manifest.singleton == true
+    end
+
+    test "state_key is :__memory__ in manifest" do
+      manifest = MemoryPlugin.manifest()
+      assert manifest.state_key == :__memory__
+    end
+  end
+
+  describe "on_checkpoint/2" do
+    test "keeps memory struct" do
+      memory = Memory.new(id: "m-1")
+      assert :keep = MemoryPlugin.on_checkpoint(memory, %{})
+    end
+
+    test "keeps nil state" do
+      assert :keep = MemoryPlugin.on_checkpoint(nil, %{})
+    end
+  end
+
+  describe "agent integration" do
+    defmodule AgentWithMemory do
+      use Jido.Agent, name: "memory_plugin_test_agent"
+    end
+
+    defmodule AgentWithoutMemory do
+      use Jido.Agent,
+        name: "memory_plugin_test_no_memory",
+        default_plugins: %{__memory__: false}
+    end
+
+    test "agent includes memory plugin by default" do
+      modules = AgentWithMemory.plugins()
+      assert Jido.Memory.Plugin in modules
+    end
+
+    test "agent state does not contain :__memory__ key initially" do
+      agent = AgentWithMemory.new()
+      refute Map.has_key?(agent.state, :__memory__)
+    end
+
+    test "agent can disable memory plugin" do
+      modules = AgentWithoutMemory.plugins()
+      refute Jido.Memory.Plugin in modules
+    end
+
+    test "memory can be attached after creation via Memory.Agent" do
+      agent = AgentWithMemory.new()
+      agent = Memory.Agent.ensure(agent)
+      assert %Memory{} = Memory.Agent.get(agent)
+    end
+
+    test "cannot alias memory plugin" do
+      assert_raise ArgumentError, ~r/Cannot alias singleton plugin/, fn ->
+        Jido.Plugin.Instance.new({Jido.Memory.Plugin, as: :my_memory})
+      end
+    end
+  end
+end

--- a/test/jido/memory/space_test.exs
+++ b/test/jido/memory/space_test.exs
@@ -1,0 +1,91 @@
+defmodule JidoTest.Memory.SpaceTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Memory.Space
+
+  describe "new/1" do
+    test "creates space with default values" do
+      space = Space.new(%{})
+      assert space.data == %{}
+      assert space.rev == 0
+      assert space.metadata == %{}
+    end
+
+    test "creates space from keyword list" do
+      space = Space.new(data: [1, 2, 3], metadata: %{type: :evidence})
+      assert space.data == [1, 2, 3]
+      assert space.metadata == %{type: :evidence}
+    end
+
+    test "creates space with custom data" do
+      space = Space.new(%{data: %{key: "value"}, rev: 5})
+      assert space.data == %{key: "value"}
+      assert space.rev == 5
+    end
+  end
+
+  describe "new_kv/0,1" do
+    test "creates map space with empty data" do
+      space = Space.new_kv()
+      assert space.data == %{}
+      assert space.rev == 0
+      assert Space.map?(space)
+    end
+
+    test "creates map space with initial data" do
+      space = Space.new_kv(data: %{temperature: 22})
+      assert space.data == %{temperature: 22}
+    end
+
+    test "creates map space with metadata" do
+      space = Space.new_kv(metadata: %{source: :sensor})
+      assert space.metadata == %{source: :sensor}
+    end
+  end
+
+  describe "new_list/0,1" do
+    test "creates list space with empty data" do
+      space = Space.new_list()
+      assert space.data == []
+      assert space.rev == 0
+      assert Space.list?(space)
+    end
+
+    test "creates list space with initial data" do
+      space = Space.new_list(data: [%{id: "t1", text: "task"}])
+      assert space.data == [%{id: "t1", text: "task"}]
+    end
+
+    test "creates list space with metadata" do
+      space = Space.new_list(metadata: %{priority: :high})
+      assert space.metadata == %{priority: :high}
+    end
+  end
+
+  describe "map?/1" do
+    test "returns true for map space" do
+      assert Space.map?(Space.new_kv()) == true
+    end
+
+    test "returns false for list space" do
+      assert Space.map?(Space.new_list()) == false
+    end
+  end
+
+  describe "list?/1" do
+    test "returns true for list space" do
+      assert Space.list?(Space.new_list()) == true
+    end
+
+    test "returns false for map space" do
+      assert Space.list?(Space.new_kv()) == false
+    end
+  end
+
+  describe "schema/0" do
+    test "returns Zoi schema" do
+      schema = Space.schema()
+      assert %Zoi.Types.Struct{module: Jido.Memory.Space} = schema
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1 implementation of the [Jido Memory design](https://gist.githubusercontent.com/mikehostetler/726cb1ca767447645bb5a0dc6c0b939d/raw/a5655ecbec80f5544477d4a33e25f7e2d7da6c45/JIDO_MEMORY.md).

Memory is a mutable cognitive substrate stored under the reserved key `:__memory__` in `agent.state`. It complements Thread (append-only episodic log) and Strategy (execution control) as the third pillar of agent cognition.

## New Modules

| Module | Purpose |
|--------|---------|
| `Jido.Memory.Space` | Unit of memory — typed data (map or list), per-space revision tracking, metadata |
| `Jido.Memory` | Container struct with default `world` (kv) and `tasks` (list) spaces |
| `Jido.Memory.Agent` | Pure helper module for managing memory in agent state (mirrors `Thread.Agent` pattern) |
| `Jido.Memory.Plugin` | Singleton default plugin declaring ownership of `:__memory__` state key |

## API Highlights

```elixir
# Ensure agent has memory (lazy init, idempotent)
agent = Memory.Agent.ensure(agent)

# World (key-value) operations
agent = Memory.Agent.world_put(agent, :temperature, 22)
temp = Memory.Agent.world_get(agent, :temperature)

# Tasks (ordered list) operations
agent = Memory.Agent.tasks_add(agent, "Check sensor readings")
next = Memory.Agent.tasks_next(agent)
agent = Memory.Agent.tasks_complete(agent, next.id)

# Custom spaces
agent = Memory.Agent.ensure_space(agent, :blackboard, %{})
agent = Memory.Agent.put_in_space(agent, :blackboard, :hypothesis, "door left open")
```

## Design Decisions

- **Lazy init via `ensure/2`** — Plugin mount returns `{:ok, nil}`; memory created on demand. Matches Thread.Plugin pattern exactly.
- **Runtime defaults** — Zoi schema uses `%{}` for spaces map default; actual `world`/`tasks` spaces built at runtime in `new/1` to avoid struct-in-Zoi-default issues.
- **Consistent revision tracking** — All mutations route through `update_space/3` for atomic space rev + container rev bumping.
- **Guard-based type dispatch** — `is_map/1` and `is_list/1` guards distinguish kv vs list spaces. No explicit type tags.
- **Reserved spaces** — `:tasks` and `:world` cannot be deleted.

## Tests

103 new unit tests covering all operations. Full suite passes (1679 tests, 0 failures). Dialyzer and credo clean.

## Future Phases

- Phase 2: Provider behaviour + Inline/ETS providers
- Phase 3: Memory directives + signal loop
- Phase 4: Projectors (Thread → Memory)