### PR TITLE
fix(agent_server): always wrap parent-down reason as `{:shutdown, _}`

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -2336,12 +2336,12 @@ defmodule Jido.AgentServer do
   defp notify_parent_of_startup(_state), do: :ok
 
   defp handle_parent_down(%State{on_parent_death: :stop} = state, _pid, reason) do
-    Logger.info("AgentServer #{state.id} stopping: parent died (#{inspect(reason)})")
-    # Wrap the stop reason so OTP treats it as a clean shutdown (no error logs).
-    # OTP considers :normal, :shutdown, and {:shutdown, term} as "normal" exits.
-    # Benign reasons: :normal (parent stopped normally), :noproc (parent already gone),
-    # :shutdown (parent shutting down), {:shutdown, _} (parent shutdown with reason).
     stop_reason = wrap_parent_down_reason(reason)
+
+    Logger.info(
+      "AgentServer #{state.id} stopping: parent died (#{inspect(reason)}), wrapped stop_reason: #{inspect(stop_reason)}"
+    )
+
     {:stop, stop_reason, State.set_status(state, :stopping)}
   end
 
@@ -2403,7 +2403,7 @@ defmodule Jido.AgentServer do
   defp wrap_parent_down_reason(:noproc), do: {:shutdown, {:parent_down, :noproc}}
   defp wrap_parent_down_reason(:shutdown), do: {:shutdown, {:parent_down, :shutdown}}
   defp wrap_parent_down_reason({:shutdown, _} = r), do: {:shutdown, {:parent_down, r}}
-  defp wrap_parent_down_reason(reason), do: {:parent_down, reason}
+  defp wrap_parent_down_reason(reason), do: {:shutdown, {:parent_down, reason}}
 
   # ---------------------------------------------------------------------------
   # Internal: Telemetry

--- a/test/jido/agent_server/hierarchy_test.exs
+++ b/test/jido/agent_server/hierarchy_test.exs
@@ -200,6 +200,41 @@ defmodule JidoTest.AgentServer.HierarchyTest do
 
       assert reason in [:shutdown, :noproc]
     end
+
+    test "child exits with {:shutdown, _} even when parent crashes abnormally", %{jido: jido} do
+      # Start parent linked to test process
+      {:ok, parent_pid} =
+        AgentServer.start_link(agent: ParentAgent, id: "parent-crash-1", jido: jido)
+
+      parent_ref = ParentRef.new!(%{pid: parent_pid, id: "parent-crash-1", tag: :worker})
+
+      # Start child linked to test process (not under DynamicSupervisor)
+      # so it won't be restarted
+      {:ok, child_pid} =
+        AgentServer.start_link(
+          agent: ChildAgent,
+          id: "child-crash-1",
+          parent: parent_ref,
+          on_parent_death: :stop,
+          jido: jido
+        )
+
+      # Verify child is alive and monitoring parent
+      assert Process.alive?(child_pid)
+      child_ref = Process.monitor(child_pid)
+
+      # Crash parent with an abnormal reason.
+      # Trap exits so we don't die along with the linked parent/child.
+      Process.flag(:trap_exit, true)
+      Process.exit(parent_pid, {:function_clause, :simulated_crash})
+
+      # Wait for child to die
+      assert_receive {:DOWN, ^child_ref, :process, ^child_pid, exit_reason}, 5000
+
+      # The child should always exit with {:shutdown, _} so supervisors
+      # with :transient restart policy do not restart it.
+      assert {:shutdown, {:parent_down, _}} = exit_reason
+    end
   end
 
   describe "on_parent_death: :continue" do
@@ -396,15 +431,13 @@ defmodule JidoTest.AgentServer.HierarchyTest do
       Process.exit(parent_pid, :kill)
 
       # Child should stop when parent dies - reason may be :killed or :noproc
-      # depending on timing (whether parent is still dying or already dead)
-      # :killed is not a benign reason, so it stays unwrapped as {:parent_down, :killed}
-      # :noproc is benign, so it becomes {:shutdown, {:parent_down, :noproc}}
+      # depending on timing (whether parent is still dying or already dead).
+      # All parent-down reasons are wrapped as {:shutdown, {:parent_down, _}}
+      # so supervisors with :transient restart policy do not restart the child.
       assert_receive {:DOWN, ^child_ref, :process, ^child_pid, exit_reason}, 1000
 
-      assert exit_reason in [
-               {:parent_down, :killed},
-               {:shutdown, {:parent_down, :noproc}}
-             ]
+      assert {:shutdown, {:parent_down, inner}} = exit_reason
+      assert inner in [:killed, :noproc]
     end
   end
 


### PR DESCRIPTION
## Description

The catch-all clause of `wrap_parent_down_reason/1` returned a bare `{:parent_down, reason}` tuple, which OTP treats as abnormal. This caused supervisors with `:transient` restart to respawn children that should stay dead after a parent crash.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

It's debatable. The exit reason is observable externally via `Process.monitor` / `:DOWN` messages and conceivably people are pattern-matching on it. Would you like me to reopen this with a `fix!` designation?

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
