### PR TITLE
refactor(igniter): deduplicate generator templates

### DIFF
--- a/test/jido/igniter/templates_test.exs
+++ b/test/jido/igniter/templates_test.exs
@@ -1,0 +1,27 @@
+defmodule JidoTest.Igniter.TemplatesTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Igniter.Templates
+
+  describe "agent_template/3" do
+    test "includes optional plugins list when provided" do
+      template =
+        Templates.agent_template(
+          "MyApp.Agent",
+          "my_agent",
+          plugins: [MyApp.PluginOne, MyApp.PluginTwo]
+        )
+
+      assert template =~ "plugins: [MyApp.PluginOne, MyApp.PluginTwo]"
+    end
+  end
+
+  describe "agent_test_template/2" do
+    test "uses module alias name in assertions" do
+      template = Templates.agent_test_template("MyApp.Agents.Example", "JidoTest.Agents.Example")
+
+      assert template =~ "agent = Example.new()"
+      assert template =~ "assert agent.name == Example.name()"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes finding 6 from #157.

Generator module/test templates are now sourced from `Jido.Igniter.Templates` instead of duplicated inline strings in each mix task.

## Changes
- Updated `mix jido.gen.agent`, `mix jido.gen.plugin`, and `mix jido.gen.sensor` to call shared template helpers
- Extended `Jido.Igniter.Templates.agent_template/3` to support plugin injection
- Added template regression tests for plugin option rendering and alias handling
- Removed duplicated inline template blocks from mix tasks

## Validation
- `mix test test/jido/igniter/templates_test.exs`

Refs #157
