### PR TITLE
test: add memory plugin and default plugins persistence examples

### DIFF
--- a/test/examples/persistence/default_plugins_persistence_test.exs
+++ b/test/examples/persistence/default_plugins_persistence_test.exs
@@ -1,0 +1,161 @@
+defmodule JidoExampleTest.DefaultPluginsPersistenceTest do
+  @moduledoc """
+  Example test verifying that all three default plugins (Thread, Identity, Memory)
+  properly survive a hibernate/thaw cycle.
+
+  This test shows:
+  - Identity plugin state (:keep) is preserved through checkpoint round-trip
+  - Memory plugin state (:keep) is preserved through checkpoint round-trip
+  - Thread plugin state (:externalize) is stored separately and rehydrated
+  - All three plugins together survive a full hibernate/thaw cycle
+  - Agents with no plugin state initialized still round-trip correctly
+
+  Run with: mix test --include example
+  """
+  use JidoTest.Case, async: true
+
+  @moduletag :example
+  @moduletag timeout: 15_000
+
+  alias Jido.Agent
+  alias Jido.Persist
+  alias Jido.Storage.ETS
+  alias Jido.Thread
+  alias Jido.Identity.Agent, as: IdentityAgent
+  alias Jido.Memory.Agent, as: MemoryAgent
+  alias Jido.Thread.Agent, as: ThreadAgent
+
+  # ===========================================================================
+  # AGENT
+  # ===========================================================================
+
+  defmodule FullAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "full_agent",
+      description: "Agent with all three default plugins for persistence testing",
+      schema: [
+        counter: [type: :integer, default: 0],
+        status: [type: :atom, default: :idle]
+      ]
+  end
+
+  # ===========================================================================
+  # HELPERS
+  # ===========================================================================
+
+  defp unique_table, do: :"default_plugins_persist_#{System.unique_integer([:positive])}"
+
+  defp storage(table), do: {ETS, table: table}
+
+  # ===========================================================================
+  # TESTS
+  # ===========================================================================
+
+  describe "identity survives hibernate/thaw" do
+    test "identity struct is preserved through checkpoint round-trip" do
+      table = unique_table()
+
+      agent =
+        FullAgent.new(id: "identity-1")
+        |> IdentityAgent.ensure(profile: %{age: 5, origin: :test})
+
+      agent = %{agent | state: %{agent.state | counter: 10, status: :active}}
+
+      :ok = Persist.hibernate(storage(table), agent)
+      {:ok, restored} = Persist.thaw(storage(table), Agent, "identity-1")
+
+      assert IdentityAgent.has_identity?(restored)
+      assert restored.state.__identity__.profile[:age] == 5
+      assert restored.state.__identity__.profile[:origin] == :test
+
+      assert restored.state.counter == 10
+      assert restored.state.status == :active
+    end
+  end
+
+  describe "memory survives hibernate/thaw" do
+    test "memory spaces are preserved through checkpoint round-trip" do
+      table = unique_table()
+
+      agent =
+        FullAgent.new(id: "memory-1")
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :temperature, 22)
+        |> MemoryAgent.append_to_space(:tasks, %{id: "t1", text: "check"})
+
+      agent = %{agent | state: %{agent.state | counter: 5}}
+
+      :ok = Persist.hibernate(storage(table), agent)
+      {:ok, restored} = Persist.thaw(storage(table), Agent, "memory-1")
+
+      assert MemoryAgent.has_memory?(restored)
+      assert MemoryAgent.get_in_space(restored, :world, :temperature) == 22
+
+      tasks_space = MemoryAgent.space(restored, :tasks)
+      assert length(tasks_space.data) == 1
+      assert Enum.at(tasks_space.data, 0).id == "t1"
+
+      assert restored.state.counter == 5
+    end
+  end
+
+  describe "all three plugins together survive hibernate/thaw" do
+    test "comprehensive round-trip with identity, memory, and thread" do
+      table = unique_table()
+
+      agent =
+        FullAgent.new(id: "all-plugins-1")
+        |> IdentityAgent.ensure(profile: %{age: 3, origin: :spawned})
+        |> MemoryAgent.ensure()
+        |> MemoryAgent.put_in_space(:world, :temperature, 18)
+        |> MemoryAgent.append_to_space(:tasks, %{id: "t1", text: "deploy"})
+        |> ThreadAgent.ensure()
+        |> ThreadAgent.append(%{kind: :message, payload: %{role: "user", content: "hello"}})
+        |> ThreadAgent.append(%{kind: :message, payload: %{role: "assistant", content: "hi"}})
+
+      agent = %{agent | state: %{agent.state | counter: 42, status: :processing}}
+
+      :ok = Persist.hibernate(storage(table), agent)
+      {:ok, restored} = Persist.thaw(storage(table), Agent, "all-plugins-1")
+
+      # Identity preserved
+      assert IdentityAgent.has_identity?(restored)
+      assert restored.state.__identity__.profile[:age] == 3
+      assert restored.state.__identity__.profile[:origin] == :spawned
+
+      # Memory preserved
+      assert MemoryAgent.has_memory?(restored)
+      assert MemoryAgent.get_in_space(restored, :world, :temperature) == 18
+      tasks_space = MemoryAgent.space(restored, :tasks)
+      assert length(tasks_space.data) == 1
+      assert Enum.at(tasks_space.data, 0).id == "t1"
+
+      # Thread rehydrated from external storage
+      assert ThreadAgent.has_thread?(restored)
+      rehydrated_thread = ThreadAgent.get(restored)
+      assert Thread.entry_count(rehydrated_thread) == 2
+
+      # Regular state preserved
+      assert restored.state.counter == 42
+      assert restored.state.status == :processing
+    end
+  end
+
+  describe "plugins without state survive hibernate/thaw" do
+    test "agent with no plugin state initialized round-trips correctly" do
+      table = unique_table()
+
+      agent = FullAgent.new(id: "no-plugins-1")
+      agent = %{agent | state: %{agent.state | counter: 7}}
+
+      :ok = Persist.hibernate(storage(table), agent)
+      {:ok, restored} = Persist.thaw(storage(table), Agent, "no-plugins-1")
+
+      assert restored.state.counter == 7
+      refute IdentityAgent.has_identity?(restored)
+      refute MemoryAgent.has_memory?(restored)
+      refute ThreadAgent.has_thread?(restored)
+    end
+  end
+end

