### PR TITLE
feat(agent_server): add cluster runtime roles

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -363,6 +363,46 @@ defmodule Jido.AgentServer do
   end
 
   @doc """
+  Exports a cluster-safe runtime snapshot for handoff or replica bootstrap.
+  """
+  @spec cluster_snapshot(server()) :: {:ok, map()} | {:error, term()}
+  def cluster_snapshot(server) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, :cluster_snapshot)
+    end
+  end
+
+  @doc """
+  Imports a previously exported runtime snapshot.
+  """
+  @spec import_cluster_snapshot(server(), map()) :: :ok | {:error, term()}
+  def import_cluster_snapshot(server, snapshot) when is_map(snapshot) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, {:import_cluster_snapshot, snapshot})
+    end
+  end
+
+  @doc """
+  Promotes the runtime into active primary mode.
+  """
+  @spec promote(server()) :: :ok | {:error, term()}
+  def promote(server) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, {:set_cluster_role, :primary})
+    end
+  end
+
+  @doc """
+  Demotes the runtime into passive standby mode.
+  """
+  @spec demote(server()) :: :ok | {:error, term()}
+  def demote(server) do
+    with {:ok, pid} <- resolve_server(server) do
+      GenServer.call(pid, {:set_cluster_role, :standby})
+    end
+  end
+
+  @doc """
   Wait for an agent to reach a terminal status (`:completed` or `:failed`).
 
   This is an event-driven wait - the caller blocks until the agent's state
@@ -974,13 +1014,17 @@ defmodule Jido.AgentServer do
 
         state = State.update_agent(state, agent)
 
-        case State.enqueue_all(state, init_signal(), List.wrap(directives)) do
-          {:ok, enq_state} ->
-            enq_state
+        if standby?(state) do
+          state
+        else
+          case State.enqueue_all(state, init_signal(), List.wrap(directives)) do
+            {:ok, enq_state} ->
+              enq_state
 
-          {:error, :queue_overflow} ->
-            Logger.warning("AgentServer #{state.id} queue overflow during strategy init")
-            state
+            {:error, :queue_overflow} ->
+              Logger.warning("AgentServer #{state.id} queue overflow during strategy init")
+              state
+          end
         end
       else
         state
@@ -1039,6 +1083,20 @@ defmodule Jido.AgentServer do
 
   def handle_call(:get_state, _from, state) do
     {:reply, {:ok, state}, state}
+  end
+
+  def handle_call(:cluster_snapshot, _from, %State{} = state) do
+    {:reply, {:ok, export_cluster_snapshot(state)}, state}
+  end
+
+  def handle_call({:import_cluster_snapshot, snapshot}, _from, %State{} = state)
+      when is_map(snapshot) do
+    {:reply, :ok, apply_cluster_snapshot(state, snapshot)}
+  end
+
+  def handle_call({:set_cluster_role, role}, _from, %State{} = state)
+      when role in [:primary, :standby] do
+    {:reply, :ok, set_cluster_role(state, role)}
   end
 
   def handle_call({:set_debug, enabled}, _from, %State{} = state) do
@@ -1544,26 +1602,34 @@ defmodule Jido.AgentServer do
           Map.merge(metadata, signal_stop_metadata(directives))
         )
 
-        case State.enqueue_all(state, signal, directives) do
-          {:ok, enq_state} ->
-            enq_state = start_drain_if_idle(enq_state)
+        if standby?(state) do
+          transformed_agent =
+            run_plugin_transform_hooks(state.agent, resolved_action, signal, state)
 
-            transformed_agent =
-              run_plugin_transform_hooks(enq_state.agent, resolved_action, signal, enq_state)
+          GenServer.reply(from, {:ok, transformed_agent})
+          maybe_set_idle_status(state)
+        else
+          case State.enqueue_all(state, signal, directives) do
+            {:ok, enq_state} ->
+              enq_state = start_drain_if_idle(enq_state)
 
-            GenServer.reply(from, {:ok, transformed_agent})
-            enq_state
+              transformed_agent =
+                run_plugin_transform_hooks(enq_state.agent, resolved_action, signal, enq_state)
 
-          {:error, :queue_overflow} ->
-            emit_telemetry(
-              [:jido, :agent_server, :queue, :overflow],
-              %{queue_size: state.max_queue_size},
-              metadata
-            )
+              GenServer.reply(from, {:ok, transformed_agent})
+              enq_state
 
-            Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
-            GenServer.reply(from, {:error, :queue_overflow})
-            maybe_set_idle_status(state)
+            {:error, :queue_overflow} ->
+              emit_telemetry(
+                [:jido, :agent_server, :queue, :overflow],
+                %{queue_size: state.max_queue_size},
+                metadata
+              )
+
+              Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
+              GenServer.reply(from, {:error, :queue_overflow})
+              maybe_set_idle_status(state)
+          end
         end
 
       {:error, reason, directives} ->
@@ -1617,6 +1683,84 @@ defmodule Jido.AgentServer do
     else
       state
     end
+  end
+
+  defp standby?(%State{cluster_role: :standby}), do: true
+  defp standby?(%State{}), do: false
+
+  defp export_cluster_snapshot(%State{} = state) do
+    %{
+      agent: state.agent,
+      cron_specs: state.cron_specs
+    }
+  end
+
+  defp apply_cluster_snapshot(%State{} = state, snapshot) do
+    state
+    |> deactivate_cluster_runtime()
+    |> Map.put(:agent, Map.fetch!(snapshot, :agent))
+    |> Map.put(:cron_specs, Map.get(snapshot, :cron_specs, %{}))
+    |> Map.put(:queue, :queue.new())
+    |> Map.put(:signal_call_inflight, nil)
+    |> Map.put(:signal_call_queue, :queue.new())
+    |> Map.put(:deferred_async_signals, :queue.new())
+    |> Map.put(:processing, false)
+    |> Map.put(:status, :idle)
+    |> Map.put(:completion_waiters, %{})
+  end
+
+  defp set_cluster_role(%State{} = state, role) when role in [:primary, :standby] do
+    state =
+      case role do
+        :primary ->
+          state
+          |> State.set_cluster_role(:primary)
+          |> activate_cluster_runtime()
+
+        :standby ->
+          state
+          |> deactivate_cluster_runtime()
+          |> State.set_cluster_role(:standby)
+      end
+
+    maybe_set_idle_status(state)
+  end
+
+  defp activate_cluster_runtime(%State{} = state) do
+    state
+    |> start_plugin_children()
+    |> start_plugin_subscriptions()
+    |> register_plugin_schedules()
+    |> register_restored_cron_specs()
+  end
+
+  defp deactivate_cluster_runtime(%State{} = state) do
+    state
+    |> cancel_cluster_cron_jobs()
+    |> stop_cluster_children()
+  end
+
+  defp cancel_cluster_cron_jobs(%State{} = state) do
+    Enum.reduce(Map.keys(state.cron_jobs), state, fn logical_id, acc ->
+      {_pid, new_state} =
+        untrack_cron_job(acc, logical_id, cancel?: true, drop_runtime_spec?: false)
+
+      new_state
+    end)
+  end
+
+  defp stop_cluster_children(%State{} = state) do
+    Enum.each(state.children, fn {_tag, child} ->
+      if is_pid(child.pid) and Process.alive?(child.pid) do
+        Process.exit(child.pid, :shutdown)
+      end
+
+      if is_reference(child.ref) do
+        Process.demonitor(child.ref, [:flush])
+      end
+    end)
+
+    %{state | children: %{}}
   end
 
   defp process_signal(%Signal{} = signal, %State{signal_router: router} = state) do
@@ -1802,19 +1946,23 @@ defmodule Jido.AgentServer do
       Map.merge(metadata, signal_stop_metadata(directives))
     )
 
-    case State.enqueue_all(state, signal, directives) do
-      {:ok, enq_state} ->
-        {:ok, start_drain_if_idle(enq_state), action_arg}
+    if standby?(state) do
+      {:ok, maybe_set_idle_status(state), action_arg}
+    else
+      case State.enqueue_all(state, signal, directives) do
+        {:ok, enq_state} ->
+          {:ok, start_drain_if_idle(enq_state), action_arg}
 
-      {:error, :queue_overflow} ->
-        emit_telemetry(
-          [:jido, :agent_server, :queue, :overflow],
-          %{queue_size: state.max_queue_size},
-          metadata
-        )
+        {:error, :queue_overflow} ->
+          emit_telemetry(
+            [:jido, :agent_server, :queue, :overflow],
+            %{queue_size: state.max_queue_size},
+            metadata
+          )
 
-        Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
-        {:error, :queue_overflow, state}
+          Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
+          {:error, :queue_overflow, state}
+      end
     end
   end
 
@@ -2059,6 +2207,8 @@ defmodule Jido.AgentServer do
   # ---------------------------------------------------------------------------
 
   @doc false
+  defp start_plugin_children(%State{cluster_role: :standby} = state), do: state
+
   defp start_plugin_children(%State{} = state) do
     agent_module = state.agent_module
 
@@ -2134,6 +2284,8 @@ defmodule Jido.AgentServer do
   # ---------------------------------------------------------------------------
 
   @doc false
+  defp start_plugin_subscriptions(%State{cluster_role: :standby} = state), do: state
+
   defp start_plugin_subscriptions(%State{} = state) do
     agent_module = state.agent_module
 
@@ -2231,6 +2383,8 @@ defmodule Jido.AgentServer do
   defp register_restored_cron_specs(%State{cron_specs: cron_specs} = state)
        when map_size(cron_specs) == 0,
        do: state
+
+  defp register_restored_cron_specs(%State{cluster_role: :standby} = state), do: state
 
   defp register_restored_cron_specs(%State{} = state) do
     Enum.reduce(state.cron_specs, state, fn {job_id, spec}, acc_state ->

--- a/lib/jido/agent_server/options.ex
+++ b/lib/jido/agent_server/options.ex
@@ -59,6 +59,9 @@ defmodule Jido.AgentServer.Options do
               skip_schedules:
                 Zoi.boolean(description: "Skip registering plugin schedules (useful for tests)")
                 |> Zoi.default(false),
+              cluster_role:
+                Zoi.atom(description: "Cluster runtime role (:primary | :standby)")
+                |> Zoi.default(:primary),
 
               # InstanceManager integration (set by Jido.Agent.InstanceManager)
               lifecycle_mod:
@@ -121,6 +124,7 @@ defmodule Jido.AgentServer.Options do
     with {:ok, _} <- validate_agent(attrs[:agent]),
          {:ok, _} <- validate_partition(attrs[:partition], agent_partition),
          {:ok, _} <- validate_error_policy(attrs[:error_policy]),
+         {:ok, _} <- validate_cluster_role(attrs[:cluster_role]),
          {:ok, parent} <- validate_parent(attrs[:parent]) do
       attrs = Map.put(attrs, :parent, parent)
       Zoi.parse(@schema, attrs)
@@ -227,6 +231,16 @@ defmodule Jido.AgentServer.Options do
        partition: partition,
        agent_partition: agent_partition
      })}
+  end
+
+  @doc false
+  @spec validate_cluster_role(term()) :: {:ok, :primary | :standby} | {:error, term()}
+  def validate_cluster_role(nil), do: {:ok, :primary}
+  def validate_cluster_role(:primary), do: {:ok, :primary}
+  def validate_cluster_role(:standby), do: {:ok, :standby}
+
+  def validate_cluster_role(other) do
+    {:error, Jido.Error.validation_error("invalid cluster_role: #{inspect(other)}")}
   end
 
   defp validate_parent(nil), do: {:ok, nil}

--- a/lib/jido/agent_server/state.ex
+++ b/lib/jido/agent_server/state.ex
@@ -79,6 +79,9 @@ defmodule Jido.AgentServer.State do
               skip_schedules:
                 Zoi.boolean(description: "Skip registering plugin schedules")
                 |> Zoi.default(false),
+              cluster_role:
+                Zoi.atom(description: "Cluster runtime role (:primary | :standby)")
+                |> Zoi.default(:primary),
               restored_from_storage:
                 Zoi.boolean(description: "Whether the startup agent was already thawed")
                 |> Zoi.default(false),
@@ -191,7 +194,8 @@ defmodule Jido.AgentServer.State do
         cron_restart_timer_refs: %{},
         cron_specs: restored_cron_specs,
         cron_runtime_specs: %{},
-        skip_schedules: opts.skip_schedules,
+        skip_schedules: opts.skip_schedules || opts.cluster_role == :standby,
+        cluster_role: opts.cluster_role,
         restored_from_storage: opts.restored_from_storage,
         error_count: 0,
         metrics: %{},
@@ -254,6 +258,14 @@ defmodule Jido.AgentServer.State do
       state
       | agent: inject_runtime_refs(agent, state.partition, state.parent, state.orphaned_from)
     }
+  end
+
+  @doc """
+  Sets the cluster runtime role.
+  """
+  @spec set_cluster_role(t(), :primary | :standby) :: t()
+  def set_cluster_role(%__MODULE__{} = state, role) when role in [:primary, :standby] do
+    %{state | cluster_role: role, skip_schedules: role == :standby}
   end
 
   @doc """

