### PR TITLE
docs: clarify what Jido is in HexDocs home

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 [![License](https://img.shields.io/hexpm/l/jido.svg)](https://github.com/agentjido/jido/blob/main/LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/agentjido/jido/badge.svg?branch=main)](https://coveralls.io/github/agentjido/jido?branch=main)
 
-> **Pure functional agents and OTP runtime for building autonomous multi-agent workflows in Elixir.**
+> **Jido is an autonomous agent framework for Elixir, built for workflows and multi-agent systems.**
+
+Define agents, connect them to actions, signals, and directives, and run them
+with supervision and fault tolerance built in.
 
 _The name "Jido" (自動) comes from the Japanese word meaning "automatic" or "automated", where 自 (ji) means "self" and 動 (dō) means "movement"._
 
@@ -14,7 +17,20 @@ _Learn more about Jido at [agentjido.xyz](https://agentjido.xyz)._
 
 ## Overview
 
-With Jido, your agents are immutable data structures with a single command function:
+Jido helps you build agent systems as ordinary Elixir and OTP software.
+
+- Agents hold state and implement `cmd/2`
+- Actions do work and transform that state
+- Signals route events into the system
+- Directives describe effects for the runtime to execute
+
+Use Jido when software needs to inspect context, choose among multiple steps,
+coordinate with other agents, and keep running reliably over time.
+
+AI is optional. The core package gives you the agent architecture and runtime;
+companion packages such as `jido_ai` add model integration when you need it.
+
+At the core, Jido agents are immutable data structures with a single command function:
 
 ```elixir
 defmodule MyAgent do

--- a/guides/core-loop.md
+++ b/guides/core-loop.md
@@ -2,7 +2,11 @@
 
 **After:** You can explain Jido in one sentence: "Signal → Action → cmd/2 → {agent, directives} → runtime executes directives."
 
-This guide explains the mental model behind Jido — an Elm/Redux-inspired agent framework for Elixir.
+This guide explains the mental model behind Jido, an autonomous agent framework
+for Elixir built for workflows and multi-agent systems.
+
+Jido combines immutable agents, actions, signals, directives, and an OTP
+runtime so you can build agent systems as ordinary Elixir software.
 
 ## The Elm/Redux Pattern
 

--- a/lib/jido.ex
+++ b/lib/jido.ex
@@ -5,7 +5,8 @@ defmodule Jido do
   alias Jido.Config.Defaults
 
   @moduledoc """
-  自動 (Jido) - A foundational framework for building autonomous, distributed agent systems in Elixir.
+  自動 (Jido) - An autonomous agent framework for Elixir, built for workflows and
+  multi-agent systems.
 
   ## Quick Start
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Jido.MixProject do
       # Docs
       name: "Jido",
       description:
-        "Pure functional agents and OTP runtime for building autonomous multi-agent workflows in Elixir.",
+        "An autonomous agent framework for Elixir, built for workflows and multi-agent systems.",
       source_url: "https://github.com/agentjido/jido",
       homepage_url: "https://github.com/agentjido/jido",
       package: package(),


### PR DESCRIPTION
## Summary
- replace the HexDocs home opener with a plain-language description of what Jido is
- explain the core building blocks before the first code example so readers understand the framework at a glance
- align the package description, top-level moduledoc, and Core Loop guide with the same positioning

Fixes #209

## Testing
- `MIX_ENV=test mix compile`
- `mix docs` is currently blocked in worktrees because `git_hooks` assumes `.git` is a directory during dependency compilation