### PR TITLE
fix(agent_server): loop back emit without dispatch to current agent

### DIFF
--- a/lib/jido/agent/directive.ex
+++ b/lib/jido/agent/directive.ex
@@ -147,6 +147,9 @@ defmodule Jido.Agent.Directive do
       - `:http` / `:webhook` - HTTP endpoints
       - `:logger` / `:console` / `:noop` - Logging/testing
 
+    If `dispatch` is omitted and the agent has no `default_dispatch`, runtime
+    falls back to emitting to the current agent process (`self()`).
+
     ## Examples
 
         # Use agent's default dispatch (configured on AgentServer)
@@ -457,6 +460,10 @@ defmodule Jido.Agent.Directive do
 
   @doc """
   Creates an Emit directive.
+
+  If `dispatch` is omitted, runtime will use `AgentServer` `default_dispatch`.
+  When no default is configured, runtime falls back to emitting to the current
+  agent process (`self()`).
 
   ## Examples
 

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -46,7 +46,7 @@ defmodule Jido.AgentServer do
   - `:id` - Instance ID (auto-generated if not provided)
   - `:initial_state` - Initial state map for agent
   - `:registry` - Registry module (default: `Jido.Registry`)
-  - `:default_dispatch` - Default dispatch config for Emit directives
+  - `:default_dispatch` - Default dispatch config for Emit directives (fallback: current agent pid)
   - `:error_policy` - Error handling policy
   - `:max_queue_size` - Max directive queue size (default: 10_000)
   - `:parent` - Parent reference for hierarchy

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -20,7 +20,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.Emit do
   end
 
   defp dispatch_signal(traced_signal, nil, _state) do
-    Logger.debug("Emit directive with no dispatch config, signal: #{traced_signal.type}")
+    send(self(), {:signal, traced_signal})
   end
 
   defp dispatch_signal(traced_signal, cfg, state) do

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -129,7 +129,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
   end
 
   describe "Emit directive" do
-    test "returns async tuple with nil ref when no dispatch config", %{
+    test "falls back to dispatching to current process when no dispatch config", %{
       state: state,
       input_signal: input_signal
     } do
@@ -137,6 +137,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       directive = %Directive.Emit{signal: signal, dispatch: nil}
 
       assert {:async, nil, ^state} = DirectiveExec.exec(directive, input_signal, state)
+      assert_receive {:signal, %Signal{type: "test.emitted"}}
     end
 
     test "returns async tuple when dispatch config provided", %{


### PR DESCRIPTION
## Summary
- make `Directive.emit(signal)` with no explicit dispatch and no `default_dispatch` loop back to the current agent process instead of being dropped
- align nil-dispatch emit behavior with internal delivery semantics used by `Directive.schedule(0, signal)`
- document the fallback behavior and add regression coverage (executor-level and example-level)

## Why
A nil-dispatch emit was previously a no-op. This caused internally emitted signals (like `print.count`) to never re-enter the agent unless users explicitly provided a dispatch target.

## Changes
- `Emit` directive executor now sends `{:signal, traced_signal}` to `self()` when dispatch config resolves to `nil`
- docs updated in directive and agent server docs
- tests updated/added:
  - `test/jido/agent_server/directive_exec_test.exs`
  - `test/examples/signals/emit_directive_test.exs`

## Verification
- `mix format --check-formatted`
- `mix test test/jido/agent_server/directive_exec_test.exs`
- `mix test --include example test/examples/signals/emit_directive_test.exs`
- `mix test`
