### PR TITLE
refactor(thread): centralize entry normalization across adapters

### DIFF
--- a/lib/jido/storage/file.ex
+++ b/lib/jido/storage/file.ex
@@ -36,6 +36,7 @@ defmodule Jido.Storage.File do
 
   alias Jido.Thread
   alias Jido.Thread.Entry
+  alias Jido.Thread.EntryNormalizer
 
   @type key :: term()
   @type opts :: keyword()
@@ -244,19 +245,7 @@ defmodule Jido.Storage.File do
     now = System.system_time(:millisecond)
     base_seq = length(current_entries)
 
-    prepared_entries =
-      entries
-      |> Enum.with_index()
-      |> Enum.map(fn {entry, idx} ->
-        %Entry{
-          id: entry.id || generate_entry_id(),
-          seq: base_seq + idx,
-          at: entry.at || now,
-          kind: entry.kind,
-          payload: entry.payload || %{},
-          refs: entry.refs || %{}
-        }
-      end)
+    prepared_entries = EntryNormalizer.normalize_many(entries, base_seq, now)
 
     {:ok, prepared_entries, now}
   end
@@ -369,9 +358,5 @@ defmodule Jido.Storage.File do
     :global.trans(lock_id, fn ->
       fun.()
     end)
-  end
-
-  defp generate_entry_id do
-    "entry_" <> Base.url_encode64(:crypto.strong_rand_bytes(12), padding: false)
   end
 end

--- a/lib/jido/thread/entry_normalizer.ex
+++ b/lib/jido/thread/entry_normalizer.ex
@@ -1,0 +1,68 @@
+defmodule Jido.Thread.EntryNormalizer do
+  @moduledoc """
+  Shared entry normalization for thread and storage append paths.
+
+  Ensures all adapters apply the same defaults and attribute extraction for
+  `%Jido.Thread.Entry{}` structs and plain maps.
+  """
+
+  alias Jido.Thread.Entry
+
+  @type entry_input :: Entry.t() | map()
+  @type opts :: [id_generator: (-> String.t())]
+
+  @doc """
+  Normalize a single entry input into `%Jido.Thread.Entry{}`.
+  """
+  @spec normalize(entry_input(), non_neg_integer(), integer(), opts()) :: Entry.t()
+  def normalize(entry, seq, now, opts \\ [])
+
+  def normalize(%Entry{} = entry, seq, now, opts) do
+    id_generator = Keyword.get(opts, :id_generator, &generate_entry_id/0)
+
+    %Entry{
+      id: entry.id || id_generator.(),
+      seq: seq,
+      at: entry.at || now,
+      kind: entry.kind || :note,
+      payload: entry.payload || %{},
+      refs: entry.refs || %{}
+    }
+  end
+
+  def normalize(attrs, seq, now, opts) when is_map(attrs) do
+    id_generator = Keyword.get(opts, :id_generator, &generate_entry_id/0)
+
+    %Entry{
+      id: fetch_entry_attr(attrs, :id, id_generator),
+      seq: seq,
+      at: fetch_entry_attr(attrs, :at, fn -> now end),
+      kind: fetch_entry_attr(attrs, :kind, fn -> :note end),
+      payload: fetch_entry_attr(attrs, :payload, fn -> %{} end),
+      refs: fetch_entry_attr(attrs, :refs, fn -> %{} end)
+    }
+  end
+
+  @doc """
+  Normalize many entries, assigning monotonic sequence numbers from `base_seq`.
+  """
+  @spec normalize_many([entry_input()], non_neg_integer(), integer(), opts()) :: [Entry.t()]
+  def normalize_many(entries, base_seq, now, opts \\ []) do
+    entries
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, idx} ->
+      normalize(entry, base_seq + idx, now, opts)
+    end)
+  end
+
+  defp fetch_entry_attr(attrs, key, default_fun) when is_function(default_fun, 0) do
+    case Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key)) do
+      nil -> default_fun.()
+      value -> value
+    end
+  end
+
+  defp generate_entry_id do
+    "entry_" <> Jido.Util.generate_id()
+  end
+end

--- a/test/jido/thread/entry_normalizer_test.exs
+++ b/test/jido/thread/entry_normalizer_test.exs
@@ -1,0 +1,57 @@
+defmodule JidoTest.Thread.EntryNormalizerTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Thread.Entry
+  alias Jido.Thread.EntryNormalizer
+
+  describe "normalize/4" do
+    test "applies consistent defaults for Entry structs" do
+      entry = %Entry{id: nil, seq: 10, at: nil, kind: nil, payload: nil, refs: nil}
+
+      normalized = EntryNormalizer.normalize(entry, 3, 1_234)
+
+      assert normalized.seq == 3
+      assert normalized.at == 1_234
+      assert normalized.kind == :note
+      assert normalized.payload == %{}
+      assert normalized.refs == %{}
+      assert is_binary(normalized.id)
+    end
+
+    test "accepts atom and string keys for map input" do
+      input = %{
+        "id" => "entry_123",
+        "at" => 999,
+        "kind" => :message,
+        "payload" => %{"text" => "hello"},
+        "refs" => %{"source" => "test"}
+      }
+
+      normalized = EntryNormalizer.normalize(input, 4, 1_234)
+
+      assert normalized.id == "entry_123"
+      assert normalized.seq == 4
+      assert normalized.at == 999
+      assert normalized.kind == :message
+      assert normalized.payload == %{"text" => "hello"}
+      assert normalized.refs == %{"source" => "test"}
+    end
+  end
+
+  describe "normalize_many/4" do
+    test "assigns monotonic sequence values from base_seq" do
+      entries = [%{kind: :message}, %{kind: :message}, %{kind: :message}]
+
+      normalized = EntryNormalizer.normalize_many(entries, 7, 1_000)
+
+      assert Enum.map(normalized, & &1.seq) == [7, 8, 9]
+    end
+
+    test "supports custom id generation" do
+      normalized =
+        EntryNormalizer.normalize(%{kind: :note}, 0, 100, id_generator: fn -> "custom_id" end)
+
+      assert normalized.id == "custom_id"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes finding 5 from #157.

Entry preparation logic is now centralized so thread/storage implementations share one normalization path.

## Changes
- Added `Jido.Thread.EntryNormalizer` for shared entry normalization
- Updated `Jido.Thread`, `Jido.Storage.ETS`, `Jido.Storage.File`, and `JournalBacked` to use it
- Removed duplicated per-module normalization helpers
- Added focused tests for defaulting, key extraction, sequence assignment, and custom ID generation

## Validation
- `mix test test/jido/thread/entry_normalizer_test.exs test/jido/thread/journal_backed_adapter_test.exs test/jido/storage/file_test.exs test/jido/storage/ets_test.exs test/jido/thread/thread_test.exs`

Refs #157
