### PR TITLE
fix(observability): quiet routed action logs

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -882,11 +882,13 @@ defmodule Jido.Agent do
 
         jido_instance = Keyword.get(opts, :__jido_instance__)
         partition = Keyword.get(opts, :__partition__, Map.get(agent.state, :__partition__))
+        action_exec_defaults = Keyword.get(opts, :__jido_action_exec_defaults__, [])
 
         instruction_opts =
           opts
           |> Keyword.delete(:__jido_instance__)
           |> Keyword.delete(:__partition__)
+          |> Keyword.delete(:__jido_action_exec_defaults__)
 
         case Instruction.normalize(action, %{state: agent.state}, instruction_opts) do
           {:ok, instructions} ->
@@ -895,7 +897,9 @@ defmodule Jido.Agent do
 
             normalized_instructions =
               Enum.map(instructions, fn instr ->
-                AgentStrategy.normalize_instruction(strat, instr, ctx)
+                strat
+                |> AgentStrategy.normalize_instruction(instr, ctx)
+                |> __apply_action_exec_defaults__(action_exec_defaults)
               end)
 
             {agent, directives} = strat.cmd(agent, normalized_instructions, ctx)
@@ -906,6 +910,21 @@ defmodule Jido.Agent do
             {agent, [%Jido.Agent.Directive.Error{error: error, context: :normalize}]}
         end
       end
+
+      defp __apply_action_exec_defaults__(%Instruction{opts: opts} = instruction, defaults)
+           when is_list(defaults) and is_list(opts) do
+        merged_opts =
+          defaults
+          |> Enum.reverse()
+          |> Enum.reduce(opts, fn
+            {key, value}, acc when is_atom(key) -> Keyword.put_new(acc, key, value)
+            _invalid, acc -> acc
+          end)
+
+        %{instruction | opts: merged_opts}
+      end
+
+      defp __apply_action_exec_defaults__(instruction, _defaults), do: instruction
     end
   end
 

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -201,6 +201,7 @@ defmodule Jido.AgentServer do
   alias Jido.Agent.Directive
   alias Jido.AgentServer.Signal.{ChildExit, ChildStarted, Orphaned}
   alias Jido.Config.Defaults
+  alias Jido.Observe.Config, as: ObserveConfig
   alias Jido.RuntimeStore
   alias Jido.Sensor.Runtime, as: SensorRuntime
   alias Jido.Signal
@@ -1523,10 +1524,7 @@ defmodule Jido.AgentServer do
       end
 
     {agent, directives} =
-      state.agent_module.cmd(state.agent, action_arg,
-        __jido_instance__: state.jido,
-        __partition__: state.partition
-      )
+      state.agent_module.cmd(state.agent, action_arg, agent_cmd_opts(state))
 
     {:ok, agent, List.wrap(directives), action_arg}
   end
@@ -1792,10 +1790,7 @@ defmodule Jido.AgentServer do
       end
 
     {agent, directives} =
-      agent_module.cmd(state.agent, action_arg,
-        __jido_instance__: state.jido,
-        __partition__: state.partition
-      )
+      agent_module.cmd(state.agent, action_arg, agent_cmd_opts(state))
 
     directives = List.wrap(directives)
     state = State.update_agent(state, agent)
@@ -1866,6 +1861,14 @@ defmodule Jido.AgentServer do
 
   defp target_to_action({mod, params}, _signal) when is_atom(mod) and is_map(params) do
     {mod, params}
+  end
+
+  defp agent_cmd_opts(%State{} = state) do
+    [
+      __jido_instance__: state.jido,
+      __partition__: state.partition,
+      __jido_action_exec_defaults__: ObserveConfig.action_exec_opts(state.jido, [])
+    ]
   end
 
   # ---------------------------------------------------------------------------

--- a/test/jido/agent_server/telemetry_test.exs
+++ b/test/jido/agent_server/telemetry_test.exs
@@ -6,6 +6,7 @@ defmodule JidoTest.AgentServer.TelemetryTest do
   alias Jido.Agent.Directive
   alias Jido.AgentServer
   alias Jido.Debug
+  alias Jido.Instruction
   alias Jido.Signal
   alias JidoTest.TestActions
 
@@ -43,6 +44,63 @@ defmodule JidoTest.AgentServer.TelemetryTest do
         {"schedule_directive", ScheduleDirectiveAction}
       ]
     end
