### PR TITLE
refactor(test): deduplicate signal collector helpers

### DIFF
--- a/test/examples/signals/emit_directive_test.exs
+++ b/test/examples/signals/emit_directive_test.exs
@@ -18,6 +18,7 @@ defmodule JidoExampleTest.EmitDirectiveTest do
   alias Jido.Agent.Directive
   alias Jido.AgentServer
   alias Jido.Signal
+  alias JidoTest.SignalCollector
 
   # ===========================================================================
   # ACTIONS: Emit domain events
@@ -96,46 +97,6 @@ defmodule JidoExampleTest.EmitDirectiveTest do
         end
 
       {:ok, %{emitted_count: count}, emissions}
-    end
-  end
-
-  # ===========================================================================
-  # COLLECTOR: Test helper to capture emitted signals
-  # ===========================================================================
-
-  defmodule SignalCollector do
-    @moduledoc false
-    use GenServer
-
-    def start_link(opts \\ []) do
-      GenServer.start_link(__MODULE__, [], opts)
-    end
-
-    def get_signals(pid) do
-      GenServer.call(pid, :get_signals)
-    end
-
-    def clear(pid) do
-      GenServer.call(pid, :clear)
-    end
-
-    @impl true
-    def init(_opts) do
-      {:ok, []}
-    end
-
-    @impl true
-    def handle_info({:signal, signal}, signals) do
-      {:noreply, [signal | signals]}
-    end
-
-    @impl true
-    def handle_call(:get_signals, _from, signals) do
-      {:reply, Enum.reverse(signals), signals}
-    end
-
-    def handle_call(:clear, _from, _signals) do
-      {:reply, :ok, []}
     end
   end
 

--- a/test/support/signal_collector.ex
+++ b/test/support/signal_collector.ex
@@ -1,0 +1,21 @@
+defmodule JidoTest.SignalCollector do
+  @moduledoc false
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, [], opts)
+  end
+
+  def get_signals(pid), do: GenServer.call(pid, :get_signals)
+  def clear(pid), do: GenServer.call(pid, :clear)
+
+  @impl true
+  def init(_opts), do: {:ok, []}
+
+  @impl true
+  def handle_info({:signal, signal}, signals), do: {:noreply, [signal | signals]}
+
+  @impl true
+  def handle_call(:get_signals, _from, signals), do: {:reply, Enum.reverse(signals), signals}
+  def handle_call(:clear, _from, _signals), do: {:reply, :ok, []}
+end


### PR DESCRIPTION
## Summary
Fixes finding 8 from #157.

Repeated signal-collector helper modules in example suites are now centralized in `test/support`.

## Changes
- Added shared `JidoTest.SignalCollector` helper in `test/support/signal_collector.ex`
- Replaced duplicated collector modules in:
  - `test/examples/observability/tracing_test.exs`
  - `test/examples/signals/emit_directive_test.exs`
  - `test/examples/runtime/hierarchical_agents_test.exs`
- Removed copy-pasted GenServer collector implementations from those suites

## Validation
- `mix test --include example test/examples/observability/tracing_test.exs test/examples/signals/emit_directive_test.exs test/examples/runtime/hierarchical_agents_test.exs`

Refs #157
