### PR TITLE
refactor: fix ex_slop findings

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -1099,11 +1099,15 @@ defmodule Jido.Agent do
 
       defp normalize_keys(map) when is_map(map) do
         Map.new(map, fn
-          {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+          {k, v} when is_binary(k) -> {existing_atom_or_original(k), v}
           pair -> pair
         end)
+      end
+
+      defp existing_atom_or_original(key) do
+        String.to_existing_atom(key)
       rescue
-        ArgumentError -> map
+        ArgumentError -> key
       end
     end
   end

--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -1062,8 +1062,9 @@ defmodule Jido.Agent do
     quote location: :keep do
       @impl true
       def restore(data, ctx) do
-        agent = new(id: data[:id] || data["id"])
-        base_state = data[:state] || data["state"] || %{}
+        data = normalize_keys(data)
+        agent = new(id: data[:id])
+        base_state = data[:state] || %{}
         agent = %{agent | state: Map.merge(agent.state, base_state)}
         externalized_keys = data[:externalized_keys] || %{}
 
@@ -1094,6 +1095,15 @@ defmodule Jido.Agent do
             {:cont, {:ok, acc}}
           end
         end)
+      end
+
+      defp normalize_keys(map) when is_map(map) do
+        Map.new(map, fn
+          {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+          pair -> pair
+        end)
+      rescue
+        ArgumentError -> map
       end
     end
   end
@@ -1294,8 +1304,8 @@ defmodule Jido.Agent do
         @validated_plugin_routes elem(@plugin_routes_result, 1)
 
         # Validate plugin requirements at compile time
-        @plugin_config_map Enum.reduce(@plugin_instances, %{}, fn instance, acc ->
-                             Map.put(acc, instance.state_key, instance.config)
+        @plugin_config_map Map.new(@plugin_instances, fn instance ->
+                             {instance.state_key, instance.config}
                            end)
         @requirements_result Jido.Plugin.Requirements.validate_all_requirements(
                                @plugin_instances,

--- a/lib/jido/plugin/config.ex
+++ b/lib/jido/plugin/config.ex
@@ -105,10 +105,7 @@ defmodule Jido.Plugin.Config do
     config_schema = get_config_schema(plugin_module)
 
     if config_schema do
-      case Zoi.parse(config_schema, config) do
-        {:ok, validated} -> {:ok, validated}
-        {:error, errors} -> {:error, errors}
-      end
+      Zoi.parse(config_schema, config)
     else
       {:ok, config}
     end

--- a/lib/jido/pod/mutation/planner.ex
+++ b/lib/jido/pod/mutation/planner.ex
@@ -244,7 +244,7 @@ defmodule Jido.Pod.Mutation.Planner do
       end)
 
     indegree =
-      Enum.reduce(ordered_nodes, %{}, fn name, acc -> Map.put(acc, name, 0) end)
+      Map.new(ordered_nodes, fn name -> {name, 0} end)
       |> then(fn base ->
         Enum.reduce(edges, base, fn {_prereq, dependent}, acc ->
           Map.update!(acc, dependent, &(&1 + 1))

--- a/lib/jido/pod/topology.ex
+++ b/lib/jido/pod/topology.ex
@@ -535,7 +535,7 @@ defmodule Jido.Pod.Topology do
       end)
 
     indegree =
-      Enum.reduce(ordered_nodes, %{}, fn name, acc -> Map.put(acc, name, 0) end)
+      Map.new(ordered_nodes, fn name -> {name, 0} end)
       |> then(fn base ->
         Enum.reduce(edges, base, fn {_prereq, dependent}, acc ->
           Map.update!(acc, dependent, &(&1 + 1))

--- a/lib/jido/runtime_store.ex
+++ b/lib/jido/runtime_store.ex
@@ -94,10 +94,7 @@ defmodule Jido.RuntimeStore do
   """
   @spec fetch(atom(), hive(), key()) :: {:ok, value()} | :error
   def fetch(instance, hive, key) when is_atom(instance) do
-    case call(instance, {:fetch, hive, key}, :error) do
-      {:ok, value} -> {:ok, value}
-      :error -> :error
-    end
+    call(instance, {:fetch, hive, key}, :error)
   end
 
   @doc """

--- a/lib/jido/storage/file.ex
+++ b/lib/jido/storage/file.ex
@@ -220,8 +220,6 @@ defmodule Jido.Storage.File do
              now
            ) do
       {:ok, thread}
-    else
-      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/jido/storage/redis.ex
+++ b/lib/jido/storage/redis.ex
@@ -199,8 +199,6 @@ defmodule Jido.Storage.Redis do
 
       with {:ok, _} <- command_fn.(command) do
         {:ok, reconstruct_thread(thread_id, updated_thread)}
-      else
-        {:error, reason} -> {:error, reason}
       end
     end
   end

--- a/lib/jido/thread/store/adapters/journal_backed.ex
+++ b/lib/jido/thread/store/adapters/journal_backed.ex
@@ -136,13 +136,15 @@ defmodule Jido.Thread.Store.Adapters.JournalBacked do
   end
 
   defp decode_entry(%Signal{data: data}) when is_map(data) do
+    data = normalize_keys(data)
+
     %Entry{
-      id: data["entry_id"] || data[:entry_id],
-      seq: data["seq"] || data[:seq],
-      at: data["at"] || data[:at],
-      kind: to_atom(data["kind"] || data[:kind]),
-      payload: data["payload"] || data[:payload] || %{},
-      refs: data["refs"] || data[:refs] || %{}
+      id: data[:entry_id],
+      seq: data[:seq],
+      at: data[:at],
+      kind: to_atom(data[:kind]),
+      payload: data[:payload] || %{},
+      refs: data[:refs] || %{}
     }
   rescue
     _ -> nil
@@ -181,5 +183,14 @@ defmodule Jido.Thread.Store.Adapters.JournalBacked do
     :crypto.strong_rand_bytes(length)
     |> Base.url_encode64()
     |> binary_part(0, length)
+  end
+
+  defp normalize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      pair -> pair
+    end)
+  rescue
+    ArgumentError -> map
   end
 end

--- a/lib/jido/thread/store/adapters/journal_backed.ex
+++ b/lib/jido/thread/store/adapters/journal_backed.ex
@@ -187,10 +187,14 @@ defmodule Jido.Thread.Store.Adapters.JournalBacked do
 
   defp normalize_keys(map) when is_map(map) do
     Map.new(map, fn
-      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      {k, v} when is_binary(k) -> {existing_atom_or_original(k), v}
       pair -> pair
     end)
+  end
+
+  defp existing_atom_or_original(key) do
+    String.to_existing_atom(key)
   rescue
-    ArgumentError -> map
+    ArgumentError -> key
   end
 end

--- a/test/jido/plugin/restore_hooks_test.exs
+++ b/test/jido/plugin/restore_hooks_test.exs
@@ -106,6 +106,13 @@ defmodule JidoTest.Plugin.RestoreHooksTest do
       schema: [counter: [type: :integer, default: 0]]
   end
 
+  defmodule AgentWithSchemaOnly do
+    use Jido.Agent,
+      name: "restore_schema_only_agent",
+      default_plugins: false,
+      schema: [counter: [type: :integer, default: 0]]
+  end
+
   describe "restore calls plugin on_restore/2" do
     test "externalized plugin state is restored via on_restore" do
       agent = AgentWithExternalizePlugin.new()
@@ -236,6 +243,27 @@ defmodule JidoTest.Plugin.RestoreHooksTest do
       {:ok, restored} = AgentWithExternalizePlugin.restore(legacy_checkpoint, %{})
 
       assert restored.state[:ext] == %{id: "legacy", rev: 1}
+    end
+
+    test "restore accepts string-keyed checkpoints with unknown keys" do
+      unknown_key = "unknown_#{System.unique_integer([:positive])}"
+
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom(unknown_key)
+      end
+
+      checkpoint = %{
+        "version" => 1,
+        "agent_module" => AgentWithSchemaOnly,
+        "id" => "string-keyed-agent",
+        "state" => %{counter: 7},
+        unknown_key => true
+      }
+
+      {:ok, restored} = AgentWithSchemaOnly.restore(checkpoint, %{})
+
+      assert restored.id == "string-keyed-agent"
+      assert restored.state[:counter] == 7
     end
 
     test "restore passes config to on_restore context" do

--- a/test/jido/thread/journal_backed_adapter_test.exs
+++ b/test/jido/thread/journal_backed_adapter_test.exs
@@ -1,6 +1,8 @@
 defmodule Jido.Thread.Store.Adapters.JournalBackedTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Signal
+  alias Jido.Signal.Journal
   alias Jido.Thread
   alias Jido.Thread.Entry
   alias Jido.Thread.Store
@@ -43,6 +45,46 @@ defmodule Jido.Thread.Store.Adapters.JournalBackedTest do
       assert Enum.at(entries, 0).payload.content == "First"
       assert Enum.at(entries, 1).payload.content == "Second"
       assert Enum.at(entries, 2).payload.name == "search"
+    end
+
+    test "loads string-keyed signal data with unknown keys" do
+      {:ok, state} = JournalBacked.init([])
+      unknown_key = "unknown_#{System.unique_integer([:positive])}"
+
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom(unknown_key)
+      end
+
+      signal =
+        Signal.new!(%{
+          id: "sig_string_keyed_entry",
+          type: "jido.thread.entry",
+          source: "jido.thread",
+          subject: "string-keyed-thread",
+          time: DateTime.utc_now() |> DateTime.to_iso8601(),
+          data: %{
+            "entry_id" => "entry-string-1",
+            "seq" => 0,
+            "at" => 123,
+            "kind" => "message",
+            "payload" => %{content: "Hello"},
+            "refs" => %{signal_id: "sig_string_keyed_entry"},
+            unknown_key => true
+          }
+        })
+
+      {:ok, journal} = Journal.record(state.journal, signal)
+
+      assert {:ok, _state, loaded} =
+               JournalBacked.load(%{state | journal: journal}, "string-keyed-thread")
+
+      [entry] = Thread.to_list(loaded)
+      assert entry.id == "entry-string-1"
+      assert entry.seq == 0
+      assert entry.at == 123
+      assert entry.kind == :message
+      assert entry.payload == %{content: "Hello"}
+      assert entry.refs == %{signal_id: "sig_string_keyed_entry"}
     end
 
     test "preserves entry metadata" do


### PR DESCRIPTION
## Summary

Code quality fixes found with [`ex_slop`](https://hex.pm/packages/ex_slop). 12 issues across 8 files.

- Remove identity `case`/`else` blocks in plugin/config, runtime_store, storage/file, storage/redis
- Replace `Enum.reduce(%{}, ..., Map.put)` with `Map.new/2` in agent, planner, topology
- Normalize keys at boundary for DualKeyAccess in agent `restore/2` and journal_backed `decode_entry/1`

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)