### PR TITLE
fix(await): make any/all timeout error shape deterministic

### DIFF
--- a/lib/jido/await.ex
+++ b/lib/jido/await.ex
@@ -220,6 +220,10 @@ defmodule Jido.Await do
         kill_waiters(Map.delete(waiters, ref))
         {:error, :timeout}
 
+      {:await_result, ref, _server, {:error, {:timeout, _details}}} ->
+        kill_waiters(Map.delete(waiters, ref))
+        {:error, :timeout}
+
       {:await_result, ref, server, {:error, reason}} ->
         kill_waiters(Map.delete(waiters, ref))
         {:error, {server, reason}}
@@ -284,6 +288,10 @@ defmodule Jido.Await do
         {:ok, {server, result}}
 
       {:await_result, ref, _server, {:error, :timeout}} ->
+        kill_waiters(Map.delete(waiters, ref))
+        {:error, :timeout}
+
+      {:await_result, ref, _server, {:error, {:timeout, _details}}} ->
         kill_waiters(Map.delete(waiters, ref))
         {:error, :timeout}
 


### PR DESCRIPTION
## Summary
Fixes a flaky timeout shape in `Jido.Await.any/3` (and `all/3`) where timeout diagnostics from `AgentServer.await_completion/2` were treated as infrastructure errors.

## Root Cause
`Await.completion/3` can return timeout as `{:error, {:timeout, diagnostic}}`.
`Await.any/3`/`Await.all/3` only matched `{:error, :timeout}`, so depending on timing they could return:
- `{:error, :timeout}` (expected)
- `{:error, {server, {:timeout, diagnostic}}}` (flaky mismatch)

## Changes
- Normalize both timeout shapes in `Await.any/3` and `Await.all/3`:
  - `{:error, :timeout}`
  - `{:error, {:timeout, _details}}`
- Both now consistently map to `{:error, :timeout}`.

## Validation
- `mix test test/jido/await_test.exs test/jido/await_coverage_test.exs test/jido/jido_test.exs`
- Stress check: repeated `mix test test/jido/await_test.exs:211` loop with varied seeds (30 runs) had `0` failures.