--- a/test/examples/plugins/memory_plugin_test.exs
+++ b/test/examples/plugins/memory_plugin_test.exs
@@ -1,0 +1,206 @@
+defmodule JidoExampleTest.MemoryPluginTest do
+  @moduledoc """
+  Example test demonstrating Memory as a default plugin.
+
+  This test shows:
+  - Every agent gets `Jido.Memory.Plugin` automatically (default singleton plugin)
+  - Using `Jido.Memory.Agent` helpers: `ensure/2`, `has_memory?/1`, `get/1`, `put/2`,
+    `put_in_space/4`, `get_in_space/4`, `append_to_space/3`, `ensure_space/3`,
+    `space/2`, `spaces/1`, `has_space?/2`, `delete_space/2`, `update_space/4`
+  - Actions that manipulate memory spaces via cmd/2
+  - Disabling the memory plugin with `default_plugins: %{__memory__: false}`
+
+  Run with: mix test --include example
+  """
+  use JidoTest.Case, async: false
+
+  @moduletag :example
+  @moduletag timeout: 15_000
+
+  alias Jido.Memory
+  alias Jido.Memory.Agent, as: MemAgent
+  alias Jido.Memory.Space
+
+  # ===========================================================================
+  # ACTIONS
+  # ===========================================================================
+
+  defmodule UpdateWorldAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "update_world",
+      schema: [
+        key: [type: :atom, required: true],
+        value: [type: :any, required: true]
+      ]
+
+    def run(%{key: key, value: value}, context) do
+      alias Jido.Memory
+      alias Jido.Memory.Space
+
+      memory = Map.get(context.state, :__memory__) || Memory.new()
+      world = Map.get(memory.spaces, :world, Space.new_kv())
+      updated_world = %{world | data: Map.put(world.data, key, value), rev: world.rev + 1}
+
+      updated_memory = %{
+        memory
+        | spaces: Map.put(memory.spaces, :world, updated_world),
+          rev: memory.rev + 1
+      }
+
+      {:ok, %{__memory__: updated_memory}}
+    end
+  end
+
+  # ===========================================================================
+  # AGENTS
+  # ===========================================================================
+
+  defmodule MemoryAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "memory_agent",
+      description: "Agent with default memory plugin",
+      schema: [
+        status: [type: :atom, default: :idle]
+      ]
+  end
+
+  defmodule NoMemoryAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "no_memory_agent",
+      description: "Agent with memory plugin disabled",
+      default_plugins: %{__memory__: false},
+      schema: [
+        value: [type: :integer, default: 0]
+      ]
+  end
+
+  # ===========================================================================
+  # TESTS
+  # ===========================================================================
+
+  describe "memory plugin is a default singleton" do
+    test "new agent has no memory until initialized on demand" do
+      agent = MemoryAgent.new()
+
+      refute MemAgent.has_memory?(agent)
+    end
+
+    test "MemAgent.ensure initializes memory on demand" do
+      agent = MemoryAgent.new()
+
+      agent = MemAgent.ensure(agent)
+
+      assert MemAgent.has_memory?(agent)
+      memory = MemAgent.get(agent)
+      assert %Memory{} = memory
+      assert Map.has_key?(memory.spaces, :world)
+      assert Map.has_key?(memory.spaces, :tasks)
+    end
+  end
+
+  describe "space operations" do
+    test "put and get in map space (:world)" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      agent = MemAgent.put_in_space(agent, :world, :temperature, 22)
+      assert MemAgent.get_in_space(agent, :world, :temperature) == 22
+
+      agent = MemAgent.put_in_space(agent, :world, :humidity, 65)
+      assert MemAgent.get_in_space(agent, :world, :humidity) == 65
+      assert MemAgent.get_in_space(agent, :world, :temperature) == 22
+    end
+
+    test "append to list space (:tasks)" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      agent = MemAgent.append_to_space(agent, :tasks, %{id: "t1", text: "Check sensor"})
+      agent = MemAgent.append_to_space(agent, :tasks, %{id: "t2", text: "Report status"})
+
+      tasks_space = MemAgent.space(agent, :tasks)
+      assert Space.list?(tasks_space)
+      assert length(tasks_space.data) == 2
+      assert Enum.map(tasks_space.data, & &1.id) == ["t1", "t2"]
+    end
+
+    test "ensure_space creates a new custom space" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      refute MemAgent.has_space?(agent, :custom)
+
+      agent = MemAgent.ensure_space(agent, :custom, %{})
+      assert MemAgent.has_space?(agent, :custom)
+
+      custom_space = MemAgent.space(agent, :custom)
+      assert Space.map?(custom_space)
+    end
+
+    test "delete_space works for custom spaces" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+        |> MemAgent.ensure_space(:scratch, %{})
+
+      assert MemAgent.has_space?(agent, :scratch)
+
+      agent = MemAgent.delete_space(agent, :scratch)
+      refute MemAgent.has_space?(agent, :scratch)
+    end
+
+    test "delete_space raises on reserved spaces" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      assert_raise ArgumentError, ~r/cannot delete reserved space/, fn ->
+        MemAgent.delete_space(agent, :world)
+      end
+    end
+  end
+
+  describe "memory state via cmd/2" do
+    test "cmd/2 with action preserves memory changes" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      {agent, []} = MemoryAgent.cmd(agent, {UpdateWorldAction, %{key: :location, value: "lab"}})
+
+      assert MemAgent.has_memory?(agent)
+      assert MemAgent.get_in_space(agent, :world, :location) == "lab"
+    end
+
+    test "multiple cmd/2 calls accumulate memory" do
+      agent =
+        MemoryAgent.new()
+        |> MemAgent.ensure()
+
+      {agent, []} = MemoryAgent.cmd(agent, {UpdateWorldAction, %{key: :x, value: 1}})
+      {agent, []} = MemoryAgent.cmd(agent, {UpdateWorldAction, %{key: :y, value: 2}})
+
+      assert MemAgent.get_in_space(agent, :world, :x) == 1
+      assert MemAgent.get_in_space(agent, :world, :y) == 2
+    end
+  end
+
+  describe "disabling memory plugin" do
+    test "agent with __memory__ disabled has no memory capability" do
+      agent = NoMemoryAgent.new()
+
+      refute MemAgent.has_memory?(agent)
+      refute Map.has_key?(agent.state, :__memory__)
+
+      specs = NoMemoryAgent.plugin_specs()
+      modules = Enum.map(specs, & &1.module)
+      refute Jido.Memory.Plugin in modules
+    end
+  end
+end


### PR DESCRIPTION
Adds example tests verifying that all three default plugins (Thread, Identity, Memory) properly handle persistence.

## New test files

- **`test/examples/plugins/memory_plugin_test.exs`** — 10 tests covering Memory.Plugin as a default singleton, map/list space operations, cmd/2 integration, and disabling via `default_plugins`
- **`test/examples/persistence/default_plugins_persistence_test.exs`** — 4 tests verifying hibernate/thaw round-trips:
  - Identity (`:keep` checkpoint strategy) preserves profile data
  - Memory (`:keep` checkpoint strategy) preserves world and tasks spaces
  - All three plugins together survive a single round-trip
  - Agent with no plugin state initialized round-trips correctly

All 167 example tests pass.