### PR TITLE
fix: misplaced end in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ defmodule MyAgent do
     schema: [
       count: [type: :integer, default: 0]
     ]
-  end
 end
 
 {agent, directives} = MyAgent.cmd(agent, action)


### PR DESCRIPTION
## Summary

Removes a misplaced `end` in a code example in the README.
