### PR TITLE
fix: ensure Elixir 1.20 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
   lint:
     name: Lint
     uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
+    with:
+      otp_version: "28"
+      elixir_version: "1.20.0-rc.4"
     secrets: inherit
 
   test:
@@ -22,4 +25,12 @@ jobs:
     with:
       otp_versions: '["27", "28"]'
       elixir_versions: '["1.18", "1.19"]'
+      test_command: mix test
+
+  test_elixir_120:
+    name: Test Elixir 1.20
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
+    with:
+      otp_versions: '["28"]'
+      elixir_versions: '["1.20.0-rc.4"]'
       test_command: mix test

--- a/lib/jido/agent_server/signal/child_exit.ex
+++ b/lib/jido/agent_server/signal/child_exit.ex
@@ -3,6 +3,10 @@ defmodule Jido.AgentServer.Signal.ChildExit do
 
   use Jido.Signal,
     type: "jido.agent.child.exit",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
     schema: [
       tag: [type: :any, required: true, doc: "Tag assigned to the child when spawned"],
       pid: [type: :any, required: true, doc: "PID of the child process that exited"],

--- a/lib/jido/agent_server/signal/child_started.ex
+++ b/lib/jido/agent_server/signal/child_started.ex
@@ -19,6 +19,10 @@ defmodule Jido.AgentServer.Signal.ChildStarted do
   use Jido.Signal,
     type: "jido.agent.child.started",
     default_source: "/agent",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
     schema: [
       parent_id: [type: :string, required: true, doc: "ID of the parent agent"],
       child_id: [type: :string, required: true, doc: "ID of the child agent"],

--- a/lib/jido/agent_server/signal/cron_tick.ex
+++ b/lib/jido/agent_server/signal/cron_tick.ex
@@ -3,6 +3,10 @@ defmodule Jido.AgentServer.Signal.CronTick do
 
   use Jido.Signal,
     type: "jido.cron_tick",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
     schema: [
       job_id: [type: :any, required: true, doc: "The logical cron job id"],
       message: [type: :any, required: true, doc: "The cron tick message payload"]

--- a/lib/jido/agent_server/signal/orphaned.ex
+++ b/lib/jido/agent_server/signal/orphaned.ex
@@ -18,6 +18,10 @@ defmodule Jido.AgentServer.Signal.Orphaned do
 
   use Jido.Signal,
     type: "jido.agent.orphaned",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
     schema: [
       parent_id: [type: :string, required: true, doc: "ID of the parent agent that died"],
       parent_pid: [type: :any, required: true, doc: "PID of the parent process that died"],

--- a/lib/jido/agent_server/signal/scheduled.ex
+++ b/lib/jido/agent_server/signal/scheduled.ex
@@ -3,6 +3,10 @@ defmodule Jido.AgentServer.Signal.Scheduled do
 
   use Jido.Signal,
     type: "jido.scheduled",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
     schema: [
       message: [type: :any, required: true, doc: "The scheduled message payload"]
     ]

--- a/lib/jido/discovery.ex
+++ b/lib/jido/discovery.ex
@@ -62,8 +62,6 @@ defmodule Jido.Discovery do
   All processes can read concurrently without contention.
   """
 
-  require Logger
-
   @catalog_key :jido_discovery_catalog
 
   @type component_type :: :actions | :sensors | :agents | :plugins | :demos

--- a/lib/jido/observe/log.ex
+++ b/lib/jido/observe/log.ex
@@ -29,8 +29,6 @@ defmodule Jido.Observe.Log do
       Log.log(:info, "Agent completed", agent_id: agent.id)
   """
 
-  require Logger
-
   @type level :: Logger.level()
 
   @doc """

--- a/lib/jido/scheduler.ex
+++ b/lib/jido/scheduler.ex
@@ -173,10 +173,7 @@ defmodule Jido.Scheduler do
   end
 
   def run_every(fun, cron_expr, opts) when is_function(fun, 0) and is_list(opts) do
-    case validate_cron_expression_type(cron_expr) do
-      :ok -> {:error, {:invalid_scheduler_options, :invalid_type}}
-      {:error, reason} -> {:error, reason}
-    end
+    validate_cron_expression_type(cron_expr)
   end
 
   def run_every(fun, _cron_expr, _opts) when is_function(fun, 0),

--- a/lib/jido/storage/file.ex
+++ b/lib/jido/storage/file.ex
@@ -334,7 +334,7 @@ defmodule Jido.Storage.File do
   defp decode_entries(_malformed, _acc), do: {:error, :invalid_entries_log}
 
   defp decode_frame(rest, size) when byte_size(rest) >= size do
-    <<term_binary::binary-size(size), remaining::binary>> = rest
+    <<term_binary::binary-size(^size), remaining::binary>> = rest
     {:ok, term_binary, remaining}
   end
 

--- a/test/jido/agent/agent_test.exs
+++ b/test/jido/agent/agent_test.exs
@@ -49,7 +49,7 @@ defmodule JidoTest.AgentTest do
       assert TestAgents.Minimal.name() == "minimal_agent"
       assert TestAgents.Minimal.description() == nil
       schema = TestAgents.Minimal.schema()
-      assert is_struct(schema) or schema == []
+      assert is_struct(schema)
     end
   end
 

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -461,9 +461,13 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       assert child_info.module == agent_struct.__struct__
       assert is_pid(child_info.pid)
 
-      # Stop the child - catch potential exit as process may be in init
-      catch_exit do
-        GenServer.stop(child_info.pid, :normal, 100)
+      # Stop the child without relying on catch_exit's generated AST handling.
+      if Process.alive?(child_info.pid) do
+        try do
+          GenServer.stop(child_info.pid, :normal, 100)
+        catch
+          :exit, _ -> :ok
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- fix Jido-owned Elixir 1.20 warnings and the test cleanup needed for ExUnit 1.20
- declare optional internal signal extensions explicitly so `use Jido.Signal` stays warning-free under 1.20
- add GitHub Actions coverage for Elixir `1.20.0-rc.4` on OTP 28, including lint/quality validation

## Why
Elixir 1.20 surfaces a few stricter warnings and test-behavior changes that do not show up on the current baseline. This keeps Jido source-compatible on day one and adds CI coverage so we keep verifying that path.

## Validation
- `mise exec elixir@1.20.0-rc.4-otp-28 -- env MIX_BUILD_ROOT=_build-elixir-1.20-day1-test-clean mix test`
- `mise exec elixir@1.20.0-rc.4-otp-28 -- env MIX_BUILD_ROOT=_build-elixir-1.20-day1-quality-clean mix q`

## Notes
- Fresh Elixir 1.20 builds still print warnings from third-party dependencies, but Jido itself is warning-clean and the full quality suite passes.
- This PR supersedes the earlier source-only compatibility branch by including CI coverage too.