+  end
+
+  defmodule FallbackExecStrategy do
+    @moduledoc false
+    use Jido.Agent.Strategy
+
+    @impl true
+    def cmd(agent, instructions, _ctx) do
+      send_instruction_opts(agent, instructions)
+      Enum.each(instructions, &Jido.Exec.run/1)
+      {agent, []}
+    end
+
+    defp send_instruction_opts(%{state: %{observer_pid: pid}}, instructions) when is_pid(pid) do
+      send(pid, {:fallback_exec_instruction_opts, Enum.map(instructions, & &1.opts)})
+    end
+
+    defp send_instruction_opts(_agent, _instructions), do: :ok
+  end
+
+  defmodule FallbackExecAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "fallback_exec_agent",
+      schema: [
+        observer_pid: [type: :any, default: nil]
+      ],
+      strategy: FallbackExecStrategy
+
+    def signal_routes(_ctx) do
+      [{"fallback_exec", JidoTest.TestActions.IncrementAction}]
+    end
+  end
+
+  defmodule InspectOptsStrategy do
+    @moduledoc false
+    use Jido.Agent.Strategy
+
+    @impl true
+    def cmd(agent, instructions, _ctx) do
+      send(
+        agent.state.observer_pid,
+        {:inspect_instruction_opts, Enum.map(instructions, & &1.opts)}
+      )
+
+      {agent, []}
+    end
+  end
+
+  defmodule InspectOptsAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "inspect_opts_agent",
+      schema: [
+        observer_pid: [type: :any, default: nil]
+      ],
+      strategy: InspectOptsStrategy
   end
 
   setup context do
@@ -174,6 +232,70 @@ defmodule JidoTest.AgentServer.TelemetryTest do
       assert_receive {:action_telemetry_event, [:jido, :action, :stop], _, _}
 
       GenServer.stop(pid)
+    end
+
+    test "passes quiet action exec opts to custom strategies", %{jido: jido} do
+      {:ok, pid} =
+        AgentServer.start_link(
+          agent: FallbackExecAgent,
+          id: "telemetry-custom-strategy",
+          initial_state: %{observer_pid: self()},
+          jido: jido
+        )
+
+      signal = Signal.new!("fallback_exec", %{}, source: "/test")
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _agent} = AgentServer.call(pid, signal)
+        end)
+
+      refute log =~ "Executing JidoTest.TestActions.IncrementAction"
+      refute log =~ "with params:"
+
+      assert_receive {:fallback_exec_instruction_opts, [opts]}
+      assert Keyword.get(opts, :log_level) == :warning
+      assert Keyword.get(opts, :telemetry) == :silent
+
+      refute_receive {:action_telemetry_event, [:jido, :action, :start], _, _}, 50
+
+      GenServer.stop(pid)
+    end
+
+    test "preserves explicit instruction opts when applying action exec defaults" do
+      agent = InspectOptsAgent.new(state: %{observer_pid: self()})
+
+      instruction = %Instruction{
+        action: TestActions.IncrementAction,
+        opts: [log_level: :info, telemetry: :full, timeout: 100]
+      }
+
+      assert {_agent, []} =
+               InspectOptsAgent.cmd(agent, instruction,
+                 __jido_action_exec_defaults__: [log_level: :warning, telemetry: :silent]
+               )
+
+      assert_receive {:inspect_instruction_opts,
+                      [[log_level: :info, telemetry: :full, timeout: 100]]}
+    end
+
+    test "applies action exec defaults without requiring keyword instruction opts" do
+      agent = InspectOptsAgent.new(state: %{observer_pid: self()})
+
+      instruction = %Instruction{
+        action: TestActions.IncrementAction,
+        opts: [:custom_flag]
+      }
+
+      assert {_agent, []} =
+               InspectOptsAgent.cmd(agent, instruction,
+                 __jido_action_exec_defaults__: [log_level: :warning, telemetry: :silent]
+               )
+
+      assert_receive {:inspect_instruction_opts, [opts]}
+      assert Keyword.get(opts, :log_level) == :warning
+      assert Keyword.get(opts, :telemetry) == :silent
+      assert :custom_flag in opts
     end
   end
 


### PR DESCRIPTION
## Summary
- propagate derived action exec logging/telemetry defaults from AgentServer into agent cmd dispatch
- preserve explicit instruction opts and original action specs seen by hooks
- harden default insertion so list-shaped instruction opts do not crash custom strategies
- add regression coverage for custom strategies that call Jido.Exec.run/1 directly and for explicit opts

## Issue
Refs #216 follow-up comments about noisy Jido.AI / Noop action logs during streaming.

## Verification
- mix format lib/jido/agent.ex test/jido/agent_server/telemetry_test.exs --check-formatted
- mix test test/jido/agent_server/telemetry_test.exs
- mix test test/jido/agent/signal_handling_test.exs test/jido/agent_server/telemetry_test.exs test/jido/agent/strategy_test.exs
- mix test
- mix q