### PR TITLE
docs(readme): add signal_routes to AgentServer quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ defmodule MyApp.CounterAgent do
     description: "A simple counter agent",
     schema: [
       count: [type: :integer, default: 0]
+    ],
+    signal_routes: [
+      {"increment", MyApp.Actions.Increment}
     ]
 end
 ```
@@ -206,6 +209,7 @@ agent.state.count
 {:ok, pid} = MyApp.Jido.start_agent(MyApp.CounterAgent, id: "counter-1")
 
 # Send signals to the running agent (synchronous)
+# Signal types must be declared in signal_routes
 {:ok, agent} = Jido.AgentServer.call(pid, Jido.Signal.new!("increment", %{amount: 10}, source: "/user"))
 
 # Look up the agent by ID


### PR DESCRIPTION
## Summary
- add `signal_routes` to the Quick Start `CounterAgent` example
- clarify that `AgentServer.call/2` signal types must be routed

## Why
The Quick Start showed calling `AgentServer.call/2` with `"increment"` but did not declare a route, causing `No route for signal` at runtime.

Fixes #174
