### PR TITLE
docs(storage): document append-only follow-up events

### DIFF
--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -251,6 +251,40 @@ defmodule MyAgent do
 end
 ```
 
+### Thread Plugin
+
+The Thread plugin stores `agent.state[:__thread__]` as an append-only journal of
+what happened. Thread entries should be treated as immutable facts.
+
+If external metadata arrives later, append a follow-up entry that points back
+to the original entry instead of updating it in place. The caller supplies a
+stable `entry_id` up front so later events can reference it:
+
+```elixir
+alias Jido.Thread.Agent, as: ThreadAgent
+
+entry_id = "entry_" <> Jido.Util.generate_id()
+
+agent =
+  ThreadAgent.append(agent, %{
+    id: entry_id,
+    kind: :message,
+    payload: %{role: "assistant", content: "hello"}
+  })
+
+agent =
+  ThreadAgent.append(agent, %{
+    kind: :message_committed,
+    payload: %{provider: :slack, remote_id: slack_ts},
+    refs: %{entry_id: entry_id}
+  })
+```
+
+This is the preferred way to model late provider acknowledgements, delivery
+receipts, and similar metadata while preserving thread history. For the
+rationale and a more general pattern, see
+[Persistence & Storage](storage.md#modeling-late-metadata-with-follow-up-events).
+
 ### Memory Plugin
 
 The Memory plugin gives every agent an on-demand cognitive memory container stored at `agent.state[:__memory__]`. Memory is organized into **spaces** — named containers holding either map (key-value) or list (ordered items) data. Two reserved spaces, `:world` and `:tasks`, are created by default. Domain-specific wrappers should be built in your own modules on top of the generic space primitives.

--- a/guides/storage.md
+++ b/guides/storage.md
@@ -86,6 +86,54 @@ This prevents:
 - Consistency drift when checkpoint and journal get out of sync
 - Memory bloat in serialized checkpoints
 
+### Modeling Late Metadata with Follow-Up Events
+
+When metadata arrives after an entry has already been appended, record it as a
+new fact instead of mutating the original entry.
+
+This comes up often with external providers. For example, an assistant message
+may be appended to the thread before Slack returns the final message `ts`. In
+that case, supply a stable `entry_id` up front, then append a second entry that
+points back to the original message by `entry_id`:
+
+```elixir
+alias Jido.Thread.Agent, as: ThreadAgent
+
+entry_id = "entry_" <> Jido.Util.generate_id()
+
+agent =
+  ThreadAgent.append(agent, %{
+    id: entry_id,
+    kind: :message,
+    payload: %{role: "assistant", content: "Working on it"}
+  })
+
+agent =
+  ThreadAgent.append(agent, %{
+    kind: :message_committed,
+    payload: %{provider: :slack, remote_id: slack_ts},
+    refs: %{entry_id: entry_id}
+  })
+```
+
+You can also model this as a more generic annotation entry:
+
+```elixir
+agent =
+  ThreadAgent.append(agent, %{
+    kind: :annotation,
+    payload: %{type: :provider_ref, provider: :slack, remote_id: slack_ts},
+    refs: %{entry_id: entry_id}
+  })
+```
+
+This keeps the journal canonical and append-only:
+
+- The original message remains immutable
+- Journal-backed storage and thawed agents see the same history
+- Read models can fold follow-up events into a resolved "message plus provider metadata" view
+- The same pattern works for retries, edits, deletes, delivery failures, and acknowledgements
+
 ### Scheduler Manifest Invariant
 
 Dynamic cron durability is stored as a scheduler manifest under


### PR DESCRIPTION
## Summary
- document the append-only pattern for late provider metadata in the storage guide
- add a Thread plugin note showing how to append a follow-up event linked by `entry_id`
- keep this as a docs-only follow-up separate from PR #210

## Testing
- not run (docs-only change)
