### PR TITLE
fix: align StopChild with SpawnAgent restart semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ State operations are internal state transitions handled by the strategy layer du
 | `Emit`       | Dispatch a signal via configured adapters        |
 | `Error`      | Signal an error from cmd/2                       |
 | `Spawn`      | Spawn a generic BEAM child process               |
-| `SpawnAgent` | Spawn a child Jido agent with hierarchy tracking |
-| `StopChild`  | Gracefully stop a tracked child agent            |
+| `SpawnAgent` | Spawn a tracked child Jido agent (`restart: :transient` by default) |
+| `StopChild`  | Gracefully stop and remove a tracked child agent                      |
 | `Schedule`   | Schedule a delayed message                       |
 | `Stop`       | Stop the agent process                           |
 

--- a/guides/directives.md
+++ b/guides/directives.md
@@ -32,8 +32,8 @@ end
 | `Emit` | Dispatch a signal via configured adapters | — |
 | `Error` | Signal an error from cmd/2 | — |
 | `Spawn` | Spawn generic BEAM child process | None (fire-and-forget) |
-| `SpawnAgent` | Spawn child Jido agent with hierarchy | Full (monitoring, exit signals) |
-| `StopChild` | Gracefully stop a tracked child agent | Uses children map |
+| `SpawnAgent` | Spawn child Jido agent with hierarchy | Full (monitoring, exit signals, `restart: :transient` default) |
+| `StopChild` | Gracefully stop and remove a tracked child agent | Uses children map |
 | `Schedule` | Schedule a delayed message | — |
 | `RunInstruction` | Execute `%Instruction{}` at runtime and route result back through `cmd/2` | — |
 | `Stop` | Stop the agent process (self) | — |
@@ -55,6 +55,7 @@ Directive.emit_to_parent(agent, signal)
 Directive.spawn(child_spec)
 Directive.spawn_agent(MyWorkerAgent, :worker_1)
 Directive.spawn_agent(MyWorkerAgent, :processor, opts: %{initial_state: %{batch_size: 100}})
+Directive.spawn_agent(MyWorkerAgent, :durable, restart: :permanent)
 
 # Stop processes
 Directive.stop_child(:worker_1)
@@ -95,6 +96,11 @@ Directive.spawn({Task, :start_link, [fn -> send_webhook(url) end]})
 # Tracked child agent
 Directive.spawn_agent(WorkerAgent, :worker_1, opts: %{initial_state: state})
 ```
+
+`SpawnAgent` children default to `restart: :transient`, which means:
+- `Directive.stop_child/2` cleanly removes them
+- abnormal exits still restart the child
+- callers can override to `:permanent` or `:temporary` when needed
 
 ## Custom Directives
 

--- a/guides/orchestration.md
+++ b/guides/orchestration.md
@@ -346,7 +346,7 @@ defmodule CleanupWorkersAction do
 
   def run(%{tags: tags}, _context) do
     stop_directives = Enum.map(tags, fn tag ->
-      Directive.stop_child(tag, reason: :cleanup)
+      Directive.stop_child(tag, :cleanup)
     end)
 
     {:ok, %{status: :cleaned_up}, stop_directives}

--- a/guides/runtime.md
+++ b/guides/runtime.md
@@ -61,12 +61,15 @@ Emit a `SpawnAgent` directive to create a child agent:
 
 ```elixir
 %Directive.SpawnAgent{agent: ChildAgent, tag: :worker_1}