--- a/test/jido/agent_server/cluster_runtime_test.exs
+++ b/test/jido/agent_server/cluster_runtime_test.exs
@@ -1,0 +1,98 @@
+defmodule JidoTest.AgentServer.ClusterRuntimeTest do
+  use JidoTest.Case, async: true
+
+  alias Jido.AgentServer
+  alias JidoTest.TestActions
+
+  defmodule IncrementAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "cluster_increment",
+      schema: [
+        amount: [type: :integer, default: 1]
+      ]
+
+    @impl true
+    def run(%{amount: amount}, context) do
+      count = Map.get(context.state, :count, 0)
+      {:ok, %{count: count + amount}}
+    end
+  end
+
+  defmodule CounterAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "cluster_counter_agent",
+      schema: [
+        count: [type: :integer, default: 0]
+      ],
+      signal_routes: [
+        {"inc", JidoTest.AgentServer.ClusterRuntimeTest.IncrementAction}
+      ]
+  end
+
+  defmodule EffectsAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "cluster_effects_agent",
+      schema: [
+        triggered: [type: :boolean, default: false]
+      ],
+      signal_routes: [
+        {"multi", TestActions.MultiEffectAction}
+      ]
+  end
+
+  test "standby runtimes suppress directive side effects", context do
+    pid =
+      start_server(
+        context,
+        EffectsAgent,
+        cluster_role: :standby,
+        skip_schedules: true
+      )
+
+    signal = signal("multi")
+
+    assert {:ok, agent} = AgentServer.call(pid, signal)
+    assert agent.state.triggered == true
+
+    assert {:ok, state} = AgentServer.state(pid)
+    assert state.cluster_role == :standby
+    assert :queue.is_empty(state.queue)
+    assert state.cron_jobs == %{}
+    assert state.children == %{}
+  end
+
+  test "cluster snapshot import and role promotion round-trip runtime state", context do
+    primary = start_server(context, CounterAgent)
+    signal = signal("inc", %{amount: 3})
+
+    assert {:ok, updated} = AgentServer.call(primary, signal)
+    assert updated.state.count == 3
+
+    assert {:ok, snapshot} = AgentServer.cluster_snapshot(primary)
+
+    standby =
+      start_server(
+        context,
+        CounterAgent,
+        cluster_role: :standby,
+        skip_schedules: true
+      )
+
+    assert :ok = AgentServer.import_cluster_snapshot(standby, snapshot)
+
+    assert {:ok, imported_state} = AgentServer.state(standby)
+    assert imported_state.cluster_role == :standby
+    assert imported_state.agent.state.count == 3
+
+    assert :ok = AgentServer.promote(standby)
+    assert {:ok, promoted_state} = AgentServer.state(standby)
+    assert promoted_state.cluster_role == :primary
+
+    assert :ok = AgentServer.demote(standby)
+    assert {:ok, demoted_state} = AgentServer.state(standby)
+    assert demoted_state.cluster_role == :standby
+  end
+end


### PR DESCRIPTION
## Description

Adds first-class AgentServer cluster runtime roles for primary/standby operation. Standby runtimes can import snapshots and suppress active side effects, while primaries can export snapshots for handoff or replica bootstrap.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. `cluster_role` defaults to `:primary`, so existing AgentServer behavior is unchanged.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Additional local downstream checks:

- `jido_cluster`: `mix compile --warnings-as-errors && mix test`
- `jido_fabric`: `mix compile --warnings-as-errors && mix test`

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
