### PR TITLE
feat: add Igniter installer fallback for graceful degradation

### DIFF
--- a/lib/mix/tasks/jido.install.ex
+++ b/lib/mix/tasks/jido.install.ex
@@ -86,4 +86,21 @@ if Code.ensure_loaded?(Igniter) do
       igniter
     end
   end
+else
+  defmodule Mix.Tasks.Jido.Install do
+    @moduledoc "Installs Jido. Should be run with `mix igniter.install jido`"
+    @shortdoc @moduledoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'jido.install' requires igniter. Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `else` fallback block to the existing Igniter installer at `lib/mix/tasks/jido.install.ex`
- When Igniter is not installed, users now get a helpful error message instead of a compilation failure
- Follows the same pattern used across all other Jido ecosystem packages

## Changes
- `lib/mix/tasks/jido.install.ex` - Added fallback `Mix.Tasks.Jido.Install` module using plain `Mix.Task` that prints installation instructions for Igniter

## Test plan
- [x] `mix jido.install` works when Igniter is available (existing behavior unchanged)
- [x] `mix jido.install` shows helpful error when Igniter is not available (new behavior)
- [x] No compilation errors in either case

Generated with [Claude Code](https://claude.com/claude-code)