### PR TITLE
[DO NOT MERGE] docs: add pod domain example for Phoenix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Jido Examples
+
+This folder is a scratch space for example project shapes and integration
+patterns.
+
+The goal is not polished documentation yet. The goal is to make the intended
+developer experience concrete enough to critique.
+
+## Current Conventions Under Test
+
+- A `Jido.Pod` is the durable multi-agent runtime definition.
+- A sibling domain/context module is the application-facing API.
+- Phoenix controllers, LiveViews, and jobs call the domain/context module, not
+  `Jido.Pod` directly.
+
+## Examples
+
+- `phoenix_issue_triage/`
+  - A larger Phoenix-shaped project slice with a pod, facade/context module,
+    sensors, custom actions, memory/thread usage, and live mutation.

--- a/examples/phoenix_issue_triage/README.md
+++ b/examples/phoenix_issue_triage/README.md
@@ -1,0 +1,115 @@
+# Phoenix Issue Triage
+
+This example is a larger showcase for the Phoenix + Pod story.
+
+The core idea is simple:
+
+- the public domain module defines the application API
+- the nested pod module defines the durable runtime shape
+- Phoenix code calls the domain module
+- plugin subscriptions own long-lived sensors for the run
+- named role nodes are backed by focused agent modules
+
+That means the answer to "what is the API surface for interacting with a pod?"
+is not "controllers should call `Jido.Pod` directly." The answer is:
+
+> wrap a pod inside a domain module, and treat that domain module as the app
+> boundary
+
+## Shape
+
+```text
+examples/phoenix_issue_triage/
+└── lib/examples/phoenix_issue_triage/
+    ├── issue_triage.ex
+    └── issue_triage/
+        ├── actions/
+        ├── agents/
+        ├── plugins/
+        ├── sensors/
+        ├── artifacts.ex
+        ├── policy.ex
+        └── pod.ex
+```
+
+## Responsibilities
+
+`IssueTriage`
+
+- is the public domain API
+- is what Phoenix should call
+- opens keyed runs
+- ingests webhook events through a sensor child
+- orchestrates triage, research, review, and publish steps
+- wraps lazy role activation, mutation, and status waiting
+
+`IssueTriage.Pod`
+
+- owns topology
+- owns signal handling for the durable run record
+- mounts plugin-backed sensor subscriptions
+- stays focused on runtime definition and persistent run state
+
+`IssueTriage.Plugins.IssueRunOpsPlugin`
+
+- owns isolated runtime ops state
+- subscribes the pod to a heartbeat sensor and a webhook sensor
+- demonstrates plugin state plus sensor-driven signal flow
+
+`IssueTriage.Artifacts`
+
+- writes workflow artifacts into memory and thread state
+- converts nested memory/thread changes into explicit `StateOp` updates
+- exposes one of the missing ergonomic seams in the current end-to-end story
+
+`IssueTriage.Policy`
+
+- holds the example's classification and review heuristics
+- separates app policy from runtime plumbing
+
+## Controller / LiveView Usage
+
+```elixir
+alias Examples.PhoenixIssueTriage.IssueTriage
+
+{:ok, run_pid} =
+  IssueTriage.open_run("issue-123")
+
+payload = %{
+  issue_id: "issue-123",
+  repo: "agentjido/jido",
+  title: "Need runtime-defined pod topology",
+  body: "We want to load pod definitions from the database and keep the workflow durable.",
+  labels: ["bug", "needs-research", "customer-facing"]
+}
+
+{:ok, reviewed} =
+  IssueTriage.process_issue(run_pid, payload)
+
+{:ok, published} =
+  IssueTriage.publish_run(run_pid)
+```
+
+## What This Example Uses
+
+- `Jido.Pod` as the durable run root
+- custom actions on the pod and roles
+- custom sensor for webhook intake
+- built-in `Jido.Sensors.Heartbeat`
+- plugin subscriptions
+- default memory and thread plugins through helper APIs
+- lazy role activation
+- live pod mutation to add a publisher role
+
+## Why This Matters
+
+This example is deliberately more opinionated:
+
+- the domain module is the app boundary
+- the pod is nested under the domain
+- sensors stay attached to the pod runtime
+- agent modules emit results upward
+- Phoenix code talks to a clean API instead of directly to `Jido.Pod`
+
+If this pattern holds up, Jido should document and eventually generate this
+shape for multi-agent Phoenix apps.

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage.ex
@@ -1,0 +1,365 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage do
+  @moduledoc """
+  Public domain API for interacting with the issue triage pod.
+
+  This is the module controllers, LiveViews, and jobs should call. It wraps the
+  raw pod runtime with semantic domain operations and hides low-level runtime
+  details such as sensor child lookup, lazy role activation, and mutation APIs.
+  """
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.{Plugins, Pod, Sensors}
+  alias Examples.PhoenixIssueTriage.IssueTriage.Agents.PublisherAgent
+  alias Jido.AgentServer
+  alias Jido.Memory.Agent, as: MemoryAgent
+  alias Jido.Pod, as: PodRuntime
+  alias Jido.Pod.Mutation
+  alias Jido.Pod.Topology
+  alias Jido.Sensor.Runtime, as: SensorRuntime
+  alias Jido.Signal
+  alias Jido.Thread
+  alias Jido.Thread.Agent, as: ThreadAgent
+
+  @pod_manager :example_issue_triage_pods
+  @publisher_manager :example_issue_triage_publishers
+  @ops_plugin Plugins.IssueRunOpsPlugin
+  @webhook_sensor Sensors.IssueWebhookSensor
+  @default_source "/examples/phoenix_issue_triage"
+
+  @type run_server :: AgentServer.server()
+  @type run_key :: term()
+  @type role_name :: PodRuntime.node_name()
+
+  @spec open_run(run_key(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def open_run(key, opts \\ []) do
+    PodRuntime.get(@pod_manager, key, opts)
+  end
+
+  @spec open_run(atom(), run_key(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def open_run(manager, key, opts) when is_atom(manager) do
+    PodRuntime.get(manager, key, opts)
+  end
+
+  @spec topology(module() | run_server()) :: {:ok, Topology.t()} | {:error, term()}
+  def topology(source \\ Pod) do
+    PodRuntime.fetch_topology(source)
+  end
+
+  @spec status(run_server()) :: {:ok, map()} | {:error, term()}
+  def status(run) do
+    with {:ok, server_state} <- AgentServer.state(run),
+         {:ok, snapshots} <- PodRuntime.nodes(run) do
+      agent = server_state.agent
+
+      {:ok,
+       %{
+         pod_id: agent.id,
+         pod_module: server_state.agent_module,
+         status: agent.state.status,
+         current_stage: agent.state.current_stage,
+         issue_id: agent.state.issue_id,
+         repo: agent.state.repo,
+         title: agent.state.title,
+         requires_research?: agent.state.requires_research?,
+         triage_summary: agent.state.triage_summary,
+         research_summary: agent.state.research_summary,
+         review_outcome: agent.state.review_outcome,
+         review_summary: agent.state.review_summary,
+         published_artifact: agent.state.published_artifact,
+         ops: Map.get(agent.state, :ops, %{}),
+         roles: summarize_roles(snapshots),
+         memory: summarize_memory(agent),
+         thread: summarize_thread(agent)
+       }}
+    end
+  end
+
+  @spec role_snapshots(run_server()) ::
+          {:ok, %{role_name() => PodRuntime.node_snapshot()}} | {:error, term()}
+  def role_snapshots(run) do
+    PodRuntime.nodes(run)
+  end
+
+  @spec lookup_role(run_server(), role_name()) :: {:ok, pid()} | :error | {:error, term()}
+  def lookup_role(run, role) do
+    PodRuntime.lookup_node(run, role)
+  end
+
+  @spec ensure_role(run_server(), role_name(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def ensure_role(run, role, opts \\ []) do
+    PodRuntime.ensure_node(run, role, opts)
+  end
+
+  @spec dispatch_to_pod(run_server(), String.t(), map(), keyword()) ::
+          {:ok, Jido.Agent.t()} | {:error, term()}
+  def dispatch_to_pod(run, signal_type, payload \\ %{}, opts \\ []) do
+    AgentServer.call(run, build_signal(signal_type, payload, opts))
+  end
+
+  @spec dispatch_to_role(run_server(), role_name(), String.t(), map(), keyword()) ::
+          {:ok, Jido.Agent.t()} | {:error, term()}
+  def dispatch_to_role(run, role, signal_type, payload \\ %{}, opts \\ []) do
+    with {:ok, pid} <- ensure_role(run, role) do
+      AgentServer.call(pid, build_signal(signal_type, payload, opts))
+    end
+  end
+
+  @spec sensor_pids(run_server()) :: {:ok, %{module() => pid()}} | {:error, term()}
+  def sensor_pids(run) do
+    with {:ok, state} <- AgentServer.state(run) do
+      sensors =
+        state.children
+        |> Map.values()
+        |> Enum.reduce(%{}, fn child, acc ->
+          case child.tag do
+            {:sensor, @ops_plugin, sensor_module} -> Map.put(acc, sensor_module, child.pid)
+            _other -> acc
+          end
+        end)
+
+      {:ok, sensors}
+    end
+  end
+
+  @spec ingest_issue(run_server(), map()) :: :ok | {:error, term()}
+  def ingest_issue(run, payload) when is_map(payload) do
+    with {:ok, sensor_pid} <- sensor_pid(run, @webhook_sensor) do
+      SensorRuntime.event(sensor_pid, {:issue_opened, payload})
+    end
+  end
+
+  @spec process_issue(run_server(), map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def process_issue(run, payload, opts \\ []) when is_map(payload) do
+    with :ok <- ingest_issue(run, payload),
+         {:ok, ingested} <- await_stage(run, :ingested, opts),
+         {:ok, _agent} <- start_triage(run, ingested),
+         {:ok, triaged} <- await_stage(run, :triaged, opts),
+         {:ok, after_research} <- maybe_research(run, triaged, opts),
+         {:ok, _agent} <- start_review(run, after_research),
+         {:ok, reviewed} <- await_stage(run, :reviewed, opts) do
+      {:ok, reviewed}
+    end
+  end
+
+  @spec publish_run(run_server(), keyword()) :: {:ok, map()} | {:error, term()}
+  def publish_run(run, opts \\ []) do
+    with {:ok, current} <- status(run),
+         :ok <- ensure_publishable(current),
+         {:ok, _mutation_report} <- add_publisher_role(run),
+         {:ok, _agent} <- start_publish(run, current),
+         {:ok, published} <- await_stage(run, :published, opts) do
+      {:ok, published}
+    end
+  end
+
+  @spec add_publisher_role(run_server()) ::
+          {:ok, PodRuntime.mutation_report() | :already_present} | {:error, term()}
+  def add_publisher_role(run) do
+    with {:ok, topology} <- topology(run) do
+      if Map.has_key?(topology.nodes, :publisher) do
+        {:ok, :already_present}
+      else
+        PodRuntime.mutate(
+          run,
+          [
+            Mutation.add_node(
+              :publisher,
+              %{
+                agent: PublisherAgent,
+                manager: @publisher_manager,
+                activation: :lazy,
+                initial_state: %{role: "publisher"}
+              },
+              depends_on: [:reviewer]
+            )
+          ]
+        )
+      end
+    end
+  end
+
+  @spec mutate(run_server(), [Mutation.t() | term()], keyword()) ::
+          {:ok, PodRuntime.mutation_report()} | {:error, PodRuntime.mutation_report() | term()}
+  def mutate(run, ops, opts \\ []) do
+    PodRuntime.mutate(run, ops, opts)
+  end
+
+  @spec shutdown(run_server(), term()) :: :ok
+  def shutdown(run, reason \\ :normal) do
+    GenServer.stop(run, reason)
+  end
+
+  @spec await_stage(run_server(), atom(), keyword()) :: {:ok, map()} | {:error, term()}
+  def await_stage(run, stage, opts \\ []) do
+    await_status(run, fn status -> status.current_stage == stage end, opts)
+  end
+
+  defp maybe_research(run, %{requires_research?: true} = _status, opts) do
+    with {:ok, refreshed} <- status(run),
+         {:ok, _agent} <- start_research(run, refreshed),
+         {:ok, researched} <- await_stage(run, :researched, opts) do
+      {:ok, researched}
+    end
+  end
+
+  defp maybe_research(_run, status, _opts), do: {:ok, status}
+
+  defp start_triage(run, status) do
+    dispatch_to_role(run, :triager, "issue.triage.requested", %{
+      issue_id: status.issue_id,
+      repo: status.repo,
+      title: status.title,
+      body: current_body(run),
+      labels: current_labels(run),
+      requires_research: status.requires_research?
+    })
+  end
+
+  defp start_research(run, status) do
+    dispatch_to_role(run, :researcher, "issue.research.requested", %{
+      issue_id: status.issue_id,
+      repo: status.repo,
+      title: status.title,
+      body: current_body(run),
+      triage_summary: status.triage_summary,
+      classification: current_classification(run),
+      priority: current_priority(run)
+    })
+  end
+
+  defp start_review(run, status) do
+    dispatch_to_role(run, :reviewer, "issue.review.requested", %{
+      issue_id: status.issue_id,
+      repo: status.repo,
+      triage_summary: status.triage_summary,
+      classification: current_classification(run),
+      priority: current_priority(run),
+      research_summary: status.research_summary
+    })
+  end
+
+  defp start_publish(run, status) do
+    dispatch_to_role(run, :publisher, "issue.publish.requested", %{
+      issue_id: status.issue_id,
+      repo: status.repo,
+      triage_summary: status.triage_summary,
+      review_summary: status.review_summary
+    })
+  end
+
+  defp await_status(run, fun, opts) do
+    timeout = Keyword.get(opts, :timeout, 2_000)
+    interval = Keyword.get(opts, :interval, 10)
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    do_await_status(run, fun, deadline, interval)
+  end
+
+  defp do_await_status(run, fun, deadline, interval) do
+    if System.monotonic_time(:millisecond) > deadline do
+      {:error, :timeout}
+    else
+      case status(run) do
+        {:ok, current} ->
+          if fun.(current) do
+            {:ok, current}
+          else
+            Process.sleep(interval)
+            do_await_status(run, fun, deadline, interval)
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp sensor_pid(run, sensor_module) do
+    with {:ok, sensors} <- sensor_pids(run) do
+      case Map.fetch(sensors, sensor_module) do
+        {:ok, pid} -> {:ok, pid}
+        :error -> {:error, {:sensor_not_found, sensor_module}}
+      end
+    end
+  end
+
+  defp current_body(run) do
+    {:ok, state} = AgentServer.state(run)
+    state.agent.state.body
+  end
+
+  defp current_labels(run) do
+    {:ok, state} = AgentServer.state(run)
+    state.agent.state.labels
+  end
+
+  defp current_classification(run) do
+    {:ok, state} = AgentServer.state(run)
+    state.agent.state.classification
+  end
+
+  defp current_priority(run) do
+    {:ok, state} = AgentServer.state(run)
+    state.agent.state.priority
+  end
+
+  defp build_signal(type, payload, opts) do
+    signal_opts =
+      opts
+      |> Keyword.take([
+        :source,
+        :subject,
+        :jido_metadata,
+        :trace_id,
+        :correlation_id,
+        :causation_id
+      ])
+      |> Keyword.put_new(:source, @default_source)
+
+    Signal.new!(type, payload, signal_opts)
+  end
+
+  defp summarize_roles(snapshots) do
+    Map.new(snapshots, fn {name, snapshot} ->
+      {name,
+       %{
+         status: snapshot.status,
+         pid: snapshot.pid,
+         owner: snapshot.owner,
+         activation: snapshot.node.activation
+       }}
+    end)
+  end
+
+  defp summarize_memory(agent) do
+    case MemoryAgent.get(agent) do
+      nil ->
+        %{present?: false}
+
+      memory ->
+        %{
+          present?: true,
+          id: memory.id,
+          rev: memory.rev,
+          spaces: Map.keys(memory.spaces) |> Enum.sort()
+        }
+    end
+  end
+
+  defp summarize_thread(agent) do
+    case ThreadAgent.get(agent) do
+      nil ->
+        %{present?: false}
+
+      thread ->
+        %{
+          present?: true,
+          id: thread.id,
+          rev: thread.rev,
+          entry_count: Thread.entry_count(thread)
+        }
+    end
+  end
+
+  defp ensure_publishable(%{review_outcome: :approved}), do: :ok
+  defp ensure_publishable(_status), do: {:error, :not_publishable}
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/agent_actions.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/agent_actions.ex
@@ -1,0 +1,221 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessTriageRequestAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "process_triage_request",
+    schema: [
+      issue_id: [type: :string, required: true],
+      repo: [type: :string, required: true],
+      title: [type: :string, required: true],
+      body: [type: :string, required: true],
+      labels: [type: {:list, :string}, default: []],
+      requires_research: [type: :boolean, default: false]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Examples.PhoenixIssueTriage.IssueTriage.Policy
+  alias Jido.Agent.Directive
+  alias Jido.Signal
+
+  def run(params, %{agent: agent}) do
+    classification = Policy.classify(params.title, params.body, params.labels)
+    priority = Policy.priority(params.body, params.labels)
+
+    summary =
+      "Triaged #{params.issue_id} as #{classification} with #{priority} priority."
+
+    updated_agent =
+      agent
+      |> Artifacts.remember_issue(params)
+      |> Artifacts.remember_triage(%{
+        issue_id: params.issue_id,
+        classification: classification,
+        priority: priority,
+        requires_research?: params.requires_research,
+        summary: summary
+      })
+
+    signal =
+      Signal.new!(
+        "issue.triage.completed",
+        %{
+          issue_id: params.issue_id,
+          summary: summary,
+          classification: classification,
+          priority: priority,
+          requires_research: params.requires_research
+        },
+        source: "/examples/phoenix_issue_triage/issue_triage/triager"
+      )
+
+    {:ok,
+     %{
+       last_issue_id: params.issue_id,
+       classification: classification,
+       priority: priority,
+       last_summary: summary,
+       status: :triaged
+     },
+     Artifacts.artifact_ops(updated_agent) ++
+       [Directive.emit_to_parent(updated_agent, signal)]}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessResearchRequestAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "process_research_request",
+    schema: [
+      issue_id: [type: :string, required: true],
+      repo: [type: :string, required: true],
+      title: [type: :string, required: true],
+      body: [type: :string, required: true],
+      triage_summary: [type: :string, required: true],
+      classification: [type: :atom, required: true],
+      priority: [type: :atom, required: true]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Jido.Agent.Directive
+  alias Jido.Signal
+
+  def run(params, %{agent: agent}) do
+    research_summary =
+      "Reviewed repository context for #{params.issue_id} and confirmed #{params.classification} handling path."
+
+    updated_agent =
+      agent
+      |> Artifacts.remember_research(%{
+        issue_id: params.issue_id,
+        research_summary: research_summary,
+        confidence: :high
+      })
+
+    signal =
+      Signal.new!(
+        "issue.research.completed",
+        %{
+          issue_id: params.issue_id,
+          research_summary: research_summary,
+          confidence: :high
+        },
+        source: "/examples/phoenix_issue_triage/issue_triage/researcher"
+      )
+
+    {:ok,
+     %{
+       last_issue_id: params.issue_id,
+       research_summary: research_summary,
+       status: :researched
+     },
+     Artifacts.artifact_ops(updated_agent) ++
+       [Directive.emit_to_parent(updated_agent, signal)]}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessReviewRequestAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "process_review_request",
+    schema: [
+      issue_id: [type: :string, required: true],
+      repo: [type: :string, required: true],
+      triage_summary: [type: :string, required: true],
+      classification: [type: :atom, required: true],
+      priority: [type: :atom, required: true],
+      research_summary: [type: :string, default: ""]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Examples.PhoenixIssueTriage.IssueTriage.Policy
+  alias Jido.Agent.Directive
+  alias Jido.Signal
+
+  def run(params, %{agent: agent}) do
+    review_outcome = Policy.review_outcome(params.priority, params.research_summary)
+
+    review_summary =
+      case review_outcome do
+        :approved -> "Approved #{params.issue_id} for next-step handling."
+        :changes_requested -> "Requested more context before approving #{params.issue_id}."
+      end
+
+    updated_agent =
+      agent
+      |> Artifacts.remember_review(%{
+        issue_id: params.issue_id,
+        review_outcome: review_outcome,
+        review_summary: review_summary
+      })
+
+    signal =
+      Signal.new!(
+        "issue.review.completed",
+        %{
+          issue_id: params.issue_id,
+          review_outcome: review_outcome,
+          review_summary: review_summary
+        },
+        source: "/examples/phoenix_issue_triage/issue_triage/reviewer"
+      )
+
+    {:ok,
+     %{
+       last_issue_id: params.issue_id,
+       review_outcome: review_outcome,
+       review_summary: review_summary,
+       status: :reviewed
+     },
+     Artifacts.artifact_ops(updated_agent) ++
+       [Directive.emit_to_parent(updated_agent, signal)]}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessPublishRequestAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "process_publish_request",
+    schema: [
+      issue_id: [type: :string, required: true],
+      repo: [type: :string, required: true],
+      triage_summary: [type: :string, required: true],
+      review_summary: [type: :string, required: true]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Jido.Agent.Directive
+  alias Jido.Signal
+
+  def run(params, %{agent: agent}) do
+    artifact_ref = "triage-note://#{params.repo}/#{params.issue_id}"
+
+    updated_agent =
+      agent
+      |> Artifacts.remember_publish(%{
+        issue_id: params.issue_id,
+        artifact_ref: artifact_ref
+      })
+
+    signal =
+      Signal.new!(
+        "issue.publish.completed",
+        %{
+          issue_id: params.issue_id,
+          artifact_ref: artifact_ref
+        },
+        source: "/examples/phoenix_issue_triage/issue_triage/publisher"
+      )
+
+    {:ok,
+     %{
+       last_issue_id: params.issue_id,
+       artifact_ref: artifact_ref,
+       status: :published
+     },
+     Artifacts.artifact_ops(updated_agent) ++
+       [Directive.emit_to_parent(updated_agent, signal)]}
+  end
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/plugin_actions.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/plugin_actions.ex
@@ -1,0 +1,33 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.TrackHeartbeatAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "track_heartbeat",
+    schema: [
+      message: [type: :string, default: "heartbeat"],
+      timestamp: [type: :any, required: false]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Jido.Agent.StateOp
+  alias Jido.Thread.Agent, as: ThreadAgent
+
+  def run(%{message: message, timestamp: timestamp}, %{state: state, agent: agent}) do
+    updated_agent =
+      ThreadAgent.append(agent, %{
+        kind: :heartbeat,
+        payload: %{message: message, timestamp: timestamp}
+      })
+
+    heartbeat_count = get_in(state, [:ops, :heartbeat_count]) || 0
+
+    {:ok, %{},
+     [
+       StateOp.set_path([:ops, :heartbeat_count], heartbeat_count + 1),
+       StateOp.set_path([:ops, :last_heartbeat_message], message),
+       StateOp.set_path([:ops, :last_heartbeat_at], timestamp),
+       StateOp.set_path([:ops, :last_signal_source], "/sensor/heartbeat")
+       | Artifacts.artifact_ops(updated_agent)
+     ]}
+  end
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/pod_actions.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/actions/pod_actions.ex
@@ -1,0 +1,168 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.IngestIssueAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "ingest_issue",
+    schema: [
+      issue_id: [type: :string, required: true],
+      repo: [type: :string, required: true],
+      title: [type: :string, required: true],
+      body: [type: :string, required: true],
+      labels: [type: {:list, :string}, default: []],
+      event_type: [type: :string, default: "issue_opened"]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+  alias Examples.PhoenixIssueTriage.IssueTriage.Policy
+  alias Jido.Agent.StateOp
+
+  def run(params, %{agent: agent, state: state}) do
+    updated_agent = Artifacts.remember_issue(agent, params)
+    requires_research = Policy.requires_research?(params.body, params.labels)
+    webhook_count = get_in(state, [:ops, :webhook_event_count]) || 0
+
+    {:ok,
+     %{
+       issue_id: params.issue_id,
+       repo: params.repo,
+       title: params.title,
+       body: params.body,
+       labels: params.labels,
+       status: :ingested,
+       current_stage: :ingested,
+       requires_research?: requires_research
+     },
+     [
+       StateOp.set_path([:ops, :webhook_event_count], webhook_count + 1),
+       StateOp.set_path([:ops, :last_webhook_event], params.event_type)
+       | Artifacts.artifact_ops(updated_agent)
+     ]}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.HandleTriageCompletedAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "handle_triage_completed",
+    schema: [
+      issue_id: [type: :string, required: true],
+      summary: [type: :string, required: true],
+      classification: [type: :atom, required: true],
+      priority: [type: :atom, required: true],
+      requires_research: [type: :boolean, default: false]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+
+  def run(params, %{agent: agent}) do
+    updated_agent =
+      Artifacts.remember_triage(agent, %{
+        issue_id: params.issue_id,
+        classification: params.classification,
+        priority: params.priority,
+        requires_research?: params.requires_research,
+        summary: params.summary
+      })
+
+    {:ok,
+     %{
+       triage_summary: params.summary,
+       classification: params.classification,
+       priority: params.priority,
+       requires_research?: params.requires_research,
+       status: :triaged,
+       current_stage: :triaged
+     }, Artifacts.artifact_ops(updated_agent)}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.HandleResearchCompletedAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "handle_research_completed",
+    schema: [
+      issue_id: [type: :string, required: true],
+      research_summary: [type: :string, required: true],
+      confidence: [type: :atom, default: :medium]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+
+  def run(params, %{agent: agent}) do
+    updated_agent =
+      Artifacts.remember_research(agent, %{
+        issue_id: params.issue_id,
+        research_summary: params.research_summary,
+        confidence: params.confidence
+      })
+
+    {:ok,
+     %{
+       research_summary: params.research_summary,
+       research_confidence: params.confidence,
+       status: :researched,
+       current_stage: :researched
+     }, Artifacts.artifact_ops(updated_agent)}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.HandleReviewCompletedAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "handle_review_completed",
+    schema: [
+      issue_id: [type: :string, required: true],
+      review_outcome: [type: :atom, required: true],
+      review_summary: [type: :string, required: true]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+
+  def run(params, %{agent: agent}) do
+    updated_agent =
+      Artifacts.remember_review(agent, %{
+        issue_id: params.issue_id,
+        review_outcome: params.review_outcome,
+        review_summary: params.review_summary
+      })
+
+    {:ok,
+     %{
+       review_outcome: params.review_outcome,
+       review_summary: params.review_summary,
+       status: params.review_outcome,
+       current_stage: :reviewed
+     }, Artifacts.artifact_ops(updated_agent)}
+  end
+end
+
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Actions.HandlePublishCompletedAction do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "handle_publish_completed",
+    schema: [
+      issue_id: [type: :string, required: true],
+      artifact_ref: [type: :string, required: true]
+    ]
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.Artifacts
+
+  def run(params, %{agent: agent}) do
+    updated_agent =
+      Artifacts.remember_publish(agent, %{
+        issue_id: params.issue_id,
+        artifact_ref: params.artifact_ref
+      })
+
+    {:ok,
+     %{
+       published_artifact: params.artifact_ref,
+       status: :published,
+       current_stage: :published
+     }, Artifacts.artifact_ops(updated_agent)}
+  end
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/publisher_agent.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/publisher_agent.ex
@@ -1,0 +1,18 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Agents.PublisherAgent do
+  @moduledoc """
+  Example agent for publishing the final triage artifact after review approval.
+  """
+
+  use Jido.Agent,
+    name: "examples_phoenix_issue_triage_publisher",
+    schema: [
+      role: [type: :string, default: "publisher"],
+      last_issue_id: [type: :string, default: ""],
+      artifact_ref: [type: :string, default: ""],
+      status: [type: :atom, default: :idle]
+    ],
+    signal_routes: [
+      {"issue.publish.requested",
+       Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessPublishRequestAction}
+    ]
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/researcher_agent.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/researcher_agent.ex
@@ -1,0 +1,18 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Agents.ResearcherAgent do
+  @moduledoc """
+  Example agent for deeper repository research.
+  """
+
+  use Jido.Agent,
+    name: "examples_phoenix_issue_triage_researcher",
+    schema: [
+      role: [type: :string, default: "researcher"],
+      last_issue_id: [type: :string, default: ""],
+      research_summary: [type: :string, default: ""],
+      status: [type: :atom, default: :idle]
+    ],
+    signal_routes: [
+      {"issue.research.requested",
+       Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessResearchRequestAction}
+    ]
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/reviewer_agent.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/reviewer_agent.ex
@@ -1,0 +1,19 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Agents.ReviewerAgent do
+  @moduledoc """
+  Example agent for human or automated review.
+  """
+
+  use Jido.Agent,
+    name: "examples_phoenix_issue_triage_reviewer",
+    schema: [
+      role: [type: :string, default: "reviewer"],
+      last_issue_id: [type: :string, default: ""],
+      review_outcome: [type: :atom, default: :pending],
+      review_summary: [type: :string, default: ""],
+      status: [type: :atom, default: :idle]
+    ],
+    signal_routes: [
+      {"issue.review.requested",
+       Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessReviewRequestAction}
+    ]
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/triager_agent.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/agents/triager_agent.ex
@@ -1,0 +1,20 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Agents.TriagerAgent do
+  @moduledoc """
+  Example agent for issue classification.
+  """
+
+  use Jido.Agent,
+    name: "examples_phoenix_issue_triage_triager",
+    schema: [
+      role: [type: :string, default: "triager"],
+      last_issue_id: [type: :string, default: ""],
+      classification: [type: :atom, default: :unknown],
+      priority: [type: :atom, default: :normal],
+      last_summary: [type: :string, default: ""],
+      status: [type: :atom, default: :idle]
+    ],
+    signal_routes: [
+      {"issue.triage.requested",
+       Examples.PhoenixIssueTriage.IssueTriage.Actions.ProcessTriageRequestAction}
+    ]
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/artifacts.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/artifacts.ex
@@ -1,0 +1,140 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Artifacts do
+  @moduledoc """
+  Persists workflow artifacts into agent memory and thread state.
+
+  This module exists because action return values can update root state directly,
+  but memory/thread live under default plugin keys and need explicit `StateOp`
+  updates after helper calls mutate the in-memory agent struct.
+  """
+
+  alias Jido.Agent
+  alias Jido.Agent.StateOp
+  alias Jido.Memory.Agent, as: MemoryAgent
+  alias Jido.Thread.Agent, as: ThreadAgent
+
+  @spec artifact_ops(Agent.t()) :: [struct()]
+  def artifact_ops(%Agent{} = agent) do
+    []
+    |> maybe_put_memory(agent)
+    |> maybe_put_thread(agent)
+    |> Enum.reverse()
+  end
+
+  @spec remember_issue(Agent.t(), map()) :: Agent.t()
+  def remember_issue(%Agent{} = agent, attrs) do
+    labels = normalize_labels(Map.get(attrs, :labels, []))
+
+    issue = %{
+      issue_id: Map.get(attrs, :issue_id, ""),
+      repo: Map.get(attrs, :repo, ""),
+      title: Map.get(attrs, :title, ""),
+      body: Map.get(attrs, :body, ""),
+      labels: labels,
+      event_type: Map.get(attrs, :event_type, "issue_opened")
+    }
+
+    agent
+    |> ensure_workflow_spaces()
+    |> MemoryAgent.put_in_space(:world, :current_issue, issue)
+    |> MemoryAgent.append_to_space(:tasks, %{
+      id: "triage:#{issue.issue_id}",
+      type: :triage,
+      status: :pending
+    })
+    |> MemoryAgent.append_to_space(:events, %{kind: :issue_ingested, issue_id: issue.issue_id})
+    |> ThreadAgent.append(%{kind: :issue_ingested, payload: issue})
+  end
+
+  @spec remember_triage(Agent.t(), map()) :: Agent.t()
+  def remember_triage(%Agent{} = agent, attrs) do
+    summary = %{
+      issue_id: Map.get(attrs, :issue_id, ""),
+      classification: Map.get(attrs, :classification),
+      priority: Map.get(attrs, :priority),
+      requires_research?: Map.get(attrs, :requires_research?, false),
+      summary: Map.get(attrs, :summary, "")
+    }
+
+    agent
+    |> ensure_workflow_spaces()
+    |> MemoryAgent.put_in_space(:world, :triage, summary)
+    |> MemoryAgent.append_to_space(:events, %{kind: :triage_completed, issue_id: summary.issue_id})
+    |> ThreadAgent.append(%{kind: :triage_completed, payload: summary})
+  end
+
+  @spec remember_research(Agent.t(), map()) :: Agent.t()
+  def remember_research(%Agent{} = agent, attrs) do
+    summary = %{
+      issue_id: Map.get(attrs, :issue_id, ""),
+      research_summary: Map.get(attrs, :research_summary, ""),
+      confidence: Map.get(attrs, :confidence, :medium)
+    }
+
+    agent
+    |> ensure_workflow_spaces()
+    |> MemoryAgent.put_in_space(:world, :research, summary)
+    |> MemoryAgent.append_to_space(:events, %{
+      kind: :research_completed,
+      issue_id: summary.issue_id
+    })
+    |> ThreadAgent.append(%{kind: :research_completed, payload: summary})
+  end
+
+  @spec remember_review(Agent.t(), map()) :: Agent.t()
+  def remember_review(%Agent{} = agent, attrs) do
+    summary = %{
+      issue_id: Map.get(attrs, :issue_id, ""),
+      review_outcome: Map.get(attrs, :review_outcome, :changes_requested),
+      review_summary: Map.get(attrs, :review_summary, "")
+    }
+
+    agent
+    |> ensure_workflow_spaces()
+    |> MemoryAgent.put_in_space(:world, :review, summary)
+    |> MemoryAgent.append_to_space(:events, %{kind: :review_completed, issue_id: summary.issue_id})
+    |> ThreadAgent.append(%{kind: :review_completed, payload: summary})
+  end
+
+  @spec remember_publish(Agent.t(), map()) :: Agent.t()
+  def remember_publish(%Agent{} = agent, attrs) do
+    summary = %{
+      issue_id: Map.get(attrs, :issue_id, ""),
+      artifact_ref: Map.get(attrs, :artifact_ref, "")
+    }
+
+    agent
+    |> ensure_workflow_spaces()
+    |> MemoryAgent.put_in_space(:world, :publish, summary)
+    |> MemoryAgent.append_to_space(:events, %{
+      kind: :publish_completed,
+      issue_id: summary.issue_id
+    })
+    |> ThreadAgent.append(%{kind: :publish_completed, payload: summary})
+  end
+
+  defp ensure_workflow_spaces(agent) do
+    agent
+    |> MemoryAgent.ensure()
+    |> MemoryAgent.ensure_space(:events, [])
+  end
+
+  defp normalize_labels(labels) when is_list(labels) do
+    Enum.map(labels, &to_string/1)
+  end
+
+  defp normalize_labels(_other), do: []
+
+  defp maybe_put_memory(ops, agent) do
+    case MemoryAgent.get(agent) do
+      nil -> ops
+      memory -> [StateOp.set_path([MemoryAgent.key()], memory) | ops]
+    end
+  end
+
+  defp maybe_put_thread(ops, agent) do
+    case ThreadAgent.get(agent) do
+      nil -> ops
+      thread -> [StateOp.set_path([ThreadAgent.key()], thread) | ops]
+    end
+  end
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/plugins/issue_run_ops_plugin.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/plugins/issue_run_ops_plugin.ex
@@ -1,0 +1,28 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Plugins.IssueRunOpsPlugin do
+  @moduledoc """
+  Pod-level operations plugin that owns sensor subscriptions and runtime ops state.
+  """
+
+  use Jido.Plugin,
+    name: "issue_run_ops",
+    state_key: :ops,
+    actions: [],
+    schema:
+      Zoi.object(
+        %{
+          heartbeat_count: Zoi.integer() |> Zoi.default(0),
+          webhook_event_count: Zoi.integer() |> Zoi.default(0),
+          last_heartbeat_at: Zoi.any() |> Zoi.optional(),
+          last_heartbeat_message: Zoi.string() |> Zoi.default(""),
+          last_webhook_event: Zoi.string() |> Zoi.default(""),
+          last_signal_source: Zoi.string() |> Zoi.default("")
+        },
+        coerce: true
+      ),
+    subscriptions: [
+      {Jido.Sensors.Heartbeat, %{interval: 100, message: "issue-run-alive"}},
+      {Examples.PhoenixIssueTriage.IssueTriage.Sensors.IssueWebhookSensor,
+       %{source_path: "/phoenix/webhooks/issues"}}
+    ],
+    capabilities: [:workflow_ops, :subscriptions]
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/pod.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/pod.ex
@@ -1,0 +1,70 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Pod do
+  @moduledoc """
+  Durable multi-agent runtime definition for issue triage runs.
+
+  In a Phoenix app this is not the module controllers or LiveViews should call
+  directly. It defines the runtime shape. The application-facing boundary lives
+  in `Examples.PhoenixIssueTriage.IssueTriage`.
+  """
+
+  alias Examples.PhoenixIssueTriage.IssueTriage.{Actions, Agents, Plugins}
+
+  use Jido.Pod,
+    name: "issue_triage_pod",
+    plugins: [Plugins.IssueRunOpsPlugin],
+    schema: [
+      repo: [type: :string, default: ""],
+      issue_id: [type: :string, default: ""],
+      title: [type: :string, default: ""],
+      body: [type: :string, default: ""],
+      labels: [type: {:list, :string}, default: []],
+      status: [type: :atom, default: :new],
+      current_stage: [type: :atom, default: :new],
+      requires_research?: [type: :boolean, default: false],
+      triage_summary: [type: :string, default: ""],
+      classification: [type: :atom, default: :unknown],
+      priority: [type: :atom, default: :normal],
+      research_summary: [type: :string, default: ""],
+      research_confidence: [type: :atom, default: :medium],
+      review_outcome: [type: :atom, default: :pending],
+      review_summary: [type: :string, default: ""],
+      published_artifact: [type: :string, default: ""]
+    ],
+    signal_routes: [
+      {"jido.sensor.heartbeat", Actions.TrackHeartbeatAction},
+      {"issue.webhook.received", Actions.IngestIssueAction},
+      {"issue.triage.completed", Actions.HandleTriageCompletedAction},
+      {"issue.research.completed", Actions.HandleResearchCompletedAction},
+      {"issue.review.completed", Actions.HandleReviewCompletedAction},
+      {"issue.publish.completed", Actions.HandlePublishCompletedAction}
+    ],
+    topology:
+      Jido.Pod.Topology.new!(
+        name: "issue_triage_pod",
+        nodes: %{
+          triager: %{
+            agent: Agents.TriagerAgent,
+            manager: :example_issue_triage_triagers,
+            activation: :eager,
+            initial_state: %{role: "triager"}
+          },
+          researcher: %{
+            agent: Agents.ResearcherAgent,
+            manager: :example_issue_triage_researchers,
+            activation: :lazy,
+            initial_state: %{role: "researcher"}
+          },
+          reviewer: %{
+            agent: Agents.ReviewerAgent,
+            manager: :example_issue_triage_reviewers,
+            activation: :lazy,
+            initial_state: %{role: "reviewer"}
+          }
+        },
+        links: [
+          {:depends_on, :researcher, :triager},
+          {:depends_on, :reviewer, :triager},
+          {:depends_on, :reviewer, :researcher}
+        ]
+      )
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/policy.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/policy.ex
@@ -1,0 +1,64 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Policy do
+  @moduledoc """
+  Example-specific workflow heuristics for the issue triage showcase.
+
+  These rules are not Jido runtime concerns; they stand in for whatever
+  classification or policy logic a real app would own.
+  """
+
+  @spec classify(String.t(), String.t(), [String.t()]) :: atom()
+  def classify(title, body, labels) do
+    downcased = Enum.map(labels, &String.downcase/1)
+    haystack = String.downcase("#{title}\n#{body}")
+
+    cond do
+      "bug" in downcased or String.contains?(haystack, "crash") or
+          String.contains?(haystack, "error") ->
+        :bug
+
+      "support" in downcased or String.contains?(haystack, "how do i") ->
+        :support
+
+      true ->
+        :feature
+    end
+  end
+
+  @spec priority(String.t(), [String.t()]) :: atom()
+  def priority(body, labels) do
+    downcased = Enum.map(labels, &String.downcase/1)
+    haystack = String.downcase(body)
+
+    cond do
+      "urgent" in downcased or "p0" in downcased or String.contains?(haystack, "production") ->
+        :high
+
+      "needs-research" in downcased or String.contains?(haystack, "unknown root cause") ->
+        :medium
+
+      true ->
+        :normal
+    end
+  end
+
+  @spec requires_research?(String.t(), [String.t()]) :: boolean()
+  def requires_research?(body, labels) do
+    downcased = Enum.map(labels, &String.downcase/1)
+    haystack = String.downcase(body)
+
+    "needs-research" in downcased or
+      String.contains?(haystack, "unknown root cause") or
+      String.contains?(haystack, "deep dive")
+  end
+
+  @spec review_outcome(atom(), String.t()) :: atom()
+  def review_outcome(priority, research_summary) do
+    cond do
+      priority == :high and research_summary in ["", nil] ->
+        :changes_requested
+
+      true ->
+        :approved
+    end
+  end
+end

--- a/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/sensors/issue_webhook_sensor.ex
+++ b/examples/phoenix_issue_triage/lib/examples/phoenix_issue_triage/issue_triage/sensors/issue_webhook_sensor.ex
@@ -1,0 +1,35 @@
+defmodule Examples.PhoenixIssueTriage.IssueTriage.Sensors.IssueWebhookSensor do
+  @moduledoc """
+  Converts webhook-style issue events into Jido signals for the pod manager.
+  """
+
+  use Jido.Sensor,
+    name: "issue_webhook_sensor",
+    description: "Receives Phoenix webhook events and emits issue intake signals",
+    schema:
+      Zoi.object(
+        %{
+          source_path:
+            Zoi.string(description: "Logical source for emitted signals")
+            |> Zoi.default("/phoenix/webhooks/issues")
+        },
+        coerce: true
+      )
+
+  @impl Jido.Sensor
+  def init(config, _context) do
+    {:ok, %{source_path: config.source_path, received_count: 0}}
+  end
+
+  @impl Jido.Sensor
+  def handle_event({event_type, payload}, state) when is_map(payload) do
+    signal =
+      Jido.Signal.new!(
+        "issue.webhook.received",
+        Map.put(payload, :event_type, to_string(event_type)),
+        source: state.source_path
+      )
+
+    {:ok, %{state | received_count: state.received_count + 1}, [{:emit, signal}]}
+  end
+end


### PR DESCRIPTION
## Summary
- add a top-level examples area
- add a Phoenix-shaped Pod domain example that wraps a Pod in a public domain module
- demonstrate the convention of a domain API module with nested Pod, policy, artifacts, agents, actions, plugins, and sensors

## Notes
- this is intended for design/docs feedback
- not proposing new core runtime APIs in this PR
- example code lives outside the normal lib compile path on purpose