### PR TITLE
feat(agent_server): add `append_thread_entry/2`

### DIFF
--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -285,6 +285,17 @@ receipts, and similar metadata while preserving thread history. For the
 rationale and a more general pattern, see
 [Persistence & Storage](storage.md#modeling-late-metadata-with-follow-up-events).
 
+When appending from an external process (outside the agent), use
+`Jido.AgentServer.append_thread_entry/2`:
+
+```elixir
+:ok = Jido.AgentServer.append_thread_entry(agent_pid, %{
+  kind: :message_committed,
+  payload: %{provider: :slack, remote_id: slack_ts},
+  refs: %{entry_id: entry_id}
+})
+```
+
 ### Memory Plugin
 
 The Memory plugin gives every agent an on-demand cognitive memory container stored at `agent.state[:__memory__]`. Memory is organized into **spaces** — named containers holding either map (key-value) or list (ordered items) data. Two reserved spaces, `:world` and `:tasks`, are created by default. Domain-specific wrappers should be built in your own modules on top of the generic space primitives.

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -359,6 +359,14 @@ defmodule Jido.AgentServer do
     end
   end
 
+  @doc "Append one or more entries to the agent's thread from an external process."
+  @spec append_thread_entry(server(), map() | [map()]) :: :ok | {:error, term()}
+  def append_thread_entry(server, entry_or_entries) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, {:append_thread_entry, entry_or_entries})
+    end
+  end
+
   @doc """
   Wait for an agent to reach a terminal status (`:completed` or `:failed`).
 
@@ -976,6 +984,11 @@ defmodule Jido.AgentServer do
 
   def handle_call(:get_state, _from, state) do
     {:reply, {:ok, state}, state}
+  end
+
+  def handle_call({:append_thread_entry, entry_or_entries}, _from, %State{} = state) do
+    agent = Jido.Thread.Agent.append(state.agent, entry_or_entries)
+    {:reply, :ok, State.update_agent(state, agent)}
   end
 
   def handle_call({:set_debug, enabled}, _from, %State{} = state) do

--- a/test/jido/agent_server/agent_server_test.exs
+++ b/test/jido/agent_server/agent_server_test.exs
@@ -1075,4 +1075,58 @@ defmodule JidoTest.AgentServerTest do
       assert priority < 0
     end
   end
+
+  describe "append_thread_entry/2" do
+    test "appends a single entry to agent thread", %{jido: jido} do
+      {:ok, pid} = AgentServer.start_link(agent: TestAgent, jido: jido)
+
+      entry = %{
+        kind: :ai_message,
+        payload: %{role: :user, content: "queued event"},
+        refs: %{source: :queued_event}
+      }
+
+      assert :ok = AgentServer.append_thread_entry(pid, entry)
+
+      {:ok, state} = AgentServer.state(pid)
+      thread = Jido.Thread.Agent.get(state.agent)
+
+      assert thread != nil
+      assert length(thread.entries) == 1
+
+      [appended] = thread.entries
+      assert appended.kind == :ai_message
+      assert appended.payload == %{role: :user, content: "queued event"}
+      assert appended.refs == %{source: :queued_event}
+    end
+
+    test "appends multiple entries at once", %{jido: jido} do
+      {:ok, pid} = AgentServer.start_link(agent: TestAgent, jido: jido)
+
+      entries = [
+        %{
+          kind: :ai_message,
+          payload: %{role: :user, content: "first"},
+          refs: %{source: :queued_event}
+        },
+        %{
+          kind: :ai_message,
+          payload: %{role: :assistant, content: "second"},
+          refs: %{source: :queued_event}
+        }
+      ]
+
+      assert :ok = AgentServer.append_thread_entry(pid, entries)
+
+      {:ok, state} = AgentServer.state(pid)
+      thread = Jido.Thread.Agent.get(state.agent)
+
+      assert thread != nil
+      assert length(thread.entries) == 2
+
+      [first, second] = thread.entries
+      assert first.payload == %{role: :user, content: "first"}
+      assert second.payload == %{role: :assistant, content: "second"}
+    end
+  end
 end


### PR DESCRIPTION
## Description

Following up from #210, I'd still need half of that PR, namely `append_thread_entry/2` to append one or more entries to the agent's thread from an external process, enabling append-only workflows where late-arriving metadata is recorded as follow-up entries.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
