### PR TITLE
Define the canonical memory plugin replacement slot

### DIFF
--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -296,6 +296,11 @@ rationale and a more general pattern, see
 
 The Memory plugin gives every agent an on-demand cognitive memory container stored at `agent.state[:__memory__]`. Memory is organized into **spaces** — named containers holding either map (key-value) or list (ordered items) data. Two reserved spaces, `:world` and `:tasks`, are created by default. Domain-specific wrappers should be built in your own modules on top of the generic space primitives.
 
+The built-in plugin is deliberately minimal. Packages that provide their own
+memory implementation should use the same `:__memory__` state key and replace
+the default through `default_plugins:`, not by mounting a second memory plugin
+in `plugins:`.
+
 ```elixir
 alias Jido.Memory.Agent, as: MemoryAgent
 
@@ -334,6 +339,11 @@ use Jido.Agent,
 use Jido.Agent,
   name: "configured",
   default_plugins: %{__identity__: {MyApp.CustomIdentityPlugin, %{profile: %{age: 10}}}}
+
+# Replace memory while preserving the canonical :__memory__ state key
+use Jido.Agent,
+  name: "persistent_memory",
+  default_plugins: %{__memory__: {MyApp.PersistentMemoryPlugin, %{store: MyApp.Store}}}
 
 # Disable memory (keep others)
 use Jido.Agent,

--- a/lib/jido/memory/plugin.ex
+++ b/lib/jido/memory/plugin.ex
@@ -16,6 +16,21 @@ defmodule Jido.Memory.Plugin do
         name: "minimal",
         default_plugins: %{__memory__: false}
 
+  ## Replacement
+
+  Packages that provide a richer memory implementation should replace this
+  default plugin through the `:__memory__` default-plugin slot:
+
+      use Jido.Agent,
+        name: "persistent_memory_agent",
+        default_plugins: %{
+          __memory__: {MyApp.PersistentMemoryPlugin, %{store: MyApp.Store}}
+        }
+
+  Do this instead of mounting a second memory plugin in `plugins:`. The
+  replacement plugin should also declare `state_key: :__memory__` so runtime
+  integrations can discover memory state at the canonical key.
+
   ## State Key
 
   Memory is stored at `agent.state[:__memory__]` as a `Jido.Memory` struct.

--- a/test/jido/memory/plugin_test.exs
+++ b/test/jido/memory/plugin_test.exs
@@ -4,6 +4,24 @@ defmodule JidoTest.Memory.PluginTest do
   alias Jido.Memory
   alias Jido.Memory.Plugin, as: MemoryPlugin
 
+  defmodule ExternalMemoryPlugin do
+    @moduledoc false
+    @state_schema Zoi.object(%{backend: Zoi.atom() |> Zoi.default(:external)})
+    @config_schema Zoi.object(%{backend: Zoi.atom() |> Zoi.default(:external)})
+
+    use Jido.Plugin,
+      name: "external_memory",
+      state_key: :__memory__,
+      actions: [],
+      schema: @state_schema,
+      config_schema: @config_schema,
+      singleton: true,
+      capabilities: [:memory]
+
+    @impl true
+    def mount(_agent, config), do: {:ok, %{backend: Map.get(config, :backend, :external)}}
+  end
+
   describe "plugin metadata" do
     test "name is memory" do
       assert MemoryPlugin.name() == "memory"
@@ -70,6 +88,12 @@ defmodule JidoTest.Memory.PluginTest do
         default_plugins: %{__memory__: false}
     end
 
+    defmodule AgentWithExternalMemory do
+      use Jido.Agent,
+        name: "memory_plugin_test_external_memory",
+        default_plugins: %{__memory__: {ExternalMemoryPlugin, %{backend: :persistent}}}
+    end
+
     test "agent includes memory plugin by default" do
       modules = AgentWithMemory.plugins()
       assert Jido.Memory.Plugin in modules
@@ -83,6 +107,15 @@ defmodule JidoTest.Memory.PluginTest do
     test "agent can disable memory plugin" do
       modules = AgentWithoutMemory.plugins()
       refute Jido.Memory.Plugin in modules
+    end
+
+    test "agent can replace memory through the canonical default plugin slot" do
+      modules = AgentWithExternalMemory.plugins()
+      agent = AgentWithExternalMemory.new()
+
+      assert ExternalMemoryPlugin in modules
+      refute Jido.Memory.Plugin in modules
+      assert agent.state[:__memory__].backend == :persistent
     end
 
     test "memory can be attached after creation via Memory.Agent" do


### PR DESCRIPTION
## Summary
- document `:__memory__` as the reserved default-plugin replacement slot for richer memory implementations
- call out that replacement plugins should use `state_key: :__memory__`
- add a memory-specific regression test for configured default plugin replacement

## Tests
- `mix format --check-formatted`
- `mix test test/jido/memory/plugin_test.exs test/jido/agent/default_plugins_test.exs`