### PR TITLE
feat(agent_server): prevent synchronous signal-call blocking

### DIFF
--- a/lib/jido/agent_server/state.ex
+++ b/lib/jido/agent_server/state.ex
@@ -32,6 +32,15 @@ defmodule Jido.AgentServer.State do
               queue:
                 Zoi.any(description: "Directive queue (:queue.queue())")
                 |> Zoi.default(:queue.new()),
+              signal_call_inflight:
+                Zoi.any(description: "In-flight synchronous signal call context")
+                |> Zoi.optional(),
+              signal_call_queue:
+                Zoi.any(description: "Queued synchronous signal call requests")
+                |> Zoi.default(:queue.new()),
+              deferred_async_signals:
+                Zoi.any(description: "Async signals buffered while sync call is in-flight")
+                |> Zoi.default(:queue.new()),
 
               # Hierarchy
               parent: Zoi.any(description: "Parent reference") |> Zoi.optional(),
@@ -119,6 +128,9 @@ defmodule Jido.AgentServer.State do
         status: :initializing,
         processing: false,
         queue: :queue.new(),
+        signal_call_inflight: nil,
+        signal_call_queue: :queue.new(),
+        deferred_async_signals: :queue.new(),
         parent: opts.parent,
         children: %{},
         on_parent_death: opts.on_parent_death,


### PR DESCRIPTION
## Summary
- rework `AgentServer.call/3` signal handling to run signal computation asynchronously
- queue synchronous calls and process one at a time to avoid blocking the GenServer message loop
- buffer async signal messages while a sync call is in-flight to prevent state clobbering
- add regression coverage for non-blocking state access and buffered async signal handling

## Changes
- `lib/jido/agent_server/state.ex`
  - add internal fields for sync call orchestration:
    - `signal_call_inflight`
    - `signal_call_queue`
    - `deferred_async_signals`
- `lib/jido/agent_server.ex`
  - `handle_call({:signal, ...})` now enqueues and schedules async signal-call processing
  - add async call task lifecycle (`start_signal_call_task/3`, `apply_signal_call_result/3`)
  - buffer cast/info signal messages while sync call is running and process afterward
  - preserve telemetry + transform hooks on sync call completion
- `test/jido/agent_server/agent_server_test.exs`
  - add test proving `AgentServer.state/1` remains responsive during slow sync call
  - add test proving async signals are buffered and applied after sync call completion

## Validation
- `mix test test/jido/agent_server/agent_server_test.exs`
- `mix quality`

Closes #146
