### PR TITLE
fix: remove invalid doctest-style doc examples

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -463,10 +463,10 @@ defmodule Jido.Agent do
       For multi-instance plugins, the module appears once regardless of how many
       instances are mounted.
 
-      ## Examples
+      ## Example
 
-          iex> #{inspect(__MODULE__)}.plugins()
-          [SlackPlugin, OpenAIPlugin]
+          MyAgent.plugins()
+          # => [MyApp.SlackPlugin, MyApp.OpenAIPlugin]
       """
       @spec plugins() :: [module()]
       def plugins do
@@ -497,10 +497,10 @@ defmodule Jido.Agent do
       Capabilities are atoms describing what the agent can do based on its
       mounted plugins.
 
-      ## Examples
+      ## Example
 
-          iex> #{inspect(__MODULE__)}.capabilities()
-          [:messaging, :channel_management, :chat, :embeddings]
+          MyAgent.capabilities()
+          # => [:messaging, :channel_management, :chat, :embeddings]
       """
       @spec capabilities() :: [atom()]
       def capabilities do
@@ -514,10 +514,10 @@ defmodule Jido.Agent do
 
       These are the fully-prefixed signal types that the agent can handle.
 
-      ## Examples
+      ## Example
 
-          iex> #{inspect(__MODULE__)}.signal_types()
-          ["slack.post", "slack.channels.list", "openai.chat", ...]
+          MyAgent.signal_types()
+          # => ["slack.post", "slack.channels.list", "openai.chat"]
       """
       @spec signal_types() :: [String.t()]
       def signal_types do

--- a/lib/jido/plugin/config.ex
+++ b/lib/jido/plugin/config.ex
@@ -39,11 +39,11 @@ defmodule Jido.Plugin.Config do
 
   ## Examples
 
-      iex> Config.resolve_config(MyApp.SlackPlugin, %{channel: "#support"})
-      {:ok, %{token: "env-token", channel: "#support"}}
+      Config.resolve_config(MyApp.SlackPlugin, %{channel: "#support"})
+      # => {:ok, %{token: "env-token", channel: "#support"}}
 
-      iex> Config.resolve_config(MyApp.SlackPlugin, %{invalid: "field"})
-      {:error, [%Zoi.Error{...}]}
+      Config.resolve_config(MyApp.SlackPlugin, %{invalid: "field"})
+      # => {:error, validation_errors}
   """
   @spec resolve_config(module(), map()) :: {:ok, map()} | {:error, list()}
   def resolve_config(plugin_module, overrides \\ %{}) do
@@ -58,11 +58,11 @@ defmodule Jido.Plugin.Config do
 
   ## Examples
 
-      iex> Config.resolve_config!(MyApp.SlackPlugin, %{channel: "#support"})
-      %{token: "env-token", channel: "#support"}
+      Config.resolve_config!(MyApp.SlackPlugin, %{channel: "#support"})
+      # => %{token: "env-token", channel: "#support"}
 
-      iex> Config.resolve_config!(MyApp.SlackPlugin, %{invalid: "field"})
-      ** (ArgumentError) Config validation failed for MyApp.SlackPlugin: ...
+      Config.resolve_config!(MyApp.SlackPlugin, %{invalid: "field"})
+      # Raises ArgumentError when the resolved config fails schema validation.
   """
   @spec resolve_config!(module(), map()) :: map()
   def resolve_config!(plugin_module, overrides \\ %{}) do

--- a/lib/jido/plugin/instance.ex
+++ b/lib/jido/plugin/instance.ex
@@ -68,14 +68,14 @@ defmodule Jido.Plugin.Instance do
 
   ## Examples
 
-      iex> Instance.new(MyPlugin)
-      %Instance{module: MyPlugin, as: nil, state_key: :my_plugin, ...}
+      Instance.new(MyPlugin)
+      # => %Instance{module: MyPlugin, as: nil, state_key: :my_plugin}
 
-      iex> Instance.new({MyPlugin, as: :support, token: "abc"})
-      %Instance{module: MyPlugin, as: :support, state_key: :my_plugin_support, ...}
+      Instance.new({MyPlugin, as: :support, token: "abc"})
+      # => %Instance{module: MyPlugin, as: :support, state_key: :my_plugin_support}
 
-      iex> Instance.new({MyPlugin, %{token: "abc"}})
-      %Instance{module: MyPlugin, as: nil, config: %{token: "abc"}, ...}
+      Instance.new({MyPlugin, %{token: "abc"}})
+      # => %Instance{module: MyPlugin, as: nil, config: %{token: "abc"}}
   """
   @spec new(module() | {module(), map() | keyword()}) :: t()
   def new(plugin_declaration) do

--- a/lib/jido/plugin/routes.ex
+++ b/lib/jido/plugin/routes.ex
@@ -50,13 +50,13 @@ defmodule Jido.Plugin.Routes do
 
   ## Examples
 
-      iex> instance = Instance.new(SlackPlugin)  # route_prefix: "slack"
-      iex> expand_routes(instance)
-      [{"slack.post", SlackActions.Post, []}, {"slack.list", SlackActions.List, []}]
+      instance = Instance.new(SlackPlugin)  # route_prefix: "slack"
+      expand_routes(instance)
+      # => [{"slack.post", SlackActions.Post, []}, {"slack.list", SlackActions.List, []}]
 
