### PR TITLE
feat(agent_server): add query/2 for server-side state reduction

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -328,6 +328,24 @@ defmodule Jido.AgentServer do
   end
 
   @doc """
+  Run a function against the server state and return only its result.
+
+  The function executes inside the AgentServer process, so only the
+  return value crosses the process boundary — avoiding a full state copy.
+
+      {:ok, rev} = Jido.AgentServer.query(pid, fn state ->
+        state.agent |> Jido.Thread.Agent.get() |> Map.get(:rev)
+      end)
+  """
+  @spec query(server(), (State.t() -> result)) :: {:ok, result} | {:error, term()}
+        when result: term()
+  def query(server, fun) when is_function(fun, 1) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, {:query, fun})
+    end
+  end
+
+  @doc """
   Wait for an agent to reach a terminal status (`:completed` or `:failed`).
 
   This is an event-driven wait - the caller blocks until the agent's state
@@ -983,6 +1001,10 @@ defmodule Jido.AgentServer do
       {:cont, new_state} -> {:reply, :ok, new_state}
       {:stop, reason, new_state} -> {:stop, reason, :ok, new_state}
     end
+  end
+
+  def handle_call({:query, fun}, _from, state) when is_function(fun, 1) do
+    {:reply, {:ok, fun.(state)}, state}
   end
 
   def handle_call(_msg, _from, state) do

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -334,6 +334,31 @@ defmodule JidoTest.AgentServerTest do
     end
   end
 
+  describe "query/2" do
+    test "runs function server-side and returns result", %{jido: jido} do
+      {:ok, pid} = AgentServer.start_link(agent: TestAgent, id: "query-test", jido: jido)
+
+      {:ok, id} = AgentServer.query(pid, fn state -> state.id end)
+      assert id == "query-test"
+
+      {:ok, counter} = AgentServer.query(pid, fn state -> state.agent.state.counter end)
+      assert counter == 0
+
+      GenServer.stop(pid)
+    end
+
+    test "raising function crashes the server", %{jido: jido} do
+      {:ok, pid} = AgentServer.start(agent: TestAgent, id: "query-crash-test", jido: jido)
+      ref = Process.monitor(pid)
+
+      catch_exit do
+        AgentServer.query(pid, fn _state -> raise "boom" end)
+      end
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    end
+  end
+
   describe "whereis/1 and whereis/2" do
     test "whereis/1 returns pid for registered agent using default registry", %{jido: jido} do
       {:ok, pid} = AgentServer.start_link(agent: TestAgent, id: "whereis-test-1", jido: jido)


### PR DESCRIPTION
## Description

`AgentServer.state/1` copies the entire server state across the process boundary. Callers that need a single field (e.g. thread rev) pay O(state_size) for an O(1) lookup. `query/2` runs a caller-supplied function inside the server and returns only its result, keeping the cost proportional to the result rather than the state.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
