### PR TITLE
chore(config): centralize timeout defaults and observability validation

### DIFF
--- a/guides/observability.md
+++ b/guides/observability.md
@@ -42,6 +42,7 @@ config :my_app, MyApp.InternalJido,
 ```
 
 Settings resolve in this order: Debug override → instance config → global config → default.
+Invalid values are ignored and fall back to Jido defaults.
 
 The `:redact_sensitive` option replaces sensitive data with `[REDACTED]` in logs and telemetry.
 

--- a/lib/jido.ex
+++ b/lib/jido.ex
@@ -2,6 +2,7 @@ defmodule Jido do
   use Supervisor
 
   alias Jido.Agent.WorkerPool
+  alias Jido.Config.Defaults
 
   @moduledoc """
   自動 (Jido) - A foundational framework for building autonomous, distributed agent systems in Elixir.
@@ -330,7 +331,7 @@ defmodule Jido do
       start: {__MODULE__, :start_link, [opts]},
       type: :supervisor,
       restart: :permanent,
-      shutdown: 10_000
+      shutdown: Defaults.jido_shutdown_timeout_ms()
     }
   end
 
@@ -525,7 +526,7 @@ defmodule Jido do
 
   See `Jido.Await.completion/3` for details.
   """
-  defdelegate await(server, timeout_ms \\ 10_000, opts \\ []),
+  defdelegate await(server, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ []),
     to: Jido.Await,
     as: :completion
 
@@ -534,16 +535,21 @@ defmodule Jido do
 
   See `Jido.Await.child/4` for details.
   """
-  defdelegate await_child(server, child_tag, timeout_ms \\ 30_000, opts \\ []),
-    to: Jido.Await,
-    as: :child
+  defdelegate await_child(
+                server,
+                child_tag,
+                timeout_ms \\ Defaults.await_child_timeout_ms(),
+                opts \\ []
+              ),
+              to: Jido.Await,
+              as: :child
 
   @doc """
   Wait for all agents to reach terminal status.
 
   See `Jido.Await.all/3` for details.
   """
-  defdelegate await_all(servers, timeout_ms \\ 10_000, opts \\ []),
+  defdelegate await_all(servers, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ []),
     to: Jido.Await,
     as: :all
 
@@ -552,7 +558,7 @@ defmodule Jido do
 
   See `Jido.Await.any/3` for details.
   """
-  defdelegate await_any(servers, timeout_ms \\ 10_000, opts \\ []),
+  defdelegate await_any(servers, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ []),
     to: Jido.Await,
     as: :any
 

--- a/lib/jido/agent/instance_manager.ex
+++ b/lib/jido/agent/instance_manager.ex
@@ -74,6 +74,7 @@ defmodule Jido.Agent.InstanceManager do
   require Logger
 
   alias Jido.Agent.Persistence
+  alias Jido.Config.Defaults
 
   @type manager_name :: atom()
   @type key :: term()
@@ -223,7 +224,7 @@ defmodule Jido.Agent.InstanceManager do
         # Use GenServer.stop for graceful shutdown (triggers terminate/2 with :shutdown)
         # This ensures hibernate happens before the process exits
         try do
-          GenServer.stop(pid, :shutdown, 5_000)
+          GenServer.stop(pid, :shutdown, Defaults.instance_manager_stop_timeout_ms())
           :ok
         catch
           :exit, _ -> :ok

--- a/lib/jido/agent/worker_pool.ex
+++ b/lib/jido/agent/worker_pool.ex
@@ -59,6 +59,8 @@ defmodule Jido.Agent.WorkerPool do
       end
   """
 
+  alias Jido.Config.Defaults
+
   @type instance :: atom()
   @type pool_name :: atom()
 
@@ -85,7 +87,7 @@ defmodule Jido.Agent.WorkerPool do
   @spec with_agent(instance(), pool_name(), (pid() -> result), keyword()) :: result
         when result: term()
   def with_agent(jido_instance, pool_name, fun, opts \\ []) when is_function(fun, 1) do
-    timeout = Keyword.get(opts, :timeout, 5_000)
+    timeout = Keyword.get(opts, :timeout, Defaults.worker_pool_checkout_timeout_ms())
     pool = Jido.agent_pool_name(jido_instance, pool_name)
 
     :poolboy.transaction(
@@ -114,7 +116,7 @@ defmodule Jido.Agent.WorkerPool do
   """
   @spec call(instance(), pool_name(), term(), keyword()) :: term()
   def call(jido_instance, pool_name, signal, opts \\ []) do
-    call_timeout = Keyword.get(opts, :call_timeout, 5_000)
+    call_timeout = Keyword.get(opts, :call_timeout, Defaults.worker_pool_call_timeout_ms())
 
     with_agent(
       jido_instance,
@@ -172,7 +174,7 @@ defmodule Jido.Agent.WorkerPool do
   """
   @spec checkout(instance(), pool_name(), keyword()) :: pid()
   def checkout(jido_instance, pool_name, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, 5_000)
+    timeout = Keyword.get(opts, :timeout, Defaults.worker_pool_checkout_timeout_ms())
     block = Keyword.get(opts, :block, true)
     pool = Jido.agent_pool_name(jido_instance, pool_name)
     :poolboy.checkout(pool, block, timeout)

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -168,6 +168,7 @@ defmodule Jido.AgentServer do
 
   alias Jido.Agent.Directive
   alias Jido.AgentServer.Signal.{ChildExit, ChildStarted, Orphaned}
+  alias Jido.Config.Defaults
   alias Jido.Sensor.Runtime, as: SensorRuntime
   alias Jido.Signal
   alias Jido.Signal.Router, as: JidoRouter
@@ -248,7 +249,7 @@ defmodule Jido.AgentServer do
     %{
       id: id,
       start: {__MODULE__, :start_link, [opts]},
-      shutdown: 5_000,
+      shutdown: Defaults.agent_server_shutdown_timeout_ms(),
       restart: :permanent,
       type: :worker
     }
@@ -273,7 +274,7 @@ defmodule Jido.AgentServer do
       {:ok, agent} = Jido.AgentServer.call("agent-id", signal, 10_000)
   """
   @spec call(server(), Signal.t(), timeout()) :: {:ok, struct()} | {:error, term()}
-  def call(server, %Signal{} = signal, timeout \\ 5_000) do
+  def call(server, %Signal{} = signal, timeout \\ Defaults.agent_server_call_timeout_ms()) do
     with {:ok, pid} <- resolve_server(server) do
       GenServer.call(pid, {:signal, signal}, timeout)
     end
@@ -348,7 +349,7 @@ defmodule Jido.AgentServer do
   """
   @spec await_completion(server(), keyword()) :: {:ok, map()} | {:error, term()}
   def await_completion(server, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, 10_000)
+    timeout = Keyword.get(opts, :timeout, Defaults.agent_server_await_timeout_ms())
 
     with {:ok, pid} <- resolve_server(server) do
       try do

--- a/lib/jido/await.ex
+++ b/lib/jido/await.ex
@@ -34,6 +34,7 @@ defmodule Jido.Await do
   """
 
   alias Jido.AgentServer
+  alias Jido.Config.Defaults
 
   @type server :: AgentServer.server()
   @type status :: :completed | :failed | atom()
@@ -75,7 +76,7 @@ defmodule Jido.Await do
   """
   @spec completion(server(), non_neg_integer(), Keyword.t()) ::
           {:ok, completion()} | {:error, term()}
-  def completion(server, timeout_ms \\ 10_000, opts \\ []) do
+  def completion(server, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ []) do
     opts = Keyword.put(opts, :timeout, timeout_ms)
 
     try do
@@ -113,7 +114,7 @@ defmodule Jido.Await do
   """
   @spec child(server(), term(), non_neg_integer(), Keyword.t()) ::
           {:ok, completion()} | {:error, term()}
-  def child(parent_server, child_tag, timeout_ms \\ 10_000, opts \\ []) do
+  def child(parent_server, child_tag, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ []) do
     deadline = now_ms() + timeout_ms
 
     with {:ok, child_pid} <- poll_for_child(parent_server, child_tag, deadline, 50) do
@@ -180,7 +181,7 @@ defmodule Jido.Await do
   """
   @spec all([server()], non_neg_integer(), Keyword.t()) ::
           {:ok, %{server() => completion()}} | {:error, :timeout} | {:error, {server(), term()}}
-  def all(servers, timeout_ms \\ 10_000, opts \\ [])
+  def all(servers, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ [])
   def all([], _timeout_ms, _opts), do: {:ok, %{}}
 
   def all(servers, timeout_ms, opts) do
@@ -250,7 +251,7 @@ defmodule Jido.Await do
   """
   @spec any([server()], non_neg_integer(), Keyword.t()) ::
           {:ok, {server(), completion()}} | {:error, :timeout} | {:error, {server(), term()}}
-  def any(servers, timeout_ms \\ 10_000, opts \\ [])
+  def any(servers, timeout_ms \\ Defaults.await_timeout_ms(), opts \\ [])
   def any([], _timeout_ms, _opts), do: {:error, :timeout}
 
   def any(servers, timeout_ms, opts) do

--- a/lib/jido/config/defaults.ex
+++ b/lib/jido/config/defaults.ex
@@ -1,0 +1,116 @@
+defmodule Jido.Config.Defaults do
+  @moduledoc """
+  Centralized default values for runtime behavior and observability.
+
+  Keeping defaults in one module avoids drift across API wrappers, runtime
+  modules, and configuration resolution.
+  """
+
+  @type telemetry_log_level :: :trace | :debug | :info | :warning | :error
+  @type telemetry_log_args :: :keys_only | :full | :none
+  @type debug_events_mode :: :off | :minimal | :all
+
+  @jido_shutdown_timeout_ms 10_000
+
+  @agent_server_shutdown_timeout_ms 5_000
+  @agent_server_call_timeout_ms 5_000
+  @agent_server_await_timeout_ms 10_000
+
+  @await_timeout_ms 10_000
+  @await_child_timeout_ms 30_000
+
+  @worker_pool_checkout_timeout_ms 5_000
+  @worker_pool_call_timeout_ms 5_000
+
+  @instance_manager_stop_timeout_ms 5_000
+
+  @telemetry_log_level :debug
+  @telemetry_log_args :keys_only
+  @slow_signal_threshold_ms 10
+  @slow_directive_threshold_ms 5
+  @interesting_signal_types [
+    "jido.strategy.init",
+    "jido.strategy.complete"
+  ]
+  @observe_log_level :info
+  @observe_debug_events :off
+  @redact_sensitive false
+  @tracer Jido.Observe.NoopTracer
+  @debug_max_events 500
+
+  @doc "Default shutdown timeout for the top-level Jido supervisor."
+  @spec jido_shutdown_timeout_ms() :: pos_integer()
+  def jido_shutdown_timeout_ms, do: @jido_shutdown_timeout_ms
+
+  @doc "Default shutdown timeout for AgentServer workers."
+  @spec agent_server_shutdown_timeout_ms() :: pos_integer()
+  def agent_server_shutdown_timeout_ms, do: @agent_server_shutdown_timeout_ms
+
+  @doc "Default timeout for synchronous AgentServer calls."
+  @spec agent_server_call_timeout_ms() :: pos_integer()
+  def agent_server_call_timeout_ms, do: @agent_server_call_timeout_ms
+
+  @doc "Default timeout for AgentServer.await_completion/2."
+  @spec agent_server_await_timeout_ms() :: pos_integer()
+  def agent_server_await_timeout_ms, do: @agent_server_await_timeout_ms
+
+  @doc "Default timeout for Jido.Await helpers."
+  @spec await_timeout_ms() :: pos_integer()
+  def await_timeout_ms, do: @await_timeout_ms
+
+  @doc "Default timeout for Jido.await_child/4."
+  @spec await_child_timeout_ms() :: pos_integer()
+  def await_child_timeout_ms, do: @await_child_timeout_ms
+
+  @doc "Default checkout timeout for worker pools."
+  @spec worker_pool_checkout_timeout_ms() :: pos_integer()
+  def worker_pool_checkout_timeout_ms, do: @worker_pool_checkout_timeout_ms
+
+  @doc "Default call timeout when signaling pooled agents."
+  @spec worker_pool_call_timeout_ms() :: pos_integer()
+  def worker_pool_call_timeout_ms, do: @worker_pool_call_timeout_ms
+
+  @doc "Default graceful-stop timeout for instance-managed agents."
+  @spec instance_manager_stop_timeout_ms() :: pos_integer()
+  def instance_manager_stop_timeout_ms, do: @instance_manager_stop_timeout_ms
+
+  @doc "Default telemetry log level."
+  @spec telemetry_log_level() :: telemetry_log_level()
+  def telemetry_log_level, do: @telemetry_log_level
+
+  @doc "Default telemetry argument logging mode."
+  @spec telemetry_log_args() :: telemetry_log_args()
+  def telemetry_log_args, do: @telemetry_log_args
+
+  @doc "Default slow-signal threshold in milliseconds."
+  @spec slow_signal_threshold_ms() :: non_neg_integer()
+  def slow_signal_threshold_ms, do: @slow_signal_threshold_ms
+
+  @doc "Default slow-directive threshold in milliseconds."
+  @spec slow_directive_threshold_ms() :: non_neg_integer()
+  def slow_directive_threshold_ms, do: @slow_directive_threshold_ms
+
+  @doc "Default list of interesting signal types."
+  @spec interesting_signal_types() :: [String.t()]
+  def interesting_signal_types, do: @interesting_signal_types
+
+  @doc "Default observe log level."
+  @spec observe_log_level() :: Logger.level()
+  def observe_log_level, do: @observe_log_level
+
+  @doc "Default debug-events mode."
+  @spec observe_debug_events() :: debug_events_mode()
+  def observe_debug_events, do: @observe_debug_events
+
+  @doc "Default redact-sensitive flag."
+  @spec redact_sensitive() :: boolean()
+  def redact_sensitive, do: @redact_sensitive
+
+  @doc "Default tracer module."
+  @spec tracer() :: module()
+  def tracer, do: @tracer
+
+  @doc "Default max debug-event buffer size."
+  @spec debug_max_events() :: non_neg_integer()
+  def debug_max_events, do: @debug_max_events
+end

--- a/lib/jido/observe/config.ex
+++ b/lib/jido/observe/config.ex
@@ -12,22 +12,9 @@ defmodule Jido.Observe.Config do
   When `instance` is `nil`, steps 1-2 are skipped.
   """
 
-  @type instance :: atom() | nil
+  alias Jido.Config.Defaults
 
-  # Defaults
-  @default_log_level :debug
-  @default_log_args :keys_only
-  @default_slow_signal_threshold_ms 10
-  @default_slow_directive_threshold_ms 5
-  @default_interesting_signal_types [
-    "jido.strategy.init",
-    "jido.strategy.complete"
-  ]
-  @default_observe_log_level :info
-  @default_debug_events :off
-  @default_redact_sensitive false
-  @default_tracer Jido.Observe.NoopTracer
-  @default_debug_max_events 500
+  @type instance :: atom() | nil
 
   @log_level_priority %{
     trace: 0,
@@ -37,30 +24,45 @@ defmodule Jido.Observe.Config do
     error: 4
   }
 
+  @telemetry_log_levels [:trace, :debug, :info, :warning, :error]
+  @telemetry_log_args_modes [:keys_only, :full, :none]
+  @debug_events_modes [:off, :minimal, :all]
+  @observe_log_levels Logger.levels()
+
   # --- Telemetry settings ---
 
   @doc "Returns the telemetry log level for the given instance."
   @spec telemetry_log_level(instance()) :: :trace | :debug | :info | :warning | :error
   def telemetry_log_level(instance \\ nil)
-  def telemetry_log_level(nil), do: global_telemetry(:log_level, @default_log_level)
+
+  def telemetry_log_level(nil) do
+    global_telemetry(:log_level, Defaults.telemetry_log_level())
+    |> normalize_telemetry_log_level()
+  end
 
   def telemetry_log_level(instance) do
     with nil <- Jido.Debug.override(instance, :telemetry_log_level),
          nil <- instance_telemetry(instance, :log_level) do
-      global_telemetry(:log_level, @default_log_level)
+      global_telemetry(:log_level, Defaults.telemetry_log_level())
     end
+    |> normalize_telemetry_log_level()
   end
 
   @doc "Returns the argument logging mode for the given instance."
   @spec telemetry_log_args(instance()) :: :keys_only | :full | :none
   def telemetry_log_args(instance \\ nil)
-  def telemetry_log_args(nil), do: global_telemetry(:log_args, @default_log_args)
+
+  def telemetry_log_args(nil) do
+    global_telemetry(:log_args, Defaults.telemetry_log_args())
+    |> normalize_telemetry_log_args()
+  end
 
   def telemetry_log_args(instance) do
     with nil <- Jido.Debug.override(instance, :telemetry_log_args),
          nil <- instance_telemetry(instance, :log_args) do
-      global_telemetry(:log_args, @default_log_args)
+      global_telemetry(:log_args, Defaults.telemetry_log_args())
     end
+    |> normalize_telemetry_log_args()
   end
 
   @doc "Returns the slow signal threshold in milliseconds."
@@ -68,13 +70,16 @@ defmodule Jido.Observe.Config do
   def slow_signal_threshold_ms(instance \\ nil)
 
   def slow_signal_threshold_ms(nil),
-    do: global_telemetry(:slow_signal_threshold_ms, @default_slow_signal_threshold_ms)
+    do:
+      global_telemetry(:slow_signal_threshold_ms, Defaults.slow_signal_threshold_ms())
+      |> normalize_non_neg_integer(Defaults.slow_signal_threshold_ms())
 
   def slow_signal_threshold_ms(instance) do
     with nil <- Jido.Debug.override(instance, :slow_signal_threshold_ms),
          nil <- instance_telemetry(instance, :slow_signal_threshold_ms) do
-      global_telemetry(:slow_signal_threshold_ms, @default_slow_signal_threshold_ms)
+      global_telemetry(:slow_signal_threshold_ms, Defaults.slow_signal_threshold_ms())
     end
+    |> normalize_non_neg_integer(Defaults.slow_signal_threshold_ms())
   end
 
   @doc "Returns the slow directive threshold in milliseconds."
@@ -82,13 +87,16 @@ defmodule Jido.Observe.Config do
   def slow_directive_threshold_ms(instance \\ nil)
 
   def slow_directive_threshold_ms(nil),
-    do: global_telemetry(:slow_directive_threshold_ms, @default_slow_directive_threshold_ms)
+    do:
+      global_telemetry(:slow_directive_threshold_ms, Defaults.slow_directive_threshold_ms())
+      |> normalize_non_neg_integer(Defaults.slow_directive_threshold_ms())
 
   def slow_directive_threshold_ms(instance) do
     with nil <- Jido.Debug.override(instance, :slow_directive_threshold_ms),
          nil <- instance_telemetry(instance, :slow_directive_threshold_ms) do
-      global_telemetry(:slow_directive_threshold_ms, @default_slow_directive_threshold_ms)
+      global_telemetry(:slow_directive_threshold_ms, Defaults.slow_directive_threshold_ms())
     end
+    |> normalize_non_neg_integer(Defaults.slow_directive_threshold_ms())
   end
 
   @doc "Returns the list of signal types considered interesting."
@@ -96,13 +104,16 @@ defmodule Jido.Observe.Config do
   def interesting_signal_types(instance \\ nil)
 
   def interesting_signal_types(nil),
-    do: global_telemetry(:interesting_signal_types, @default_interesting_signal_types)
+    do:
+      global_telemetry(:interesting_signal_types, Defaults.interesting_signal_types())
+      |> normalize_interesting_signal_types()
 
   def interesting_signal_types(instance) do
     with nil <- Jido.Debug.override(instance, :interesting_signal_types),
          nil <- instance_telemetry(instance, :interesting_signal_types) do
-      global_telemetry(:interesting_signal_types, @default_interesting_signal_types)
+      global_telemetry(:interesting_signal_types, Defaults.interesting_signal_types())
     end
+    |> normalize_interesting_signal_types()
   end
 
   @doc "Returns true if trace-level logging is enabled."
@@ -136,25 +147,35 @@ defmodule Jido.Observe.Config do
   @doc "Returns the observability log level for the given instance."
   @spec observe_log_level(instance()) :: Logger.level()
   def observe_log_level(instance \\ nil)
-  def observe_log_level(nil), do: global_observability(:log_level, @default_observe_log_level)
+
+  def observe_log_level(nil) do
+    global_observability(:log_level, Defaults.observe_log_level())
+    |> normalize_observe_log_level()
+  end
 
   def observe_log_level(instance) do
     with nil <- Jido.Debug.override(instance, :observe_log_level),
          nil <- instance_observability(instance, :log_level) do
-      global_observability(:log_level, @default_observe_log_level)
+      global_observability(:log_level, Defaults.observe_log_level())
     end
+    |> normalize_observe_log_level()
   end
 
   @doc "Returns the debug events mode for the given instance."
   @spec debug_events(instance()) :: :off | :minimal | :all
   def debug_events(instance \\ nil)
-  def debug_events(nil), do: global_observability(:debug_events, @default_debug_events)
+
+  def debug_events(nil) do
+    global_observability(:debug_events, Defaults.observe_debug_events())
+    |> normalize_debug_events()
+  end
 
   def debug_events(instance) do
     with nil <- Jido.Debug.override(instance, :observe_debug_events),
          nil <- instance_observability(instance, :debug_events) do
-      global_observability(:debug_events, @default_debug_events)
+      global_observability(:debug_events, Defaults.observe_debug_events())
     end
+    |> normalize_debug_events()
   end
 
   @doc "Returns true if debug events are enabled."
@@ -168,31 +189,33 @@ defmodule Jido.Observe.Config do
   def redact_sensitive?(instance \\ nil)
 
   def redact_sensitive?(nil),
-    do: global_observability(:redact_sensitive, @default_redact_sensitive) == true
+    do:
+      global_observability(:redact_sensitive, Defaults.redact_sensitive())
+      |> normalize_boolean()
 
   def redact_sensitive?(instance) do
-    case Jido.Debug.override(instance, :redact_sensitive) do
-      nil ->
-        case instance_observability(instance, :redact_sensitive) do
-          nil -> global_observability(:redact_sensitive, @default_redact_sensitive) == true
-          val -> val == true
-        end
-
-      val ->
-        val == true
+    with nil <- Jido.Debug.override(instance, :redact_sensitive),
+         nil <- instance_observability(instance, :redact_sensitive) do
+      global_observability(:redact_sensitive, Defaults.redact_sensitive())
     end
+    |> normalize_boolean()
   end
 
   @doc "Returns the tracer module for the given instance."
   @spec tracer(instance()) :: module()
   def tracer(instance \\ nil)
-  def tracer(nil), do: global_observability(:tracer, @default_tracer)
+
+  def tracer(nil) do
+    global_observability(:tracer, Defaults.tracer())
+    |> normalize_tracer()
+  end
 
   def tracer(instance) do
     with nil <- Jido.Debug.override(instance, :tracer),
          nil <- instance_observability(instance, :tracer) do
-      global_observability(:tracer, @default_tracer)
+      global_observability(:tracer, Defaults.tracer())
     end
+    |> normalize_tracer()
   end
 
   # --- Debug buffer settings ---
@@ -200,13 +223,18 @@ defmodule Jido.Observe.Config do
   @doc "Returns the maximum number of debug events to store."
   @spec debug_max_events(instance()) :: non_neg_integer()
   def debug_max_events(instance \\ nil)
-  def debug_max_events(nil), do: global_telemetry(:debug_max_events, @default_debug_max_events)
+
+  def debug_max_events(nil) do
+    global_telemetry(:debug_max_events, Defaults.debug_max_events())
+    |> normalize_non_neg_integer(Defaults.debug_max_events())
+  end
 
   def debug_max_events(instance) do
     with nil <- Jido.Debug.override(instance, :debug_max_events),
          nil <- instance_telemetry(instance, :debug_max_events) do
-      global_telemetry(:debug_max_events, @default_debug_max_events)
+      global_telemetry(:debug_max_events, Defaults.debug_max_events())
     end
+    |> normalize_non_neg_integer(Defaults.debug_max_events())
   end
 
   # --- Private helpers ---
@@ -247,4 +275,46 @@ defmodule Jido.Observe.Config do
   defp global_observability(key, default) do
     :jido |> Application.get_env(:observability, []) |> Keyword.get(key, default)
   end
+
+  defp normalize_telemetry_log_level(level) when level in @telemetry_log_levels, do: level
+  defp normalize_telemetry_log_level(_), do: Defaults.telemetry_log_level()
+
+  defp normalize_telemetry_log_args(mode) when mode in @telemetry_log_args_modes, do: mode
+  defp normalize_telemetry_log_args(_), do: Defaults.telemetry_log_args()
+
+  defp normalize_observe_log_level(level) when level in @observe_log_levels, do: level
+  defp normalize_observe_log_level(_), do: Defaults.observe_log_level()
+
+  defp normalize_debug_events(mode) when mode in @debug_events_modes, do: mode
+  defp normalize_debug_events(_), do: Defaults.observe_debug_events()
+
+  defp normalize_interesting_signal_types(types) when is_list(types) do
+    if Enum.all?(types, &is_binary/1), do: types, else: Defaults.interesting_signal_types()
+  end
+
+  defp normalize_interesting_signal_types(_), do: Defaults.interesting_signal_types()
+
+  defp normalize_non_neg_integer(value, _default) when is_integer(value) and value >= 0, do: value
+  defp normalize_non_neg_integer(_, default), do: default
+
+  defp normalize_boolean(true), do: true
+  defp normalize_boolean(_), do: false
+
+  defp normalize_tracer(module) when is_atom(module) do
+    case Code.ensure_loaded(module) do
+      {:module, ^module} ->
+        if function_exported?(module, :span_start, 2) and
+             function_exported?(module, :span_stop, 2) and
+             function_exported?(module, :span_exception, 4) do
+          module
+        else
+          Defaults.tracer()
+        end
+
+      _ ->
+        Defaults.tracer()
+    end
+  end
+
+  defp normalize_tracer(_), do: Defaults.tracer()
 end

--- a/test/jido/config/defaults_test.exs
+++ b/test/jido/config/defaults_test.exs
@@ -1,0 +1,30 @@
+defmodule JidoTest.Config.DefaultsTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Config.Defaults
+
+  test "returns centralized timeout defaults" do
+    assert Defaults.jido_shutdown_timeout_ms() == 10_000
+    assert Defaults.agent_server_shutdown_timeout_ms() == 5_000
+    assert Defaults.agent_server_call_timeout_ms() == 5_000
+    assert Defaults.agent_server_await_timeout_ms() == 10_000
+    assert Defaults.await_timeout_ms() == 10_000
+    assert Defaults.await_child_timeout_ms() == 30_000
+    assert Defaults.worker_pool_checkout_timeout_ms() == 5_000
+    assert Defaults.worker_pool_call_timeout_ms() == 5_000
+    assert Defaults.instance_manager_stop_timeout_ms() == 5_000
+  end
+
+  test "returns centralized observability defaults" do
+    assert Defaults.telemetry_log_level() == :debug
+    assert Defaults.telemetry_log_args() == :keys_only
+    assert Defaults.slow_signal_threshold_ms() == 10
+    assert Defaults.slow_directive_threshold_ms() == 5
+    assert Defaults.interesting_signal_types() == ["jido.strategy.init", "jido.strategy.complete"]
+    assert Defaults.observe_log_level() == :info
+    assert Defaults.observe_debug_events() == :off
+    refute Defaults.redact_sensitive()
+    assert Defaults.tracer() == Jido.Observe.NoopTracer
+    assert Defaults.debug_max_events() == 500
+  end
+end

--- a/test/jido/debug_integration_test.exs
+++ b/test/jido/debug_integration_test.exs
@@ -1,6 +1,7 @@
 defmodule JidoTest.DebugIntegrationTest do
   use JidoTest.Case, async: false
 
+  alias Jido.Config.Defaults
   alias Jido.Debug
 
   defmodule TestAgent do
@@ -58,7 +59,7 @@ defmodule JidoTest.DebugIntegrationTest do
       pid = start_server(%{jido: jido}, TestAgent, debug: true)
 
       {:ok, state} = Jido.AgentServer.state(pid)
-      assert state.debug_max_events == 500
+      assert state.debug_max_events == Defaults.debug_max_events()
     end
   end
 


### PR DESCRIPTION
## Summary
- add `Jido.Config.Defaults` as the centralized source for runtime timeout and observability defaults
- replace scattered timeout literals in `Jido`, `AgentServer`, `Await`, `WorkerPool`, and `InstanceManager` with shared defaults
- harden `Jido.Observe.Config` with explicit value normalization/validation and safe fallback to defaults
- add tests for the defaults module and invalid observability config fallbacks
- document that invalid observability config values fall back to defaults

## Issue
Closes #149

## Validation
- `mix test`
- `mix quality`
