### PR TITLE
fix: send jido.agent.stop in StopChild runtime path

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -1095,12 +1095,19 @@ defmodule Jido.AgentServer do
         {:ok, actions}
 
       {:error, %{details: %{reason: :no_handlers_found}}} ->
-        {:error, :no_matching_route}
+        default_system_action(signal)
 
       {:error, reason} ->
         {:error, reason}
     end
   end
+
+  defp default_system_action(%Signal{type: "jido.agent.stop", data: data}) do
+    params = if is_map(data), do: data, else: %{}
+    {:ok, [{Jido.Actions.Lifecycle.StopSelf, params}]}
+  end
+
+  defp default_system_action(_signal), do: {:error, :no_matching_route}
 
   defp target_to_action({:strategy_cmd, cmd}, %Signal{data: data}) do
     {cmd, data}

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -332,6 +332,16 @@ defmodule JidoTest.AgentServerTest do
 
       GenServer.stop(pid)
     end
+
+    test "jido.agent.stop gracefully stops even without explicit routes", %{jido: jido} do
+      {:ok, pid} = AgentServer.start(agent: TestAgent, jido: jido)
+      ref = Process.monitor(pid)
+
+      signal = Signal.new!("jido.agent.stop", %{reason: :shutdown}, source: "/test")
+      assert :ok = AgentServer.cast(pid, signal)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}, 1_000
+    end
   end
 
   describe "drain loop" do


### PR DESCRIPTION
## Summary
- update `StopChild` directive execution to cast `jido.agent.stop` to the child process instead of calling `GenServer.stop/3` directly
- preserve trace correlation on the forwarded stop signal
- add runtime fallback routing so `jido.agent.stop` gracefully stops agents even when no explicit route is defined
- add regression tests proving the stop signal is emitted and that default stop behavior remains intact

## Verification
- `mix test test/jido/agent_server/directive_exec_test.exs test/jido/agent_server/agent_server_test.exs test/jido/agent_server/hierarchy_test.exs test/examples/runtime/spawn_agent_test.exs`
- `mix test`
- `mix test --cover`
- `mix quality`

Closes #135
