### PR TITLE
fix(discovery): restore __agent_metadata__/0 for agent discovery

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -419,6 +419,21 @@ defmodule Jido.Agent do
       @doc "Returns the merged schema (base + plugin schemas)."
       @spec schema() :: Zoi.schema() | keyword()
       def schema, do: @merged_schema
+
+      @doc false
+      @spec __agent_metadata__() :: map()
+      def __agent_metadata__ do
+        %{
+          module: __MODULE__,
+          name: name(),
+          description: description(),
+          category: category(),
+          tags: tags(),
+          vsn: vsn(),
+          actions: actions(),
+          schema: schema()
+        }
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- restore `__agent_metadata__/0` generation in `use Jido.Agent` modules
- emit metadata aligned with discovery expectations (`name`, `description`, `category`, `tags`, `vsn`, `actions`, `schema`)
- add a discovery regression test that loads a temporary OTP app and verifies agent metadata is indexed by `Jido.Discovery.list_agents/1`

## Validation
- `mix test test/jido/discovery_test.exs`
- `mix test test/jido/agent/agent_test.exs test/jido/instance_test.exs`
- `mix test`
- `mix quality`

Fixes #158
