### PR TITLE
fix(sensor): deliver subscription signals to via refs

### DIFF
--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -305,6 +305,9 @@ defmodule Jido.Sensor.Runtime do
       is_pid(agent_ref) ->
         send(agent_ref, {:signal, signal})
 
+      is_pid(server_pid = resolve_server_pid(agent_ref)) ->
+        send(server_pid, {:signal, signal})
+
       agent_ref != nil ->
         dispatch_signal_async(signal, agent_ref, state)
 
@@ -341,6 +344,22 @@ defmodule Jido.Sensor.Runtime do
 
     :ok
   end
+
+  defp resolve_server_pid(agent_ref) when is_atom(agent_ref), do: GenServer.whereis(agent_ref)
+
+  defp resolve_server_pid({name, node} = agent_ref) when is_atom(name) and is_atom(node) do
+    GenServer.whereis(agent_ref)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp resolve_server_pid({:via, _, _} = agent_ref) do
+    GenServer.whereis(agent_ref)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp resolve_server_pid(_agent_ref), do: nil
 
   defp dispatch_fun(state) do
     case get_in(state, [:context, :dispatch_fun]) do

--- a/test/jido/agent_server/plugin_subscriptions_test.exs
+++ b/test/jido/agent_server/plugin_subscriptions_test.exs
@@ -107,6 +107,20 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     def run(_params, _context), do: {:ok, %{}}
   end
 
+  defmodule RecordSensorSignalAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "record_sensor_signal",
+      schema: [
+        value: [type: :any, required: true],
+        count: [type: :integer, required: true]
+      ]
+
+    def run(params, _context) do
+      {:ok, %{last_sensor_value: params.value, last_sensor_count: params.count}}
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Test Plugin Modules
   # ---------------------------------------------------------------------------
@@ -166,6 +180,26 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       actions: [JidoTest.AgentServer.PluginSubscriptionsTest.SimpleAction]
   end
 
+  defmodule PluginWithRoutedSensor do
+    @moduledoc false
+    use Jido.Plugin,
+      name: "plugin_with_routed_sensor",
+      state_key: :routed_sensor,
+      actions: [JidoTest.AgentServer.PluginSubscriptionsTest.SimpleAction]
+
+    @impl Jido.Plugin
+    def subscriptions(_config, context) do
+      [
+        {JidoTest.AgentServer.PluginSubscriptionsTest.TestSensor,
+         %{
+           emit_on_init: false,
+           signal_type: "plugin.sensor.delivered",
+           agent_ref: context.agent_ref
+         }}
+      ]
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Test Agent Modules
   # ---------------------------------------------------------------------------
@@ -175,6 +209,21 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     use Jido.Agent,
       name: "agent_with_sensor_plugin",
       plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithSensor]
+  end
+
+  defmodule AgentWithRoutedSensorPlugin do
+    @moduledoc false
+    use Jido.Agent,
+      name: "agent_with_routed_sensor_plugin",
+      schema: [
+        last_sensor_value: [type: :any, default: nil],
+        last_sensor_count: [type: :integer, default: 0]
+      ],
+      plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithRoutedSensor],
+      signal_routes: [
+        {"plugin.sensor.delivered",
+         JidoTest.AgentServer.PluginSubscriptionsTest.RecordSensorSignalAction}
+      ]
   end
 
   defmodule PluginWithStaticSubscriptions do
@@ -308,7 +357,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
   describe "signal delivery to agent" do
     test "sensor signals are delivered to the agent", %{jido: jido} do
-      {:ok, pid} = Jido.AgentServer.start_link(agent: AgentWithSensorPlugin, jido: jido)
+      {:ok, pid} = Jido.AgentServer.start_link(agent: AgentWithRoutedSensorPlugin, jido: jido)
 
       {:ok, state} = Jido.AgentServer.state(pid)
 
@@ -320,7 +369,14 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       Runtime.event(child_info.pid, {:trigger, :test_value})
 
-      Process.sleep(50)
+      state =
+        eventually_state(pid, fn state ->
+          state.agent.state.last_sensor_value == :test_value and
+            state.agent.state.last_sensor_count == 1
+        end)
+
+      assert state.agent.state.last_sensor_value == :test_value
+      assert state.agent.state.last_sensor_count == 1
 
       GenServer.stop(pid)
     end

--- a/test/jido/sensor/runtime_test.exs
+++ b/test/jido/sensor/runtime_test.exs
@@ -167,6 +167,26 @@ defmodule JidoTest.Sensor.RuntimeTest do
     end
   end
 
+  defmodule SignalReceiver do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, Keyword.fetch!(opts, :test_pid),
+        name: Keyword.get(opts, :name)
+      )
+    end
+
+    @impl GenServer
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl GenServer
+    def handle_info({:signal, signal}, test_pid) do
+      send(test_pid, {:received_signal, signal})
+      {:noreply, test_pid}
+    end
+  end
+
   defmodule RequiredFieldSensor do
     @moduledoc false
     use Jido.Sensor,
@@ -528,6 +548,30 @@ defmodule JidoTest.Sensor.RuntimeTest do
   end
 
   describe "signal delivery via async dispatch" do
+    test "resolves registry via tuples before dispatching" do
+      registry = :"sensor_runtime_registry_#{System.unique_integer([:positive])}"
+      receiver_name = {:via, Registry, {registry, "sensor-receiver"}}
+
+      {:ok, _registry_pid} = Registry.start_link(keys: :unique, name: registry)
+      {:ok, receiver_pid} = SignalReceiver.start_link(test_pid: self(), name: receiver_name)
+
+      {:ok, pid} =
+        Runtime.start_link(
+          sensor: SimpleSensor,
+          config: %{prefix: "via"},
+          context: %{agent_ref: receiver_name}
+        )
+
+      :ok = Runtime.event(pid, {:data, 42})
+
+      assert_receive {:received_signal, signal}, 200
+      assert signal.type == "via.data.received"
+      assert signal.data.value == 42
+
+      GenServer.stop(pid)
+      GenServer.stop(receiver_pid)
+    end
+
     test "dispatches to non-pid agent_ref using context dispatch_fun/2" do
       test_pid = self()
 


### PR DESCRIPTION
## Summary
- follow up to #198
- replace the sleep-based subscription delivery test with an `eventually_state/3` assertion against agent-visible state
- resolve registry `via` refs before sensor delivery so plugin subscription sensors can actually reach `AgentServer`
- add a focused runtime regression test for `via` tuple delivery

## Why
Strengthening the test from #198 exposed that subscription sensors were started with a registry `via` ref, but `Jido.Sensor.Runtime` only delivered directly to pids and otherwise fell through to generic async dispatch. The previous test masked that because it never asserted agent-side delivery.

## Verification
- `MIX_ENV=test mix test test/jido/sensor/runtime_test.exs`
- `MIX_ENV=test mix test test/jido/agent_server/plugin_subscriptions_test.exs`