### PR TITLE
fix: Improve typespec precision

### DIFF
--- a/lib/jido.ex
+++ b/lib/jido.ex
@@ -85,7 +85,7 @@ defmodule Jido do
       @jido_storage Jido.Storage.normalize_storage(unquote(Macro.escape(storage)))
 
       @doc false
-      @spec __otp_app__() :: atom()
+      @spec __otp_app__() :: unquote(otp_app)
       def __otp_app__, do: @otp_app
 
       @doc "Returns the storage configuration for this Jido instance."
@@ -100,6 +100,9 @@ defmodule Jido do
                          unquote(Macro.escape(default_plugins))
                        )
 
+      # The typespec for __default_plugins__ triggers a `contract_supertype`
+      # warning from dialyzer.
+      @dialyzer {:nowarn_function, [__default_plugins__: 0]}
       @doc "Returns the default plugins for agents bound to this Jido instance."
       @spec __default_plugins__() :: [module() | {module(), map()}]
       def __default_plugins__, do: @default_plugins
@@ -206,7 +209,7 @@ defmodule Jido do
       @spec debug() :: Jido.Debug.level()
       def debug, do: Jido.Debug.level(__MODULE__)
 
-      @spec debug(Jido.Debug.level() | pid()) :: :ok | Jido.Debug.level()
+      @spec debug(Jido.Debug.level() | pid()) :: :ok | {:error, term()} | Jido.Debug.level()
       def debug(pid) when is_pid(pid), do: Jido.AgentServer.set_debug(pid, true)
       def debug(level) when is_atom(level), do: Jido.Debug.enable(__MODULE__, level)
 


### PR DESCRIPTION
The type for `__otp_app__` wasn't as precise as it could be. Similarly, the type for `debug` left out the error tuple that `AgentServer.set_debug` can return.

The `__default_plugins__` function triggers a `contract_supertype` warning from Dialyzer, but I haven't found a good way to fix that. For now, I've silenced the warning so downstream projects aren't bothered by it.

I'm not sure how to add tests, but the warnings arose from me when I used `use Jido` in my own project which has `contract_supertype` and other dialyzer warnings enabled.

## Description

Brief description of changes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