-      iex> instance = Instance.new({SlackPlugin, as: :support})  # route_prefix: "support.slack"
-      iex> expand_routes(instance)
-      [{"support.slack.post", SlackActions.Post, []}, ...]
+      instance = Instance.new({SlackPlugin, as: :support})  # route_prefix: "support.slack"
+      expand_routes(instance)
+      # => [{"support.slack.post", SlackActions.Post, []}, {"support.slack.list", SlackActions.List, []}]
   """
   @spec expand_routes(Instance.t()) :: [{String.t(), module(), keyword()}]
   def expand_routes(%Instance{} = instance) do

--- a/lib/jido/sensor/spec.ex
+++ b/lib/jido/sensor/spec.ex
@@ -15,11 +15,11 @@ defmodule Jido.Sensor.Spec do
 
   ## Examples
 
-      iex> Sensor.Spec.new!(%{module: MySensor, name: "my_sensor"})
-      %Sensor.Spec{module: MySensor, name: "my_sensor", ...}
+      Sensor.Spec.new!(%{module: MySensor, name: "my_sensor"})
+      # => %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{}}
 
-      iex> Sensor.Spec.new(%{module: MySensor, name: "my_sensor", config: %{interval: 1000}})
-      {:ok, %Sensor.Spec{...}}
+      Sensor.Spec.new(%{module: MySensor, name: "my_sensor", config: %{interval: 1000}})
+      # => {:ok, %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{interval: 1000}}}
   """
 
   @schema Zoi.struct(
@@ -49,11 +49,11 @@ defmodule Jido.Sensor.Spec do
 
   ## Examples
 
-      iex> Sensor.Spec.new(%{module: MySensor, name: "my_sensor"})
-      {:ok, %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{}, ...}}
+      Sensor.Spec.new(%{module: MySensor, name: "my_sensor"})
+      # => {:ok, %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{}}}
 
-      iex> Sensor.Spec.new(%{name: "missing_module"})
-      {:error, ...}
+      Sensor.Spec.new(%{name: "missing_module"})
+      # => {:error, validation_errors}
   """
   @spec new(map()) :: {:ok, t()} | {:error, term()}
   def new(attrs) when is_map(attrs) do
@@ -67,8 +67,8 @@ defmodule Jido.Sensor.Spec do
 
   ## Examples
 
-      iex> Sensor.Spec.new!(%{module: MySensor, name: "my_sensor"})
-      %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{}, ...}
+      Sensor.Spec.new!(%{module: MySensor, name: "my_sensor"})
+      # => %Sensor.Spec{module: MySensor, name: "my_sensor", config: %{}}
   """
   @spec new!(map()) :: t()
   def new!(attrs) do

--- a/test/jido/docs_examples_test.exs
+++ b/test/jido/docs_examples_test.exs
@@ -1,0 +1,50 @@
+defmodule Jido.DocsExamplesTest do
+  use ExUnit.Case, async: true
+
+  @invalid_doctest_placeholder ~r/iex>.*\n\s*(?:\[.*\.\.\.|%[A-Za-z0-9_.]+\{.*\.\.\.\}|\{:error,\s*\.\.\.\}|\*\* \([^)]+\).*\.\.\.)/m
+
+  test "generated agent accessor docs do not emit doctest prompts" do
+    docs = function_docs(JidoTest.TestAgents.AgentWithPluginRoutes)
+
+    for function_name <- [:plugins, :capabilities, :signal_types] do
+      doc = Map.fetch!(docs, {function_name, 0})
+
+      refute doc =~ "iex>"
+      refute Regex.match?(@invalid_doctest_placeholder, doc)
+    end
+  end
+
+  test "local source docs do not include placeholder outputs in iex examples" do
+    offenders =
+      Path.wildcard("lib/**/*.ex")
+      |> Enum.filter(&File.regular?/1)
+      |> Enum.flat_map(&invalid_source_docs/1)
+
+    assert offenders == []
+  end
+
+  defp function_docs(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        docs
+        |> Enum.flat_map(fn
+          {{:function, name, arity}, _, _, %{"en" => doc}, _} -> [{{name, arity}, doc}]
+          _ -> []
+        end)
+        |> Map.new()
+
+      {:error, reason} ->
+        flunk("could not fetch docs for #{inspect(module)}: #{inspect(reason)}")
+    end
+  end
+
+  defp invalid_source_docs(path) do
+    case File.read(path) do
+      {:ok, contents} ->
+        if Regex.match?(@invalid_doctest_placeholder, contents), do: [path], else: []
+
+      {:error, reason} ->
+        flunk("could not read #{path}: #{inspect(reason)}")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Removes invalid doctest-style examples from `Jido.Agent` generated accessor docs and from other local API docs that used placeholder outputs like `...` inside `iex>` examples.

This fixes the issue where downstream doctest extraction can fail at compile time for consuming modules, and adds a regression test to keep local `lib/**/*.ex` docs free of that placeholder pattern.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

Ran:
- `MIX_ENV=test mix test test/jido/docs_examples_test.exs`
- `MIX_ENV=test mix run -e 'ExUnit.start(); Code.ensure_compiled!(JidoTest.TestAgents.AgentWithPluginRoutes); Code.compile_string("""\ndefmodule Issue226Doctest do\n  use ExUnit.Case, async: true\n  doctest JidoTest.TestAgents.AgentWithPluginRoutes\nend\n""")'`

The second check now completes with `0 tests, 0 failures` instead of crashing on `undefined function .../0`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #226

## Follow-up

While investigating, I found the same placeholder-doc pattern in `jido_signal`, including the macro-generated docs in `lib/jido_signal/using.ex`. I did not include that change here because it belongs in a separate repo/PR.
