### PR TITLE
fix(thread): prevent atom table growth in JournalBacked kind decoding

### DIFF
--- a/lib/jido/thread/store/adapters/journal_backed.ex
+++ b/lib/jido/thread/store/adapters/journal_backed.ex
@@ -189,7 +189,7 @@ defmodule Jido.Thread.Store.Adapters.JournalBacked do
   defp to_atom(string) when is_binary(string) do
     String.to_existing_atom(string)
   rescue
-    ArgumentError -> String.to_atom(string)
+    ArgumentError -> :unknown
   end
 
   defp to_atom(_), do: :unknown


### PR DESCRIPTION
## Summary
Fixes finding 1 from #157.

`Jido.Thread.Store.Adapters.JournalBacked` no longer falls back to `String.to_atom/1` when decoding persisted entry kinds.

## Changes
- Changed kind decoding fallback from dynamic atom creation to `:unknown`
- Added regression test proving unknown string kinds do not create atoms

## Validation
- `mix test test/jido/thread/journal_backed_adapter_test.exs`

Refs #157
