### PR TITLE
fix(agent): normalize id in both constructor paths to guarantee UUID7

### DIFF
--- a/test/jido/agent/agent_test.exs
+++ b/test/jido/agent/agent_test.exs
@@ -34,6 +34,24 @@ defmodule JidoTest.AgentTest do
       assert agent.id == "custom-123"
     end
 
+    test "generates unique ids for each instance" do
+      agent1 = TestAgents.Minimal.new()
+      agent2 = TestAgents.Minimal.new()
+      assert agent1.id != agent2.id
+    end
+
+    test "generates id when nil is passed" do
+      agent = TestAgents.Minimal.new(id: nil)
+      assert is_binary(agent.id)
+      assert String.length(agent.id) > 0
+    end
+
+    test "generates id when empty string is passed" do
+      agent = TestAgents.Minimal.new(id: "")
+      assert is_binary(agent.id)
+      assert String.length(agent.id) > 0
+    end
+
     test "creates agent with initial state" do
       agent = TestAgents.Basic.new(state: %{counter: 10})
       assert agent.state.counter == 10
@@ -303,6 +321,24 @@ defmodule JidoTest.AgentTest do
       {:ok, agent} = Agent.new(name: "test_agent", id: "kw-123")
       assert agent.id == "kw-123"
       assert agent.name == "test_agent"
+    end
+
+    test "Agent.new/1 auto-generates id when not provided" do
+      {:ok, agent} = Agent.new(%{name: "test_agent"})
+      assert is_binary(agent.id)
+      assert String.length(agent.id) > 0
+    end
+
+    test "Agent.new/1 generates id when nil is passed" do
+      {:ok, agent} = Agent.new(%{id: nil, name: "test_agent"})
+      assert is_binary(agent.id)
+      assert String.length(agent.id) > 0
+    end
+
+    test "Agent.new/1 generates id when empty string is passed" do
+      {:ok, agent} = Agent.new(%{id: "", name: "test_agent"})
+      assert is_binary(agent.id)
+      assert String.length(agent.id) > 0
     end
 
     test "Agent.set/2 updates state" do


### PR DESCRIPTION
## Summary

Hardens both agent constructor paths to guarantee every `Jido.Agent` instance gets a unique UUID7, matching Jido 1.x behavior.

## Problem

Two subtle bugs allowed agents to be created with nil or empty-string IDs:

- **Module-based `new/1`** used `opts[:id] || generate_id()`, which accepted `id: ""` since empty string is truthy in Elixir
- **Base `Agent.new/1`** used `Map.put_new_lazy/3`, which did not override an explicitly-passed `id: nil` (key present, value nil)

## Fix

- Module-based `new/1`: replaced `||` with explicit `case` matching `nil` and `""` as "generate new ID"
- Base `Agent.new/1`: replaced `Map.put_new_lazy` with `normalize_agent_id/1` helper using the same logic
- Added 6 tests covering unique generation, `id: nil`, and `id: ""` for both paths

## Notes

- The `AgentServer.Options` path already handled this correctly (lines 134-140)
- The `id` field remains **optional** in the schema — no breaking change to struct literals

Addresses #131