### PR TITLE
docs: clarify AI observability ownership

### DIFF
--- a/guides/observability.md
+++ b/guides/observability.md
@@ -493,6 +493,15 @@ always emit telemetry regardless of `:debug_events` config.
 `Jido.Observe.EventContract` provides lightweight key validation helpers so
 downstream namespaces keep stable metadata/measurement contracts.
 
+Namespace ownership matters here:
+
+- `jido` owns the generic runtime and execution surfaces such as
+  `[:jido, :agent, ...]`, `[:jido, :agent_server, ...]`, and `[:jido, :action, ...]`.
+- Domain packages should own their own higher-level namespaces such as
+  `[:jido, :ai, ...]` in `jido_ai`.
+- Keep AI- or domain-specific event contracts out of core `jido`; use
+  `emit_event/3` plus package-local docs/tests in the owning package instead.
+
 ```elixir
 alias Jido.Observe
 alias Jido.Observe.EventContract

--- a/test/examples/observability/domain_event_observability_test.exs
+++ b/test/examples/observability/domain_event_observability_test.exs
@@ -131,6 +131,47 @@ defmodule JidoExampleTest.DomainEventObservabilityTest do
     end
   end
 
+  test "keeps generic action spans separate from package-owned AI domain events" do
+    events = [
+      [:jido, :action, :demo, :start],
+      [:jido, :action, :demo, :stop],
+      [:jido, :ai, :request, :completed]
+    ]
+
+    handler_id = attach_handler(self(), events)
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    span = Observe.start_span([:jido, :action, :demo], %{action: "demo_tool"})
+    Observe.finish_span(span, %{duration_ms: 7})
+
+    {:ok, validated} =
+      EventContract.validate_event(
+        [:jido, :ai, :request, :completed],
+        %{duration_ms: 11},
+        %{request_id: "req-owned-by-package", terminal_state: :completed},
+        required_metadata: [:request_id, :terminal_state],
+        required_measurements: [:duration_ms]
+      )
+
+    assert :ok = Observe.emit_event(validated.event, validated.measurements, validated.metadata)
+
+    received = collect_events(3)
+
+    assert Enum.any?(received, fn {event, _measurements, metadata} ->
+             event == [:jido, :action, :demo, :start] and metadata.action == "demo_tool"
+           end)
+
+    assert Enum.any?(received, fn {event, measurements, metadata} ->
+             event == [:jido, :action, :demo, :stop] and is_integer(measurements.duration) and
+               metadata.action == "demo_tool"
+           end)
+
+    assert Enum.any?(received, fn {event, measurements, metadata} ->
+             event == [:jido, :ai, :request, :completed] and measurements.duration_ms == 11 and
+               metadata.request_id == "req-owned-by-package"
+           end)
+  end
+
   defp attach_handler(test_pid, events) do
     handler_id = "domain-observability-handler-#{System.unique_integer([:positive])}"
 


### PR DESCRIPTION
## Summary
- document the boundary between generic action telemetry in `jido` and AI-domain telemetry owned by downstream packages
- add an example test showing the two telemetry layers can coexist without overlap

Companion to agentjido/jido_ai#222.

## Verification
- mix test test/examples/observability/domain_event_observability_test.exs --include example