### PR TITLE
fix: preserve plugin_specs structs for Dialyzer

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -1125,8 +1125,8 @@ defmodule Jido.Agent do
 
         # Build plugin specs from instances (for backward compatibility)
         @plugin_specs Enum.map(@plugin_instances, fn instance ->
-                        instance.module.plugin_spec(instance.config)
-                        |> Map.put(:state_key, instance.state_key)
+                        spec = instance.module.plugin_spec(instance.config)
+                        %{spec | state_key: instance.state_key}
                       end)
 
         # Validate unique state_keys (now derived from instances)

--- a/test/jido/agent_plugin_integration_test.exs
+++ b/test/jido/agent_plugin_integration_test.exs
@@ -861,6 +861,17 @@ defmodule JidoTest.AgentPluginIntegrationTest do
       assert :slack_sales in state_keys
     end
 
+    test "plugin_specs/0 preserves Spec structs for aliased instances" do
+      specs = MultiSlackAgent.plugin_specs()
+
+      assert length(specs) == 2
+      assert Enum.all?(specs, &match?(%Spec{}, &1))
+
+      state_keys = Enum.map(specs, & &1.state_key)
+      assert :slack_support in state_keys
+      assert :slack_sales in state_keys
+    end
+
     test "instances have different route_prefixes" do
       instances = MultiSlackAgent.plugin_instances()
 


### PR DESCRIPTION
## Summary
- preserve `Jido.Plugin.Spec` structs when generating agent `plugin_specs/0`
- add regression coverage for aliased plugin instances
- keep the generated `plugin_specs/0` contract aligned with Dialyzer inference

## Testing
- mix test test/jido/agent_plugin_integration_test.exs
- mix dialyzer --format short

Closes #187