+# Or keep the child running across restarts/stops:
+%Directive.SpawnAgent{agent: ChildAgent, tag: :durable_worker, restart: :permanent}
 ```
 
 The parent:
 - Monitors the child process
 - Tracks children in `state.children` map by tag
 - Receives `jido.agent.child.exit` signals when children exit
+- Rebinds tracked child info automatically if the child restarts
 
 ### Child Communication
 
@@ -81,6 +84,9 @@ Directive.emit_to_parent(agent, signal)
 ```elixir
 %Directive.StopChild{tag: :worker_1}
 ```
+
+`SpawnAgent` children default to `restart: :transient`, so `StopChild` cleanly removes
+them instead of immediately restarting them.
 
 ## Completion Detection
 

--- a/lib/jido/actions/lifecycle.ex
+++ b/lib/jido/actions/lifecycle.ex
@@ -122,6 +122,7 @@ defmodule Jido.Actions.Lifecycle do
     - `tag` - Tag for tracking this child (required)
     - `initial_state` - Initial state for the child agent (default: %{})
     - `meta` - Metadata to pass to child (default: %{})
+    - `restart` - Restart policy for the child (default: `:transient`)
 
     ## Example
 
@@ -131,9 +132,12 @@ defmodule Jido.Actions.Lifecycle do
         {Jido.Actions.Lifecycle.SpawnChild, %{
           agent_module: MyWorker,
           tag: :worker_1,
-          initial_state: %{batch_size: 100}
+          initial_state: %{batch_size: 100},
+          restart: :permanent
         }}
     """
+    @restart_policies Directive.valid_restart_policies()
+
     use Jido.Action,
       name: "spawn_child",
       description: "Spawn a child agent with hierarchy tracking",
@@ -141,12 +145,20 @@ defmodule Jido.Actions.Lifecycle do
         agent_module: [type: :atom, required: true, doc: "Agent module to spawn"],
         tag: [type: :atom, required: true, doc: "Tag for tracking this child"],
         initial_state: [type: :map, default: %{}, doc: "Initial state for child"],
-        meta: [type: :map, default: %{}, doc: "Metadata to pass to child"]
+        meta: [type: :map, default: %{}, doc: "Metadata to pass to child"],
+        restart: [
+          type: {:in, @restart_policies},
+          default: :transient,
+          doc: "Restart policy for the child"
+        ]
       ]
 
-    def run(%{agent_module: mod, tag: tag, initial_state: state, meta: meta}, _context) do
+    def run(
+          %{agent_module: mod, tag: tag, initial_state: state, meta: meta, restart: restart},
+          _context
+        ) do
       opts = if state == %{}, do: %{}, else: %{initial_state: state}
-      directive = Directive.spawn_agent(mod, tag, opts: opts, meta: meta)
+      directive = Directive.spawn_agent(mod, tag, opts: opts, meta: meta, restart: restart)
       {:ok, %{spawning: tag}, [directive]}
     end
   end

--- a/lib/jido/agent/directive.ex
+++ b/lib/jido/agent/directive.ex
@@ -90,6 +90,25 @@ defmodule Jido.Agent.Directive do
           | Cron.t()
           | CronCancel.t()
 
+  @typedoc "Restart policy for spawned AgentServer children."
+  @type restart_policy :: :permanent | :temporary | :transient
+
+  @restart_policies [:permanent, :temporary, :transient]
+
+  @doc false
+  @spec valid_restart_policies() :: [restart_policy()]
+  def valid_restart_policies, do: @restart_policies
+
+  @doc false
+  @spec validate_restart_policy(term(), keyword()) :: :ok | {:error, String.t()}
+  def validate_restart_policy(restart, _opts \\ [])
+
+  def validate_restart_policy(restart, _opts) when restart in @restart_policies, do: :ok
+
+  def validate_restart_policy(restart, _opts) do
+    {:error, "restart must be one of #{inspect(@restart_policies)}, got: #{inspect(restart)}"}
+  end
+
   # ============================================================================
   # Error - Signal an error from cmd/2
   # ============================================================================
@@ -249,6 +268,7 @@ defmodule Jido.Agent.Directive do
     - `tag` - Tag for tracking this child (used as key in children map)
     - `opts` - Additional options passed to child AgentServer
     - `meta` - Metadata to pass to child via parent reference
+    - `restart` - Restart policy for the child under supervision (default: `:transient`)
 
     ## Examples
 
@@ -268,6 +288,13 @@ defmodule Jido.Agent.Directive do
           tag: :handler,
           meta: %{assigned_topic: "events.user"}
         }
+
+        # Override restart behavior for long-lived workers
+        %SpawnAgent{
+          agent: MyWorkerAgent,
+          tag: :supervised,
+          restart: :permanent
+        }
     """
 
     @schema Zoi.struct(
@@ -276,7 +303,11 @@ defmodule Jido.Agent.Directive do
                 agent: Zoi.any(description: "Agent module (atom) or pre-built agent struct"),
                 tag: Zoi.any(description: "Tag for tracking this child"),
                 opts: Zoi.map(description: "Options for child AgentServer") |> Zoi.default(%{}),
-                meta: Zoi.map(description: "Metadata to pass to child") |> Zoi.default(%{})
+                meta: Zoi.map(description: "Metadata to pass to child") |> Zoi.default(%{}),
+                restart:
+                  Zoi.atom(description: "Restart policy for the child")
+                  |> Zoi.refine({Jido.Agent.Directive, :validate_restart_policy, []})
+                  |> Zoi.default(:transient)
               },
               coerce: true
             )
@@ -323,6 +354,9 @@ defmodule Jido.Agent.Directive do
     The runtime sends a `jido.agent.stop` signal to the child process,
     which triggers a graceful shutdown. The child's exit will be delivered
     back to the parent as a `jido.agent.child.exit` signal.
+
+    `SpawnAgent` children default to `restart: :transient`, so a normal
+    `StopChild` shutdown removes the child instead of immediately restarting it.
     """
 
     @schema Zoi.struct(
@@ -508,18 +542,28 @@ defmodule Jido.Agent.Directive do
 
   - `:opts` - Additional options for the child AgentServer (map)
   - `:meta` - Metadata to pass to the child via parent reference (map)
+  - `:restart` - Child restart policy under supervision (default: `:transient`)
 
   ## Examples
 
       Directive.spawn_agent(MyWorkerAgent, :worker_1)
       Directive.spawn_agent(MyWorkerAgent, :processor, opts: %{initial_state: %{batch_size: 100}})
       Directive.spawn_agent(MyWorkerAgent, :handler, meta: %{assigned_topic: "events"})
+      Directive.spawn_agent(MyWorkerAgent, :durable, restart: :permanent)
   """
   @spec spawn_agent(term(), term(), keyword()) :: SpawnAgent.t()
   def spawn_agent(agent, tag, options \\ []) do
     opts = Keyword.get(options, :opts, %{})
     meta = Keyword.get(options, :meta, %{})
-    %SpawnAgent{agent: agent, tag: tag, opts: opts, meta: meta}
+    restart = Keyword.get(options, :restart, :transient)
+
+    case validate_restart_policy(restart) do
+      :ok ->
+        %SpawnAgent{agent: agent, tag: tag, opts: opts, meta: meta, restart: restart}
+
+      {:error, message} ->
+        raise Jido.Error.validation_error(message, field: :restart)
+    end
   end
 
   @doc """

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -1241,6 +1241,8 @@ defmodule Jido.AgentServer do
         id: signal.id
       })
 
+    state = maybe_track_child_started(state, signal)
+
     emit_telemetry(
       [:jido, :agent_server, :signal, :start],
       %{system_time: System.system_time()},
@@ -1271,6 +1273,58 @@ defmodule Jido.AgentServer do
       jido_instance: state.jido
     }
     |> Map.merge(trace_metadata)
+  end
+
+  defp maybe_track_child_started(
+         %State{id: state_id} = state,
+         %Signal{type: "jido.agent.child.started", data: data}
+       )
+       when is_map(data) do
+    with %{
+           parent_id: ^state_id,
+           tag: tag,
+           pid: pid,
+           child_id: child_id,
+           child_module: child_module
+         } <-
+           data,
+         true <- is_pid(pid),
+         true <- is_binary(child_id),
+         true <- is_atom(child_module) do
+      meta = Map.get(data, :meta, %{})
+
+      case State.get_child(state, tag) do
+        %ChildInfo{pid: ^pid} ->
+          state
+
+        %ChildInfo{ref: ref} ->
+          Process.demonitor(ref, [:flush])
+          track_child_started(state, pid, child_module, child_id, tag, meta)
+
+        nil ->
+          track_child_started(state, pid, child_module, child_id, tag, meta)
+      end
+    else
+      _ -> state
+    end
+  end
+
+  defp maybe_track_child_started(state, _signal), do: state
+
+  defp track_child_started(state, pid, child_module, child_id, tag, meta) do
+    ref = Process.monitor(pid)
+
+    child_info =
+      ChildInfo.new!(%{
+        pid: pid,
+        ref: ref,
+        module: child_module,
+        id: child_id,
+        tag: tag,
+        meta: meta
+      })
+
+    State.add_child(state, tag, child_info)
   end
 
   defp do_process_signal(signal, router, state, start_time, metadata) do

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -187,48 +187,71 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.SpawnAgent do
 
   require Logger
 
+  alias Jido.Agent.Directive
   alias Jido.AgentServer
   alias Jido.AgentServer.{ChildInfo, State}
 
-  def exec(%{agent: agent, tag: tag, opts: opts, meta: meta}, _input_signal, state) do
-    child_id = opts[:id] || "#{state.id}/#{tag}"
+  def exec(
+        %{agent: agent, tag: tag, opts: opts, meta: meta, restart: restart},
+        _input_signal,
+        state
+      ) do
+    case Directive.validate_restart_policy(restart) do
+      :ok ->
+        child_id = opts[:id] || "#{state.id}/#{tag}"
 
-    child_opts =
-      [
-        agent: agent,
-        id: child_id,
-        parent: %{
-          pid: self(),
-          id: state.id,
-          tag: tag,
-          meta: meta
-        }
-      ] ++ Map.to_list(Map.delete(opts, :id))
-
-    child_opts = if state.jido, do: Keyword.put(child_opts, :jido, state.jido), else: child_opts
-
-    case AgentServer.start(child_opts) do
-      {:ok, pid} ->
-        ref = Process.monitor(pid)
-
-        child_info =
-          ChildInfo.new!(%{
-            pid: pid,
-            ref: ref,
-            module: resolve_agent_module(agent),
+        child_opts =
+          [
+            agent: agent,
             id: child_id,
-            tag: tag,
-            meta: meta
-          })
+            parent: %{
+              pid: self(),
+              id: state.id,
+              tag: tag,
+              meta: meta
+            }
+          ] ++ Map.to_list(Map.delete(opts, :id))
 
-        new_state = State.add_child(state, tag, child_info)
+        child_opts =
+          if state.jido, do: Keyword.put(child_opts, :jido, state.jido), else: child_opts
 
-        Logger.debug("AgentServer #{state.id} spawned child #{child_id} with tag #{inspect(tag)}")
+        child_spec = Supervisor.child_spec({AgentServer, child_opts}, restart: restart)
 
-        {:ok, new_state}
+        supervisor =
+          if state.jido, do: Jido.agent_supervisor_name(state.jido), else: Jido.AgentSupervisor
+
+        case DynamicSupervisor.start_child(supervisor, child_spec) do
+          {:ok, pid} ->
+            ref = Process.monitor(pid)
+
+            child_info =
+              ChildInfo.new!(%{
+                pid: pid,
+                ref: ref,
+                module: resolve_agent_module(agent),
+                id: child_id,
+                tag: tag,
+                meta: meta
+              })
+
+            new_state = State.add_child(state, tag, child_info)
+
+            Logger.debug(
+              "AgentServer #{state.id} spawned child #{child_id} with tag #{inspect(tag)}"
+            )
+
+            {:ok, new_state}
+
+          {:error, reason} ->
+            Logger.error(
+              "AgentServer #{state.id} failed to spawn child with restart #{inspect(restart)}: #{inspect(reason)}"
+            )
+
+            {:ok, state}
+        end
 
       {:error, reason} ->
-        Logger.error("AgentServer #{state.id} failed to spawn child: #{inspect(reason)}")
+        Logger.error("AgentServer #{state.id} failed to spawn child: #{reason}")
         {:ok, state}
     end
   end

--- a/test/examples/runtime/spawn_agent_test.exs
+++ b/test/examples/runtime/spawn_agent_test.exs
@@ -8,6 +8,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
   - Child can access parent info via state.__parent__
   - Using emit_to_parent/3 for child-to-parent communication
   - StopChild directive to gracefully stop tracked children
+  - SpawnAgent children default to `restart: :transient`
   - Parent tracks children in state.children map
 
   ## Key Patterns
@@ -17,6 +18,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
   3. Child state contains `__parent__` with ParentRef (pid, id, tag, meta)
   4. Use `Directive.emit_to_parent(agent, signal)` from child actions
   5. Use `Directive.stop_child(:tag)` to stop a tracked child
+  6. Override `restart:` only for children that should survive crashes or clean stops
 
   Run with: mix test --include example
   """
@@ -36,18 +38,25 @@ defmodule JidoExampleTest.SpawnAgentTest do
 
   defmodule SpawnWorkerAction do
     @moduledoc false
+    @restart_policies Directive.valid_restart_policies()
+
     use Jido.Action,
       name: "spawn_worker",
       schema: [
         tag: [type: :atom, required: true],
-        meta: [type: :map, default: %{}]
+        meta: [type: :map, default: %{}],
+        restart: [type: {:in, @restart_policies}, default: :transient]
       ]
 
     def run(%{tag: tag} = params, _context) do
       meta = Map.get(params, :meta, %{})
+      restart = Map.get(params, :restart, :transient)
 
       directive =
-        Directive.spawn_agent(JidoExampleTest.SpawnAgentTest.WorkerAgent, tag, meta: meta)
+        Directive.spawn_agent(JidoExampleTest.SpawnAgentTest.WorkerAgent, tag,
+          meta: meta,
+          restart: restart
+        )
 
       {:ok, %{last_spawned: tag}, [directive]}
     end
@@ -104,7 +113,7 @@ defmodule JidoExampleTest.SpawnAgentTest do
       ]
 
     def run(%{tag: tag, reason: reason}, _context) do
-      directive = Directive.stop_child(tag, reason: reason)
+      directive = Directive.stop_child(tag, reason)
       {:ok, %{last_stopped: tag}, [directive]}
     end
   end
@@ -359,6 +368,71 @@ defmodule JidoExampleTest.SpawnAgentTest do
         not Map.has_key?(state.children, :stopable_worker)
       end)
 
+      eventually(fn -> Jido.whereis(jido, child_info.id) == nil end)
+
+      {:ok, parent_state} = AgentServer.state(parent_pid)
+
+      assert Enum.count(parent_state.agent.state.child_started_events, fn event ->
+               event.tag == :stopable_worker
+             end) == 1
+
+      DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), parent_pid)
+    end
+  end
+
+  describe "restarted children rebind and still notify parent" do
+    test "parent tracks restarted child and still receives child.started", %{jido: jido} do
+      parent_id = unique_id("parent")
+      {:ok, parent_pid} = Jido.start_agent(jido, ParentAgent, id: parent_id)
+
+      signal =
+        Signal.new!(
+          "spawn_worker",
+          %{tag: :restarting_worker, restart: :permanent},
+          source: "/test"
+        )
+
+      {:ok, _agent} = AgentServer.call(parent_pid, signal)
+
+      child_info = await_child(parent_pid, :restarting_worker)
+      child_pid = child_info.pid
+      child_ref = Process.monitor(child_pid)
+
+      GenServer.stop(child_pid, :boom)
+      assert_receive {:DOWN, ^child_ref, :process, ^child_pid, :boom}, 1000
+
+      eventually(fn ->
+        case AgentServer.state(parent_pid) do
+          {:ok, state} ->
+            case Map.get(state.children, :restarting_worker) do
+              %{pid: pid} when is_pid(pid) -> pid != child_pid
+              _ -> false
+            end
+
+          _ ->
+            false
+        end
+      end)
+
+      restarted_child = await_child(parent_pid, :restarting_worker, 1000)
+      refute restarted_child.pid == child_pid
+      assert restarted_child.id == child_info.id
+      assert Jido.whereis(jido, child_info.id) == restarted_child.pid
+
+      eventually_state(parent_pid, fn state ->
+        Enum.any?(state.agent.state.child_started_events, &(&1.pid == restarted_child.pid))
+      end)
+
+      {:ok, parent_state} = AgentServer.state(parent_pid)
+
+      assert Enum.any?(parent_state.agent.state.child_started_events, &(&1.pid == child_pid))
+
+      assert Enum.any?(
+               parent_state.agent.state.child_started_events,
+               &(&1.pid == restarted_child.pid)
+             )
+
+      DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), restarted_child.pid)
       DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), parent_pid)
     end
   end

--- a/test/jido/actions/lifecycle_test.exs
+++ b/test/jido/actions/lifecycle_test.exs
@@ -85,7 +85,8 @@ defmodule JidoTest.Actions.LifecycleTest do
         agent_module: SomeWorker,
         tag: :worker_1,
         initial_state: %{batch_size: 100},
-        meta: %{assigned: true}
+        meta: %{assigned: true},
+        restart: :permanent
       }
 
       {:ok, result, [directive]} = Lifecycle.SpawnChild.run(params, %{})
@@ -96,6 +97,7 @@ defmodule JidoTest.Actions.LifecycleTest do
       assert directive.tag == :worker_1
       assert directive.opts == %{initial_state: %{batch_size: 100}}
       assert directive.meta == %{assigned: true}
+      assert directive.restart == :permanent
     end
 
     test "uses empty opts when no initial_state" do
@@ -103,12 +105,14 @@ defmodule JidoTest.Actions.LifecycleTest do
         agent_module: SomeWorker,
         tag: :worker_2,
         initial_state: %{},
-        meta: %{}
+        meta: %{},
+        restart: :transient
       }
 
       {:ok, _result, [directive]} = Lifecycle.SpawnChild.run(params, %{})
 
       assert directive.opts == %{}
+      assert directive.restart == :transient
     end
   end
 

--- a/test/jido/agent/directive_test.exs
+++ b/test/jido/agent/directive_test.exs
@@ -57,6 +57,7 @@ defmodule JidoTest.Agent.DirectiveTest do
       assert directive.tag == :worker_1
       assert directive.opts == %{}
       assert directive.meta == %{}
+      assert directive.restart == :transient
     end
 
     test "creates SpawnAgent directive with opts" do
@@ -65,12 +66,14 @@ defmodule JidoTest.Agent.DirectiveTest do
 
       assert directive.opts == %{initial_state: %{batch: 100}}
       assert directive.meta == %{}
+      assert directive.restart == :transient
     end
 
     test "creates SpawnAgent directive with meta" do
       directive = Directive.spawn_agent(MyAgent, :handler, meta: %{topic: "events"})
       assert directive.opts == %{}
       assert directive.meta == %{topic: "events"}
+      assert directive.restart == :transient
     end
 
     test "creates SpawnAgent directive with both opts and meta" do
@@ -82,6 +85,13 @@ defmodule JidoTest.Agent.DirectiveTest do
 
       assert directive.opts == %{id: "custom"}
       assert directive.meta == %{assigned: true}
+      assert directive.restart == :transient
+    end
+
+    test "creates SpawnAgent directive with explicit restart policy" do
+      directive = Directive.spawn_agent(MyAgent, :durable, restart: :permanent)
+
+      assert directive.restart == :permanent
     end
   end
 

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -122,6 +122,28 @@ defmodule JidoTest.AgentServerTest do
       assert AgentServer.whereis(Jido.registry_name(jido), "dynamic-test") == pid
       DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), pid)
     end
+
+    test "retains permanent restart semantics for directly started agents", %{jido: jido} do
+      id = "dynamic-restart-test"
+      {:ok, pid} = AgentServer.start(agent: TestAgent, id: id, jido: jido)
+      ref = Process.monitor(pid)
+
+      GenServer.stop(pid, :normal)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+
+      eventually(fn ->
+        case AgentServer.whereis(Jido.registry_name(jido), id) do
+          new_pid when is_pid(new_pid) -> new_pid != pid and Process.alive?(new_pid)
+          _ -> false
+        end
+      end)
+
+      restarted_pid = AgentServer.whereis(Jido.registry_name(jido), id)
+      assert is_pid(restarted_pid)
+      refute restarted_pid == pid
+
+      DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), restarted_pid)
+    end
   end
 
   describe "call/3 (sync)" do

--- a/test/jido/agent_server/hierarchy_test.exs
+++ b/test/jido/agent_server/hierarchy_test.exs
@@ -36,7 +36,8 @@ defmodule JidoTest.AgentServer.HierarchyTest do
     def run(%{module: mod, tag: tag} = params, _context) do
       opts = Map.get(params, :opts, %{})
       meta = Map.get(params, :meta, %{})
-      {:ok, %{}, [Directive.spawn_agent(mod, tag, opts: opts, meta: meta)]}
+      restart = Map.get(params, :restart, :transient)
+      {:ok, %{}, [Directive.spawn_agent(mod, tag, opts: opts, meta: meta, restart: restart)]}
     end
   end
 
@@ -558,6 +559,49 @@ defmodule JidoTest.AgentServer.HierarchyTest do
       assert event.tag == :dying_child
       assert event.reason == :shutdown
 
+      DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), parent_pid)
+    end
+
+    test "rebinds restarted child info when child restarts", %{jido: jido} do
+      parent_id = unique_id("spawn-parent")
+      {:ok, parent_pid} = AgentServer.start(agent: ParentAgent, id: parent_id, jido: jido)
+
+      signal =
+        Signal.new!(
+          "spawn_agent",
+          %{module: ChildAgent, tag: :restarting_child, restart: :permanent},
+          source: "/test"
+        )
+
+      {:ok, _agent} = AgentServer.call(parent_pid, signal)
+
+      child_info = await_child(parent_pid, :restarting_child)
+      child_pid = child_info.pid
+      child_ref = Process.monitor(child_pid)
+
+      GenServer.stop(child_pid, :boom)
+      assert_receive {:DOWN, ^child_ref, :process, ^child_pid, :boom}, 500
+
+      eventually(fn ->
+        case AgentServer.state(parent_pid) do
+          {:ok, state} ->
+            case Map.get(state.children, :restarting_child) do
+              %{pid: pid} when is_pid(pid) -> pid != child_pid
+              _ -> false
+            end
+
+          _ ->
+            false
+        end
+      end)
+
+      restarted_child = await_child(parent_pid, :restarting_child, 1000)
+      refute restarted_child.pid == child_pid
+      assert restarted_child.id == child_info.id
+      assert restarted_child.tag == :restarting_child
+      assert Jido.whereis(jido, child_info.id) == restarted_child.pid
+
+      DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), restarted_child.pid)
       DynamicSupervisor.terminate_child(Jido.agent_supervisor_name(jido), parent_pid)
     end
 


### PR DESCRIPTION
## Summary
- default SpawnAgent children to transient restart semantics while keeping direct AgentServer starts permanent
- preserve StopChild as the graceful jido.agent.stop path and rebind parent child tracking on child restarts
- expose restart policy on SpawnAgent and Lifecycle.SpawnChild and update the runtime docs/examples

## Testing
- elixir -e 'Application.put_env(:git_hooks, :auto_install, false, persistent: true)' -S mix test test/jido/agent/directive_test.exs test/jido/actions/lifecycle_test.exs test/jido/agent_server/hierarchy_test.exs test/jido/agent_server/agent_server_test.exs test/jido/agent_server/directive_exec_test.exs
- elixir -e 'Application.put_env(:git_hooks, :auto_install, false, persistent: true)' -S mix test --include example test/examples/runtime/spawn_agent_test.exs test/examples/runtime/parent_child_test.exs test/examples/runtime/hierarchical_agents_test.exs

Fixes #185