### PR TITLE
feat(observe): add event contracts and lifecycle guidance without core otel deps

### DIFF
--- a/guides/observability.md
+++ b/guides/observability.md
@@ -325,77 +325,26 @@ Call `MyApp.JidoTelemetryHandler.attach()` in your application startup.
 
 ## OpenTelemetry Integration
 
-Implement the `Jido.Observe.Tracer` behaviour to integrate with OpenTelemetry:
+Core `jido` intentionally stays free of direct OpenTelemetry dependencies.
+Use a separate package (for example, `jido_otel`) to provide a concrete tracer
+implementation, then configure Jido to use that module.
+
+### Quick Start (External `jido_otel` Package)
 
 ```elixir
 # mix.exs
 defp deps do
   [
-    {:opentelemetry, "~> 1.4"},
-    {:opentelemetry_api, "~> 1.3"},
+    {:jido_otel, "~> 0.1"},
     {:opentelemetry_exporter, "~> 1.7"}
   ]
 end
 ```
 
 ```elixir
-defmodule MyApp.OtelTracer do
-  @behaviour Jido.Observe.Tracer
-
-  require OpenTelemetry.Tracer, as: Tracer
-
-  @impl true
-  def span_start(event_prefix, metadata) do
-    span_name = Enum.join(event_prefix, ".")
-
-    attributes =
-      metadata
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-      |> Enum.map(fn {k, v} -> {k, to_string(v)} end)
-
-    Tracer.start_span(span_name, %{attributes: attributes})
-  end
-
-  @impl true
-  def span_stop(span_ctx, measurements) do
-    if span_ctx do
-      duration_ms =
-        case measurements[:duration] do
-          nil -> 0
-          d -> System.convert_time_unit(d, :native, :millisecond)
-        end
-
-      Tracer.set_attribute(:duration_ms, duration_ms)
-
-      if directive_count = measurements[:directive_count] do
-        Tracer.set_attribute(:directive_count, directive_count)
-      end
-
-      Tracer.end_span(span_ctx)
-    end
-
-    :ok
-  end
-
-  @impl true
-  def span_exception(span_ctx, kind, reason, stacktrace) do
-    if span_ctx do
-      Tracer.set_status(:error, inspect(reason))
-      Tracer.record_exception(reason, stacktrace, %{kind: kind})
-      Tracer.end_span(span_ctx)
-    end
-
-    :ok
-  end
-end
-```
-
-Configure Jido to use your tracer:
-
-```elixir
 # config/prod.exs
 config :jido, :observability,
-  tracer: MyApp.OtelTracer,
+  tracer: JidoOtel.Tracer,
   log_level: :info,
   redact_sensitive: true
 
@@ -407,6 +356,33 @@ config :opentelemetry,
 config :opentelemetry_exporter,
   otlp_protocol: :grpc,
   otlp_endpoint: System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+```
+
+### Custom Tracer Extensions
+
+For custom backend behavior, you can still implement `Jido.Observe.Tracer` directly:
+
+```elixir
+defmodule MyApp.CustomTracer do
+  @behaviour Jido.Observe.Tracer
+
+  @impl true
+  def span_start(event_prefix, metadata) do
+    # Start external span and return tracer context.
+  end
+
+  @impl true
+  def span_stop(tracer_ctx, measurements) do
+    # Complete external span.
+    :ok
+  end
+
+  @impl true
+  def span_exception(tracer_ctx, kind, reason, stacktrace) do
+    # Record exception in external tracer.
+    :ok
+  end
+end
 ```
 
 ## Correlation IDs and Distributed Tracing
