### PR TITLE
[codex] Fix pod plugin alias expansion and add regression test

### DIFF
--- a/lib/jido/pod.ex
+++ b/lib/jido/pod.ex
@@ -67,10 +67,13 @@ defmodule Jido.Pod do
     {pod_plugins, remaining_default_plugins} =
       Definition.split_pod_plugins!(default_plugins, __CALLER__)
 
+    user_plugins =
+      Definition.expand_and_eval_literal_option(Keyword.get(opts, :plugins, []), __CALLER__)
+
     agent_opts =
       opts
       |> Keyword.delete(:topology)
-      |> Keyword.put(:plugins, pod_plugins ++ Keyword.get(opts, :plugins, []))
+      |> Keyword.put(:plugins, pod_plugins ++ (user_plugins || []))
       |> then(fn resolved_opts ->
         if is_nil(remaining_default_plugins) do
           Keyword.delete(resolved_opts, :default_plugins)

--- a/test/jido/pod_test.exs
+++ b/test/jido/pod_test.exs
@@ -34,6 +34,16 @@ defmodule JidoTest.PodTest do
     end
   end
 
+  defmodule UserPlugin do
+    @moduledoc false
+    use Jido.Plugin,
+      name: "pod_test_user_plugin",
+      state_key: :pod_test_user_plugin,
+      actions: [],
+      schema: Zoi.object(%{}),
+      capabilities: []
+  end
+
   defmodule ExamplePod do
     @moduledoc false
     use Jido.Pod,
@@ -88,6 +98,27 @@ defmodule JidoTest.PodTest do
 
     assert {:ok, %{metadata: %{custom: true}}} = Pod.fetch_state(agent)
     assert {:ok, %Topology{name: "custom_plugin_pod"}} = Pod.fetch_topology(agent)
+  end
+
+  test "plugins option resolves aliased plugin modules before pod opts are escaped" do
+    suffix = System.unique_integer([:positive])
+    pod_mod = Module.concat(__MODULE__, :"AliasedPluginPod#{suffix}")
+    pod_name = "aliased_plugin_pod_#{suffix}"
+
+    Code.compile_string("""
+    defmodule #{inspect(pod_mod)} do
+      @moduledoc false
+      alias #{inspect(UserPlugin)}, as: UserPlugin
+
+      use Jido.Pod,
+        name: #{inspect(pod_name)},
+        plugins: [UserPlugin]
+    end
+    """)
+
+    assert Enum.any?(pod_mod.plugin_instances(), fn instance ->
+             instance.module == UserPlugin and instance.state_key == :pod_test_user_plugin
+           end)
   end
 
   test "disabling the reserved __pod__ plugin raises at compile time" do


### PR DESCRIPTION
## Summary

- expand user-provided `:plugins` in `Jido.Pod.__using__/1` via `Definition.expand_and_eval_literal_option/2` before `Macro.escape/1`
- merge pod plugins with expanded user plugins (`pod_plugins ++ (user_plugins || [])`)
- add a regression test that compiles a pod using an aliased plugin module in `plugins:` and verifies the module is resolved and mounted

## Root Cause

`Jido.Pod.__using__/1` passed `opts[:plugins]` through raw. When the pod options were later escaped, aliased plugin modules remained as alias AST tuples rather than resolved module atoms, causing plugin normalization/compile checks to fail.

## Impact

Pods can now safely use aliased plugin modules in `plugins:` declarations. This restores expected macro behavior and prevents compile-time plugin extraction failures.

## Validation

- `mix test test/jido/pod_test.exs test/jido/pod/topology_test.exs test/jido/pod/mutation/planner_test.exs test/jido/pod/mutation_runtime_test.exs test/jido/pod/runtime_test.exs test/jido/pod/telemetry_test.exs`
