### PR TITLE
fix: reduce default log verbosity

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :logger, level: :warning
+
+config :jido, :telemetry, log_level: :warning

--- a/lib/jido/config/defaults.ex
+++ b/lib/jido/config/defaults.ex
@@ -25,7 +25,7 @@ defmodule Jido.Config.Defaults do
 
   @instance_manager_stop_timeout_ms 5_000
 
-  @telemetry_log_level :debug
+  @telemetry_log_level :info
   @telemetry_log_args :keys_only
   @slow_signal_threshold_ms 10
   @slow_directive_threshold_ms 5

--- a/test/jido/config/defaults_test.exs
+++ b/test/jido/config/defaults_test.exs
@@ -16,7 +16,7 @@ defmodule JidoTest.Config.DefaultsTest do
   end
 
   test "returns centralized observability defaults" do
-    assert Defaults.telemetry_log_level() == :debug
+    assert Defaults.telemetry_log_level() == :info
     assert Defaults.telemetry_log_args() == :keys_only
     assert Defaults.slow_signal_threshold_ms() == 10
     assert Defaults.slow_directive_threshold_ms() == 5

--- a/test/jido/observe/config_test.exs
+++ b/test/jido/observe/config_test.exs
@@ -115,8 +115,8 @@ defmodule JidoTest.Observe.ConfigTest do
   end
 
   describe "debug_enabled?/1" do
-    test "true by default (default log level is :debug)" do
-      assert Config.debug_enabled?(nil)
+    test "false by default (default log level is :info)" do
+      refute Config.debug_enabled?(nil)
     end
 
     test "false when log level is info" do
@@ -233,8 +233,8 @@ defmodule JidoTest.Observe.ConfigTest do
   end
 
   describe "level_enabled?/2" do
-    test "debug is enabled at debug level" do
-      assert Config.level_enabled?(nil, :debug)
+    test "debug is not enabled at info level" do
+      refute Config.level_enabled?(nil, :debug)
     end
 
     test "trace is not enabled at debug level" do


### PR DESCRIPTION
## Problem
Default log verbosity was too high, causing noisy logs in production environments.

## Solution
Reduced default log verbosity to appropriate levels.

## Changes
- Adjusted default log levels to prevent excessive noise
- Maintains important operational logs while reducing debug noise