### PR TITLE
fix(agent_server): return routing error struct for unknown signals

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -1090,7 +1090,7 @@ defmodule Jido.AgentServer do
               })
 
             error_directive = %Directive.Error{error: error, context: :routing}
-            {:error, reason, [error_directive]}
+            {:error, error, [error_directive]}
         end
     end
   end


### PR DESCRIPTION
## Summary
- fix sync signal-call routing to return `%Jido.Error.RoutingError{}` instead of legacy `:no_matching_route`
- keep directive enqueue behavior unchanged; only normalize the public error contract for `AgentServer.call/3`

## Validation
- mix test test/jido/agent/signal_handling_test.exs test/jido/agent_server/agent_server_coverage_test.exs test/jido/agent_server/agent_server_test.exs
- mix test
- mix quality
