### PR TITLE
feat(observe): include directive struct in agent_server directive telemetry metadata

### DIFF
--- a/guides/observability.md
+++ b/guides/observability.md
@@ -64,9 +64,9 @@ Jido emits telemetry events for all core operations. Use these for metrics colle
 | `[:jido, :agent_server, :signal, :start]` | Signal processing started | `system_time` | `agent_id`, `signal_type`, `jido_instance` |
 | `[:jido, :agent_server, :signal, :stop]` | Signal processing completed | `duration` | `agent_id`, `signal_type`, `directive_count`, `jido_instance` |
 | `[:jido, :agent_server, :signal, :exception]` | Signal processing failed | `duration` | `agent_id`, `signal_type`, `error`, `jido_instance` |
-| `[:jido, :agent_server, :directive, :start]` | Directive execution started | `system_time` | `agent_id`, `directive_type`, `jido_instance` |
-| `[:jido, :agent_server, :directive, :stop]` | Directive execution completed | `duration` | `agent_id`, `directive_type`, `result`, `jido_instance` |
-| `[:jido, :agent_server, :directive, :exception]` | Directive execution failed | `duration` | `agent_id`, `directive_type`, `error`, `jido_instance` |
+| `[:jido, :agent_server, :directive, :start]` | Directive execution started | `system_time` | `agent_id`, `directive_type`, `directive`, `jido_instance` |
+| `[:jido, :agent_server, :directive, :stop]` | Directive execution completed | `duration` | `agent_id`, `directive_type`, `directive`, `result`, `jido_instance` |
+| `[:jido, :agent_server, :directive, :exception]` | Directive execution failed | `duration` | `agent_id`, `directive_type`, `directive`, `error`, `jido_instance` |
 | `[:jido, :agent_server, :queue, :overflow]` | Directive queue overflow | `queue_size` | `agent_id`, `signal_type`, `jido_instance` |
 
 ### Strategy Events

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -1796,6 +1796,7 @@ defmodule Jido.AgentServer do
         agent_id: state.id,
         agent_module: state.agent_module,
         directive_type: directive_type,
+        directive: directive,
         signal_type: signal.type,
         jido_instance: state.jido
       }

--- a/test/jido/agent_server/telemetry_test.exs
+++ b/test/jido/agent_server/telemetry_test.exs
@@ -134,12 +134,14 @@ defmodule JidoTest.AgentServer.TelemetryTest do
       assert is_integer(measurements.system_time)
       assert metadata.agent_id == "telemetry-directive-test"
       assert metadata.directive_type == "Emit"
+      assert match?(%Directive.Emit{}, metadata.directive)
 
       assert_receive {:telemetry_event, [:jido, :agent_server, :directive, :stop], measurements,
                       metadata}
 
       assert is_integer(measurements.duration)
       assert metadata.result == :async
+      assert match?(%Directive.Emit{}, metadata.directive)
 
       GenServer.stop(pid)
     end
@@ -160,10 +162,12 @@ defmodule JidoTest.AgentServer.TelemetryTest do
       assert_receive {:telemetry_event, [:jido, :agent_server, :directive, :start], _, metadata}
 
       assert metadata.directive_type == "Schedule"
+      assert match?(%Directive.Schedule{}, metadata.directive)
 
       assert_receive {:telemetry_event, [:jido, :agent_server, :directive, :stop], _, metadata}
 
       assert metadata.result == :ok
+      assert match?(%Directive.Schedule{}, metadata.directive)
 
       GenServer.stop(pid)
     end


### PR DESCRIPTION
## Summary
- add raw directive structs to AgentServer directive telemetry metadata
- assert the new metadata contract in directive telemetry tests
- update observability docs for directive event metadata

## Changes
- `lib/jido/agent_server.ex`
  - add `metadata.directive` in `exec_directive_with_telemetry/3`
  - applies to `[:jido, :agent_server, :directive, :start|:stop|:exception]`
- `test/jido/agent_server/telemetry_test.exs`
  - assert `%Jido.Agent.Directive.Emit{}` payload for emit directive events
  - assert `%Jido.Agent.Directive.Schedule{}` payload for schedule directive events
- `guides/observability.md`
  - include `directive` metadata key in directive event reference table

## Validation
- `mix test test/jido/agent_server/telemetry_test.exs`
- `mix quality`

Closes #134
