### PR TITLE
[codex] Generate markdown docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -190,7 +190,7 @@ defmodule Jido.MixProject do
         {"LICENSE", title: "Apache 2.0 License"}
       ],
       extra_section: "Guides",
-      formatters: ["html"],
+      formatters: ["html", "markdown"],
       skip_undefined_reference_warnings_on: [
         "CHANGELOG.md",
         "LICENSE"
@@ -435,7 +435,7 @@ defmodule Jido.MixProject do
       test: "test --exclude flaky",
 
       # Helper to run docs
-      docs: "docs -f html --open",
+      docs: "docs --open",
 
       # Run to check the quality of your code
       q: ["quality"],


### PR DESCRIPTION
## Summary

- Enable ExDoc's markdown formatter alongside HTML for the Jido package docs.
- Move formatter selection into `docs/0` and simplify the docs alias to `docs --open`.

## Why

Hex.pm can serve `llms.txt` for packages when markdown docs are generated. The previous config forced HTML only through both the docs config and alias.

## Validation

- `mix format --check-formatted mix.exs`
- `mix docs -f html -f markdown`

The docs build reported markdown output at `doc/llms.txt`.