@@ -463,42 +439,96 @@ def handle_event([:jido, :agent_server, :signal, :stop], _measurements, metadata
 end
 ```
 
-## Using Jido.Observe for Custom Spans
+## Custom Namespace Events and Spans
 
-Wrap custom operations with `Jido.Observe.with_span/3`:
+### Non-Gated Domain Events (`emit_event/3`)
+
+Use `Jido.Observe.emit_event/3` for production domain lifecycle events that must
+always emit telemetry regardless of `:debug_events` config.
+
+`Jido.Observe.EventContract` provides lightweight key validation helpers so
+downstream namespaces keep stable metadata/measurement contracts.
 
 ```elixir
-defmodule MyApp.CustomAction do
-  use Jido.Action,
-    name: "custom_action",
-    schema: [query: [type: :string, required: true]]
+alias Jido.Observe
+alias Jido.Observe.EventContract
 
-  def run(%{query: query}, context) do
-    Jido.Observe.with_span([:my_app, :external, :search], %{query: query}, fn ->
-      result = ExternalService.search(query)
-      {:ok, %{results: result}}
-    end)
-  end
+with {:ok, validated} <-
+       EventContract.validate_event(
+         [:jido, :ai, :request, :completed],
+         %{duration_ms: 42},
+         %{request_id: "req-1", terminal_state: :completed, model: "gpt-4.1"},
+         required_metadata: [:request_id, :terminal_state],
+         required_measurements: [:duration_ms]
+       ) do
+  Observe.emit_event(validated.event, validated.measurements, validated.metadata)
 end
 ```
 
-For async operations, use `start_span/2` and `finish_span/2`:
+### Async Request Lifecycle Pattern
+
+For long-lived request workflows, use a request-root span plus async child spans.
+Propagate correlation metadata across async boundaries, then emit terminal
+domain events (`completed`, `failed`, `cancelled`, `rejected`).
 
 ```elixir
-span_ctx = Jido.Observe.start_span([:my_app, :async, :fetch], %{url: url})
+alias Jido.Observe
+alias Jido.Observe.EventContract
+alias Jido.Tracing.Context, as: TraceContext
 
-Task.async(fn ->
-  try do
-    result = HTTPClient.get(url)
-    Jido.Observe.finish_span(span_ctx, %{response_size: byte_size(result)})
-    result
-  rescue
-    e ->
-      Jido.Observe.finish_span_error(span_ctx, :error, e, __STACKTRACE__)
-      reraise e, __STACKTRACE__
-  end
-end)
+# Root request span
+request_span = Observe.start_span([:jido, :ai, :request], %{request_id: request_id})
+trace_metadata = TraceContext.to_telemetry_metadata()
+
+# Async tool span
+task =
+  Task.async(fn ->
+    child_metadata = Map.merge(trace_metadata, %{request_id: request_id, tool: "search"})
+    tool_span = Observe.start_span([:jido, :ai, :request, :tool], child_metadata)
+    result = ExternalSearch.run(query)
+    Observe.finish_span(tool_span, %{result_count: length(result.items)})
+  end)
+
+Task.await(task)
+
+# Terminal lifecycle event
+{:ok, validated} =
+  EventContract.validate_event(
+    [:jido, :ai, :request, :completed],
+    %{duration_ms: 125},
+    %{request_id: request_id, terminal_state: :completed},
+    required_metadata: [:request_id, :terminal_state],
+    required_measurements: [:duration_ms]
+  )
+
+Observe.emit_event(
+  validated.event,
+  validated.measurements,
+  Map.merge(validated.metadata, trace_metadata)
+)
+
+Observe.finish_span(request_span, %{directive_count: 1})
 ```
+
+### Recommended Event Taxonomy
+
+| Event | Purpose | Required Metadata | Required Measurements |
+|-------|---------|-------------------|-----------------------|
+| `[:jido, :ai, :request, :start]` | Request lifecycle start | `request_id` | — |
+| `[:jido, :ai, :request, :tool, :start]` | Async tool lifecycle start | `request_id`, `tool` | — |
+| `[:jido, :ai, :request, :tool, :stop]` | Async tool lifecycle stop | `request_id`, `tool` | `duration` or `duration_ms` |
+| `[:jido, :ai, :request, :completed]` | Request completed | `request_id`, `terminal_state` | `duration_ms` |
+| `[:jido, :ai, :request, :failed]` | Request failed | `request_id`, `terminal_state` | `duration_ms` |
+| `[:jido, :ai, :request, :cancelled]` | Request cancelled | `request_id`, `terminal_state` | `duration_ms` |
+| `[:jido, :ai, :request, :rejected]` | Request rejected | `request_id`, `terminal_state` | `duration_ms` |
+
+### Recommended Contract Keys and Metric Tags
+
+| Category | Keys | Notes |
+|----------|------|-------|
+| Metadata | `request_id`, `terminal_state`, `tool`, `model` | Use IDs and categorical values, avoid payloads. |
+| Measurements | `duration_ms`, `token_count`, `result_count`, `cost_usd` | Numeric measurements only. |
+| Metric Tags | `jido_instance`, `terminal_state`, `tool`, `model` | Keep tag cardinality bounded. |
 
 ## Dashboard Metrics Recommendations
 
@@ -625,6 +655,7 @@ Debug events are no-ops when `:debug_events` is `:off` (production default).
 ## Key Modules
 
 - `Jido.Observe` — Unified observability façade with span helpers
+- `Jido.Observe.EventContract` — Lightweight required-key validation for custom event contracts
 - `Jido.Observe.Config` — Per-instance config resolution (debug override → instance → global → default)
 - `Jido.Debug` — Per-instance runtime debug mode
 - `Jido.Telemetry` — Built-in telemetry handler and metrics definitions

--- a/lib/jido/observe/event_contract.ex
+++ b/lib/jido/observe/event_contract.ex
@@ -1,0 +1,98 @@
+defmodule Jido.Observe.EventContract do
+  @moduledoc """
+  Minimal helpers for validating custom telemetry event contracts.
+
+  Downstream packages can use this module to enforce stable required keys for
+  metadata and measurements before emitting namespaced events.
+  """
+
+  @type event_prefix :: [atom()]
+  @type key :: atom() | String.t()
+  @type required_keys :: [key()]
+
+  @type metadata_error :: {:missing_metadata_keys, required_keys()}
+  @type measurements_error :: {:missing_measurement_keys, required_keys()}
+
+  @type event_error ::
+          {:invalid_event_contract,
+           %{
+             event: event_prefix(),
+             missing_metadata_keys: required_keys(),
+             missing_measurement_keys: required_keys()
+           }}
+
+  @doc """
+  Validates that metadata contains all required keys.
+  """
+  @spec validate_metadata(map(), required_keys()) :: {:ok, map()} | {:error, metadata_error()}
+  def validate_metadata(metadata, required_keys)
+      when is_map(metadata) and is_list(required_keys) do
+    missing_keys = missing_required_keys(metadata, required_keys)
+
+    case missing_keys do
+      [] -> {:ok, metadata}
+      _ -> {:error, {:missing_metadata_keys, missing_keys}}
+    end
+  end
+
+  @doc """
+  Validates that measurements contain all required keys.
+  """
+  @spec validate_measurements(map(), required_keys()) ::
+          {:ok, map()} | {:error, measurements_error()}
+  def validate_measurements(measurements, required_keys)
+      when is_map(measurements) and is_list(required_keys) do
+    missing_keys = missing_required_keys(measurements, required_keys)
+
+    case missing_keys do
+      [] -> {:ok, measurements}
+      _ -> {:error, {:missing_measurement_keys, missing_keys}}
+    end
+  end
+
+  @doc """
+  Validates event metadata and measurements against required keys.
+
+  ## Options
+
+  - `:required_metadata` - Required metadata keys.
+  - `:required_measurements` - Required measurement keys.
+  """
+  @spec validate_event(event_prefix(), map(), map(), keyword()) ::
+          {:ok, %{event: event_prefix(), measurements: map(), metadata: map()}}
+          | {:error, event_error()}
+  def validate_event(event_prefix, measurements, metadata, opts \\ [])
+
+  def validate_event(event_prefix, measurements, metadata, opts)
+      when is_list(event_prefix) and is_map(measurements) and is_map(metadata) and is_list(opts) do
+    required_metadata = Keyword.get(opts, :required_metadata, [])
+    required_measurements = Keyword.get(opts, :required_measurements, [])
+
+    missing_metadata = missing_required_keys(metadata, required_metadata)
+    missing_measurements = missing_required_keys(measurements, required_measurements)
+
+    if missing_metadata == [] and missing_measurements == [] do
+      {:ok, %{event: event_prefix, measurements: measurements, metadata: metadata}}
+    else
+      {:error,
+       {:invalid_event_contract,
+        %{
+          event: event_prefix,
+          missing_metadata_keys: missing_metadata,
+          missing_measurement_keys: missing_measurements
+        }}}
+    end
+  end
+
+  defp missing_required_keys(map, required_keys) do
+    required_keys
+    |> Enum.uniq()
+    |> Enum.reject(&key_present?(map, &1))
+  end
+
+  defp key_present?(map, key) when is_atom(key) do
+    Map.has_key?(map, key) or Map.has_key?(map, Atom.to_string(key))
+  end
+
+  defp key_present?(map, key), do: Map.has_key?(map, key)
+end

--- a/test/examples/observability/domain_event_observability_test.exs
+++ b/test/examples/observability/domain_event_observability_test.exs
@@ -1,0 +1,161 @@
+defmodule JidoExampleTest.DomainEventObservabilityTest do
+  @moduledoc """
+  Example test for custom namespace observability patterns.
+
+  Demonstrates:
+  - Custom domain events via `Jido.Observe.emit_event/3`
+  - Contract validation via `Jido.Observe.EventContract`
+  - Correlated request root + async child spans
+  - Terminal lifecycle states (`completed/failed/cancelled/rejected`)
+  """
+  use JidoTest.Case, async: false
+
+  @moduletag :example
+
+  alias Jido.Observe
+  alias Jido.Observe.EventContract
+  alias Jido.Signal
+  alias Jido.Tracing.Context, as: TraceContext
+
+  setup do
+    TraceContext.clear()
+    :ok
+  end
+
+  test "validates and emits custom namespace domain event" do
+    events = [[:jido, :ai, :request, :completed]]
+    handler_id = attach_handler(self(), events)
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, validated} =
+             EventContract.validate_event(
+               [:jido, :ai, :request, :completed],
+               %{duration_ms: 42},
+               %{request_id: "req-1", terminal_state: :completed, model: "gpt-4.1"},
+               required_metadata: [:request_id, :terminal_state],
+               required_measurements: [:duration_ms]
+             )
+
+    assert :ok =
+             Observe.emit_event(validated.event, validated.measurements, validated.metadata)
+
+    assert_receive {:telemetry_event, [:jido, :ai, :request, :completed], %{duration_ms: 42},
+                    metadata}
+
+    assert metadata.request_id == "req-1"
+    assert metadata.terminal_state == :completed
+    assert metadata.model == "gpt-4.1"
+  end
+
+  test "correlates request root and async child spans with terminal lifecycle events" do
+    events = [
+      [:jido, :ai, :request, :start],
+      [:jido, :ai, :request, :stop],
+      [:jido, :ai, :request, :tool, :start],
+      [:jido, :ai, :request, :tool, :stop],
+      [:jido, :ai, :request, :completed],
+      [:jido, :ai, :request, :failed],
+      [:jido, :ai, :request, :cancelled],
+      [:jido, :ai, :request, :rejected]
+    ]
+
+    handler_id = attach_handler(self(), events)
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    signal = Signal.new!("jido.ai.request", %{}, source: "/example")
+    {_traced_signal, trace} = TraceContext.ensure_from_signal(signal)
+    trace_metadata = TraceContext.to_telemetry_metadata()
+    request_id = "req-42"
+
+    root_span = Observe.start_span([:jido, :ai, :request], %{request_id: request_id})
+
+    task =
+      Task.async(fn ->
+        child_metadata =
+          trace_metadata
+          |> Map.merge(%{request_id: request_id, tool: "search"})
+
+        child_span = Observe.start_span([:jido, :ai, :request, :tool], child_metadata)
+        Process.sleep(5)
+        Observe.finish_span(child_span, %{result_count: 3})
+      end)
+
+    assert :ok = Task.await(task)
+
+    for terminal_state <- [:completed, :failed, :cancelled, :rejected] do
+      assert {:ok, validated} =
+               EventContract.validate_event(
+                 [:jido, :ai, :request, terminal_state],
+                 %{duration_ms: 25},
+                 %{request_id: request_id, terminal_state: terminal_state},
+                 required_metadata: [:request_id, :terminal_state],
+                 required_measurements: [:duration_ms]
+               )
+
+      assert :ok =
+               Observe.emit_event(
+                 validated.event,
+                 validated.measurements,
+                 Map.merge(validated.metadata, trace_metadata)
+               )
+    end
+
+    Observe.finish_span(root_span, %{directive_count: 1})
+    TraceContext.clear()
+
+    received = collect_events(8)
+    assert length(received) == 8
+
+    assert Enum.any?(received, fn {event, _measurements, metadata} ->
+             event == [:jido, :ai, :request, :start] and metadata.request_id == request_id and
+               metadata.jido_trace_id == trace.trace_id
+           end)
+
+    assert Enum.any?(received, fn {event, _measurements, metadata} ->
+             event == [:jido, :ai, :request, :tool, :start] and metadata.request_id == request_id and
+               metadata.jido_trace_id == trace.trace_id
+           end)
+
+    assert Enum.any?(received, fn {event, _measurements, metadata} ->
+             event == [:jido, :ai, :request, :stop] and metadata.request_id == request_id and
+               metadata.jido_trace_id == trace.trace_id
+           end)
+
+    for terminal_state <- [:completed, :failed, :cancelled, :rejected] do
+      assert Enum.any?(received, fn {event, measurements, metadata} ->
+               event == [:jido, :ai, :request, terminal_state] and measurements.duration_ms == 25 and
+                 metadata.request_id == request_id and
+                 metadata.terminal_state == terminal_state and
+                 metadata.jido_trace_id == trace.trace_id
+             end)
+    end
+  end
+
+  defp attach_handler(test_pid, events) do
+    handler_id = "domain-observability-handler-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, _ ->
+          send(test_pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    handler_id
+  end
+
+  defp collect_events(count) do
+    Enum.map(1..count, fn _index ->
+      receive do
+        {:telemetry_event, event, measurements, metadata} ->
+          {event, measurements, metadata}
+      after
+        1_500 ->
+          flunk("Timed out collecting telemetry events")
+      end
+    end)
+  end
+end

--- a/test/jido/observe/event_contract_test.exs
+++ b/test/jido/observe/event_contract_test.exs
@@ -1,0 +1,80 @@
+defmodule JidoTest.Observe.EventContractTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Observe.EventContract
+
+  describe "validate_metadata/2" do
+    test "returns ok when all required keys exist" do
+      metadata = %{request_id: "req-1", state: :completed}
+
+      assert {:ok, ^metadata} =
+               EventContract.validate_metadata(metadata, [:request_id, :state])
+    end
+
+    test "returns missing metadata keys in deterministic order" do
+      metadata = %{request_id: "req-1"}
+
+      assert {:error, {:missing_metadata_keys, [:state, :model]}} =
+               EventContract.validate_metadata(metadata, [:request_id, :state, :model])
+    end
+
+    test "treats atom required keys as present when metadata uses string keys" do
+      metadata = %{"request_id" => "req-1", "state" => "completed"}
+
+      assert {:ok, ^metadata} =
+               EventContract.validate_metadata(metadata, [:request_id, :state])
+    end
+  end
+
+  describe "validate_measurements/2" do
+    test "returns ok when all required keys exist" do
+      measurements = %{duration_ms: 12, token_count: 40}
+
+      assert {:ok, ^measurements} =
+               EventContract.validate_measurements(measurements, [:duration_ms, :token_count])
+    end
+
+    test "returns missing measurement keys in deterministic order" do
+      measurements = %{duration_ms: 12}
+
+      assert {:error, {:missing_measurement_keys, [:token_count, :attempt]}} =
+               EventContract.validate_measurements(measurements, [
+                 :duration_ms,
+                 :token_count,
+                 :attempt
+               ])
+    end
+  end
+
+  describe "validate_event/4" do
+    test "returns normalized event payload when contract is valid" do
+      event = [:jido, :ai, :request, :completed]
+      measurements = %{duration_ms: 45}
+      metadata = %{request_id: "req-1", terminal_state: :completed}
+
+      assert {:ok, %{event: ^event, measurements: ^measurements, metadata: ^metadata}} =
+               EventContract.validate_event(event, measurements, metadata,
+                 required_metadata: [:request_id, :terminal_state],
+                 required_measurements: [:duration_ms]
+               )
+    end
+
+    test "returns combined missing keys for invalid contracts" do
+      event = [:jido, :ai, :request, :failed]
+      measurements = %{}
+      metadata = %{request_id: "req-1"}
+
+      assert {:error,
+              {:invalid_event_contract,
+               %{
+                 event: ^event,
+                 missing_metadata_keys: [:terminal_state],
+                 missing_measurement_keys: [:duration_ms]
+               }}} =
+               EventContract.validate_event(event, measurements, metadata,
+                 required_metadata: [:request_id, :terminal_state],
+                 required_measurements: [:duration_ms]
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- remove the direct-OpenTelemetry-in-core direction
- add minimal contract helpers for custom telemetry namespaces via `Jido.Observe.EventContract`
- expand observability docs around non-gated domain events (`emit_event/3`) and async lifecycle patterns
- add executable examples/tests for lifecycle event taxonomy and contract validation

## Important Design Constraint
This PR intentionally keeps **core `jido` free of direct OpenTelemetry dependencies**.
OpenTelemetry tracer implementation is expected to live in a separate package (for example, `jido_otel`).

## Changes
- `lib/jido/observe/event_contract.ex`
  - `validate_metadata/2`
  - `validate_measurements/2`
  - `validate_event/4`
  - deterministic missing-key error payloads
- `test/jido/observe/event_contract_test.exs`
  - contract validation behavior coverage
- `test/jido/observe/observe_test.exs`
  - primary-suite `emit_event/3` coverage for non-gated emission and correlation merge behavior
- `test/examples/observability/domain_event_observability_test.exs`
  - end-to-end custom namespace lifecycle example (`completed/failed/cancelled/rejected`)
- `guides/observability.md`
  - documents external OTel package path (`jido_otel`) instead of core tracer
  - formalizes `emit_event/3` + `EventContract` as domain event path
  - adds request-root/async-child lifecycle tracing and contract tables

## Validation
- `mix test test/jido/observe/event_contract_test.exs`
- `mix test test/jido/observe/observe_test.exs`
- `mix test --include example test/examples/observability/*`
- `mix quality`

Refs #140
