### PR TITLE
feat(error): sanitize public error payloads

### DIFF
--- a/guides/errors.md
+++ b/guides/errors.md
@@ -251,10 +251,15 @@ map = Jido.Error.to_map(error)
 %{
   type: :validation_error,
   message: "Bad input",
-  details: %{},
-  stacktrace: [...]
+  details: %{kind: :input, subject: :email},
+  retryable?: false
 }
 ```
+
+`to_map/1` is the public transport-safe error boundary. It does not include
+stacktraces by default, redacts sensitive detail keys, bounds nested values, and
+keeps retryability derived centrally from the structured error type plus any
+explicit `:retry`, `:retryable`, or `:retryable?` detail hint.
 
 ### Extracting Messages
 

--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -463,31 +463,90 @@ defmodule Jido.Error do
   # Utilities
   # ============================================================================
 
-  @doc """
-  Converts an error struct to a normalized map.
+  @transport_max_depth 4
+  @transport_max_items 20
+  @transport_max_string 512
+  @transport_inspect_limit 50
+  @transport_printable_limit 200
+  @redacted "[REDACTED]"
+  @omitted "[OMITTED]"
+  @depth_limit "[DEPTH_LIMIT]"
+  @sensitive_key_parts MapSet.new(~w[
+    api_key
+    apikey
+    authorization
+    credential
+    credentials
+    password
+    private_key
+    secret
+    token
+  ])
 
-  Returns a map with `:type`, `:message`, `:details`, and `:stacktrace` keys.
+  @doc """
+  Converts an error into a stable, public map.
+
+  The returned map is suitable for transport and reporting boundaries. It
+  includes bounded, sanitized details and never includes stacktraces by default.
   """
   @spec to_map(any()) :: map()
   def to_map(error) do
-    case error do
-      %{message: message} = err ->
-        %{
-          type: unified_type(err),
-          message: message,
-          details: Map.get(err, :details, %{}),
-          stacktrace: capture_stacktrace()
-        }
-
-      _ ->
-        %{
-          type: :internal,
-          message: inspect(error),
-          details: %{},
-          stacktrace: capture_stacktrace()
-        }
-    end
+    %{
+      type: unified_type(error),
+      message: public_message(error),
+      details: public_details(error),
+      retryable?: retryable?(error)
+    }
   end
+
+  @doc """
+  Returns whether an error is safe to retry by default.
+
+  Explicit `:retry`, `:retryable`, and `:retryable?` boolean hints in structured
+  details override the default classification.
+  """
+  @spec retryable?(term()) :: boolean()
+  def retryable?({:error, reason, _effects}), do: retryable?(reason)
+  def retryable?({:error, reason}), do: retryable?(reason)
+  def retryable?(%ValidationError{details: details}), do: retryable_hint(details, false)
+
+  def retryable?(%ExecutionError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%RoutingError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%TimeoutError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%CompensationError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%InternalError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%Internal.UnknownError{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%{retryable?: value}) when is_boolean(value), do: value
+  def retryable?(%{retryable: value}) when is_boolean(value), do: value
+  def retryable?(%{"retryable" => value}) when is_boolean(value), do: value
+  def retryable?(%{"retryable?" => value}) when is_boolean(value), do: value
+
+  def retryable?(%{type: type} = error) when is_atom(type),
+    do: retryable_hint(Map.get(error, :details, error), default_retryable_for_type?(type))
+
+  def retryable?(%{"type" => type} = error) when is_atom(type),
+    do: retryable_hint(Map.get(error, "details", error), default_retryable_for_type?(type))
+
+  def retryable?(%{details: details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(%{"details" => details} = error),
+    do: retryable_hint(details, default_retryable?(error))
+
+  def retryable?(reason) when is_atom(reason), do: default_retryable?(reason)
+  def retryable?(_reason), do: true
 
   @doc """
   Extracts the message string from a nested error structure.
@@ -557,6 +616,219 @@ defmodule Jido.Error do
     Enum.drop(stacktrace, 2)
   end
 
+  defp public_message(error) when is_exception(error),
+    do: truncate_string(Exception.message(error))
+
+  defp public_message(%{message: message}), do: transport_string(message)
+  defp public_message(%{"message" => message}), do: transport_string(message)
+  defp public_message(error), do: error |> sanitize_transport() |> safe_inspect()
+
+  defp public_details(%ValidationError{} = error) do
+    error.details
+    |> sanitize_details()
+    |> merge_public_fields(%{
+      kind: error.kind,
+      subject: error.subject
+    })
+  end
+
+  defp public_details(%ExecutionError{} = error) do
+    error.details
+    |> sanitize_details()
+    |> merge_public_fields(%{phase: error.phase})
+  end
+
+  defp public_details(%RoutingError{} = error) do
+    error.details
+    |> sanitize_details()
+    |> merge_public_fields(%{target: error.target})
+  end
+
+  defp public_details(%TimeoutError{} = error) do
+    error.details
+    |> sanitize_details()
+    |> merge_public_fields(%{timeout: error.timeout})
+  end
+
+  defp public_details(%CompensationError{} = error) do
+    error.details
+    |> sanitize_details()
+    |> merge_public_fields(%{
+      original_error: maybe_error_map(error.original_error),
+      compensated: error.compensated,
+      result: error.result
+    })
+  end
+
+  defp public_details(%{details: details}), do: sanitize_details(details)
+  defp public_details(%{"details" => details}), do: sanitize_details(details)
+  defp public_details(_error), do: %{}
+
+  defp maybe_error_map(nil), do: nil
+  defp maybe_error_map(error), do: to_map(error)
+
+  defp sanitize_details(details) when is_map(details), do: sanitize_transport(details)
+  defp sanitize_details(details) when details in [nil, []], do: %{}
+  defp sanitize_details(details), do: %{value: sanitize_transport(details)}
+
+  defp merge_public_fields(details, fields) do
+    fields
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new(fn {key, value} -> {key, sanitize_transport(value)} end)
+    |> then(&Map.merge(details, &1))
+  end
+
+  defp sanitize_transport(value, depth \\ @transport_max_depth)
+  defp sanitize_transport(_value, 0), do: @depth_limit
+  defp sanitize_transport(value, _depth) when is_binary(value), do: truncate_string(value)
+
+  defp sanitize_transport(value, _depth)
+       when is_boolean(value) or is_number(value) or is_atom(value), do: value
+
+  defp sanitize_transport(%_{} = value, _depth) when is_exception(value) do
+    %{
+      type: value.__struct__ |> Module.split() |> Enum.join("."),
+      message: truncate_string(Exception.message(value))
+    }
+  end
+
+  defp sanitize_transport(%_{} = value, depth) do
+    value
+    |> Map.from_struct()
+    |> Map.put(:struct, value.__struct__)
+    |> sanitize_transport(depth)
+  rescue
+    _ -> safe_inspect(value)
+  end
+
+  defp sanitize_transport(value, depth) when is_map(value) do
+    value
+    |> Enum.take(@transport_max_items)
+    |> Map.new(fn {key, nested_value} ->
+      sanitized_key = sanitize_key(key)
+
+      nested_value =
+        cond do
+          sensitive_key?(sanitized_key) -> @redacted
+          stacktrace_key?(sanitized_key) -> @omitted
+          true -> sanitize_transport(nested_value, depth - 1)
+        end
+
+      {sanitized_key, nested_value}
+    end)
+  end
+
+  defp sanitize_transport(value, depth) when is_list(value) do
+    value
+    |> Enum.take(@transport_max_items)
+    |> Enum.map(&sanitize_transport(&1, depth - 1))
+  end
+
+  defp sanitize_transport(value, _depth) when is_tuple(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_function(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_pid(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_reference(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth), do: safe_inspect(value)
+
+  defp sanitize_key(key) when is_atom(key) or is_binary(key), do: key
+  defp sanitize_key(key), do: safe_inspect(key)
+
+  defp sensitive_key?(key) do
+    normalized_key = normalized_key(key)
+
+    MapSet.member?(@sensitive_key_parts, normalized_key) ||
+      normalized_key |> key_parts() |> Enum.any?(&MapSet.member?(@sensitive_key_parts, &1))
+  end
+
+  defp stacktrace_key?(key) do
+    normalized_key(key) in ["stacktrace", "stack_trace"]
+  end
+
+  defp normalized_key(key) when is_atom(key), do: key |> Atom.to_string() |> String.downcase()
+  defp normalized_key(key) when is_binary(key), do: String.downcase(key)
+
+  defp key_parts(key), do: String.split(key, ~r/[^a-z0-9]+/, trim: true)
+
+  defp transport_string(value) when is_binary(value), do: truncate_string(value)
+  defp transport_string(%{message: message}), do: transport_string(message)
+  defp transport_string(value), do: value |> sanitize_transport() |> safe_inspect()
+
+  defp safe_inspect(value) do
+    value
+    |> inspect(limit: @transport_inspect_limit, printable_limit: @transport_printable_limit)
+    |> truncate_string()
+  rescue
+    _ -> inspect_fallback(value)
+  end
+
+  defp inspect_fallback(value) do
+    module =
+      case value do
+        %{__struct__: struct} when is_atom(struct) -> inspect(struct)
+        _ -> value |> :erlang.term_to_binary() |> byte_size() |> then(&"#{&1} bytes")
+      end
+
+    "#Inspect.Error<#{module}>"
+  end
+
+  defp truncate_string(value, max_chars \\ @transport_max_string) when is_binary(value) do
+    if String.length(value) > max_chars do
+      String.slice(value, 0, max_chars) <> "...(truncated)"
+    else
+      value
+    end
+  end
+
+  defp retryable_hint(term, default) do
+    case extract_retry_hint(term) do
+      value when is_boolean(value) -> value
+      _ -> default
+    end
+  end
+
+  defp extract_retry_hint(%{details: details}) do
+    case extract_retry_hint(details) do
+      nil -> nil
+      value -> value
+    end
+  end
+
+  defp extract_retry_hint(%{} = map) do
+    cond do
+      is_boolean(Map.get(map, :retry)) -> Map.get(map, :retry)
+      is_boolean(Map.get(map, "retry")) -> Map.get(map, "retry")
+      is_boolean(Map.get(map, :retryable)) -> Map.get(map, :retryable)
+      is_boolean(Map.get(map, "retryable")) -> Map.get(map, "retryable")
+      is_boolean(Map.get(map, :retryable?)) -> Map.get(map, :retryable?)
+      is_boolean(Map.get(map, "retryable?")) -> Map.get(map, "retryable?")
+      Map.has_key?(map, :reason) -> extract_retry_hint(Map.get(map, :reason))
+      Map.has_key?(map, "reason") -> extract_retry_hint(Map.get(map, "reason"))
+      true -> nil
+    end
+  end
+
+  defp extract_retry_hint(keyword) when is_list(keyword) do
+    if Keyword.keyword?(keyword) do
+      cond do
+        is_boolean(Keyword.get(keyword, :retry)) -> Keyword.get(keyword, :retry)
+        is_boolean(Keyword.get(keyword, :retryable)) -> Keyword.get(keyword, :retryable)
+        is_boolean(Keyword.get(keyword, :retryable?)) -> Keyword.get(keyword, :retryable?)
+        true -> nil
+      end
+    end
+  end
+
+  defp extract_retry_hint(_term), do: nil
+
+  defp default_retryable?(type) when is_atom(type), do: default_retryable_for_type?(type)
+  defp default_retryable?(error), do: error |> unified_type() |> default_retryable_for_type?()
+
+  defp default_retryable_for_type?(type)
+       when type in [:validation_error, :invalid_action, :invalid_sensor, :config_error],
+       do: false
+
+  defp default_retryable_for_type?(_type), do: true
+
   # Maps error structs to unified type atoms
   defp unified_type(%ValidationError{kind: :action}), do: :invalid_action
   defp unified_type(%ValidationError{kind: :sensor}), do: :invalid_sensor
@@ -583,6 +855,9 @@ defmodule Jido.Error do
   defp unified_type(%Jido.Signal.Error.TimeoutError{}), do: :timeout
   defp unified_type(%Jido.Signal.Error.DispatchError{}), do: :routing_error
   defp unified_type(%Jido.Signal.Error.InternalError{}), do: :internal
+
+  defp unified_type(%{type: type}) when is_atom(type), do: type
+  defp unified_type(%{"type" => type}) when is_atom(type), do: type
 
   defp unified_type(_), do: :internal
 end

--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -468,6 +468,24 @@ defmodule Jido.Error do
   @transport_max_string 512
   @transport_inspect_limit 50
   @transport_printable_limit 200
+  @non_retryable_error_type_strings ~w[
+    validation_error
+    invalid_action
+    invalid_sensor
+    config_error
+  ]
+  @known_error_type_strings %{
+    "validation_error" => :validation_error,
+    "invalid_action" => :invalid_action,
+    "invalid_sensor" => :invalid_sensor,
+    "config_error" => :config_error,
+    "planning_error" => :planning_error,
+    "execution_error" => :execution_error,
+    "routing_error" => :routing_error,
+    "timeout" => :timeout,
+    "compensation_error" => :compensation_error,
+    "internal" => :internal
+  }
   @redacted "[REDACTED]"
   @omitted "[OMITTED]"
   @depth_limit "[DEPTH_LIMIT]"
@@ -546,7 +564,13 @@ defmodule Jido.Error do
   def retryable?(%{type: type} = error) when is_atom(type),
     do: retryable_hint(Map.get(error, :details, error), default_retryable_for_type?(type))
 
+  def retryable?(%{type: type} = error) when is_binary(type),
+    do: retryable_hint(Map.get(error, :details, error), default_retryable_for_type?(type))
+
   def retryable?(%{"type" => type} = error) when is_atom(type),
+    do: retryable_hint(Map.get(error, "details", error), default_retryable_for_type?(type))
+
+  def retryable?(%{"type" => type} = error) when is_binary(type),
     do: retryable_hint(Map.get(error, "details", error), default_retryable_for_type?(type))
 
   def retryable?(%{details: details} = error),
@@ -712,7 +736,30 @@ defmodule Jido.Error do
   end
 
   defp sanitize_transport(value, depth) when is_map(value) do
-    value
+    sanitize_key_value_pairs(value, depth)
+  end
+
+  defp sanitize_transport(value, depth) when is_list(value) do
+    if key_value_list?(value) do
+      sanitize_key_value_pairs(value, depth)
+    else
+      value
+      |> Enum.take(@transport_max_items)
+      |> Enum.map(&sanitize_transport(&1, depth - 1))
+    end
+  end
+
+  defp sanitize_transport(value, _depth) when is_tuple(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_function(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_pid(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth) when is_reference(value), do: safe_inspect(value)
+  defp sanitize_transport(value, _depth), do: safe_inspect(value)
+
+  defp sanitize_key(key) when is_atom(key) or is_binary(key), do: key
+  defp sanitize_key(key), do: safe_inspect(key)
+
+  defp sanitize_key_value_pairs(entries, depth) do
+    entries
     |> Enum.take(@transport_max_items)
     |> Map.new(fn {key, nested_value} ->
       sanitized_key = sanitize_key(key)
@@ -728,20 +775,13 @@ defmodule Jido.Error do
     end)
   end
 
-  defp sanitize_transport(value, depth) when is_list(value) do
-    value
-    |> Enum.take(@transport_max_items)
-    |> Enum.map(&sanitize_transport(&1, depth - 1))
+  defp key_value_list?(value) do
+    value != [] and
+      Enum.all?(value, fn
+        {key, _value} when is_atom(key) or is_binary(key) -> true
+        _other -> false
+      end)
   end
-
-  defp sanitize_transport(value, _depth) when is_tuple(value), do: safe_inspect(value)
-  defp sanitize_transport(value, _depth) when is_function(value), do: safe_inspect(value)
-  defp sanitize_transport(value, _depth) when is_pid(value), do: safe_inspect(value)
-  defp sanitize_transport(value, _depth) when is_reference(value), do: safe_inspect(value)
-  defp sanitize_transport(value, _depth), do: safe_inspect(value)
-
-  defp sanitize_key(key) when is_atom(key) or is_binary(key), do: key
-  defp sanitize_key(key), do: safe_inspect(key)
 
   defp sensitive_key?(key) do
     normalized_key = normalized_key(key)
@@ -846,6 +886,9 @@ defmodule Jido.Error do
        when type in [:validation_error, :invalid_action, :invalid_sensor, :config_error],
        do: false
 
+  defp default_retryable_for_type?(type) when is_binary(type),
+    do: normalize_type_string(type) not in @non_retryable_error_type_strings
+
   defp default_retryable_for_type?(_type), do: true
 
   # Maps error structs to unified type atoms
@@ -876,7 +919,19 @@ defmodule Jido.Error do
   defp unified_type(%Jido.Signal.Error.InternalError{}), do: :internal
 
   defp unified_type(%{type: type}) when is_atom(type), do: type
+  defp unified_type(%{type: type}) when is_binary(type), do: unified_type_from_string(type)
   defp unified_type(%{"type" => type}) when is_atom(type), do: type
+  defp unified_type(%{"type" => type}) when is_binary(type), do: unified_type_from_string(type)
 
   defp unified_type(_), do: :internal
+
+  defp unified_type_from_string(type) do
+    Map.get(@known_error_type_strings, normalize_type_string(type), :internal)
+  end
+
+  defp normalize_type_string(type) do
+    type
+    |> String.trim()
+    |> String.trim_leading(":")
+  end
 end

--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -482,6 +482,16 @@ defmodule Jido.Error do
     secret
     token
   ])
+  @sensitive_key_fragments ~w[
+    apikey
+    authorization
+    credential
+    credentials
+    password
+    privatekey
+    secret
+    token
+  ]
 
   @doc """
   Converts an error into a stable, public map.
@@ -735,19 +745,28 @@ defmodule Jido.Error do
 
   defp sensitive_key?(key) do
     normalized_key = normalized_key(key)
+    key_parts = key_parts(normalized_key)
+    compact_key = compact_key(normalized_key)
 
     MapSet.member?(@sensitive_key_parts, normalized_key) ||
-      normalized_key |> key_parts() |> Enum.any?(&MapSet.member?(@sensitive_key_parts, &1))
+      Enum.any?(key_parts, &MapSet.member?(@sensitive_key_parts, &1)) ||
+      Enum.any?(@sensitive_key_fragments, &String.contains?(compact_key, &1))
   end
 
   defp stacktrace_key?(key) do
-    normalized_key(key) in ["stacktrace", "stack_trace"]
+    normalized_key = normalized_key(key)
+    compact_key = compact_key(normalized_key)
+
+    normalized_key in ["stacktrace", "stack_trace"] ||
+      "stacktrace" in key_parts(normalized_key) ||
+      String.contains?(compact_key, "stacktrace")
   end
 
   defp normalized_key(key) when is_atom(key), do: key |> Atom.to_string() |> String.downcase()
   defp normalized_key(key) when is_binary(key), do: String.downcase(key)
 
   defp key_parts(key), do: String.split(key, ~r/[^a-z0-9]+/, trim: true)
+  defp compact_key(key), do: String.replace(key, ~r/[^a-z0-9]+/, "")
 
   defp transport_string(value) when is_binary(value), do: truncate_string(value)
   defp transport_string(%{message: message}), do: transport_string(message)

--- a/test/jido/error_coverage_test.exs
+++ b/test/jido/error_coverage_test.exs
@@ -151,7 +151,8 @@ defmodule JidoTest.ErrorCoverageTest do
       assert result.type == :internal
       assert result.message =~ "some"
       assert result.details == %{}
-      assert is_list(result.stacktrace)
+      assert result.retryable? == true
+      refute Map.has_key?(result, :stacktrace)
     end
 
     test "handles string error" do

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -3,6 +3,10 @@ defmodule JidoTest.ErrorTest do
 
   alias Jido.Error
 
+  defmodule BadInspect do
+    defstruct [:token]
+  end
+
   describe "validation_error/2" do
     test "creates a validation error with message" do
       error = Error.validation_error("Invalid input")
@@ -234,13 +238,15 @@ defmodule JidoTest.ErrorTest do
       end
     end
 
-    test "converts validation error to map with message and stacktrace" do
+    test "converts validation error to public map without stacktrace" do
       error = Error.validation_error("Invalid", field: :email)
       result = Error.to_map(error)
 
       assert result.type == :validation_error
       assert result.message == "Invalid"
-      assert is_list(result.stacktrace)
+      assert result.details == %{kind: :input, subject: :email}
+      assert result.retryable? == false
+      refute Map.has_key?(result, :stacktrace)
     end
 
     test "converts compensation error to map" do
@@ -249,12 +255,70 @@ defmodule JidoTest.ErrorTest do
       result = Error.to_map(error)
 
       assert result.type == :compensation_error
+      assert result.details.compensated == true
+      assert result.details.original_error.type == :execution_error
+      assert result.details.original_error.message == "Original"
+    end
+
+    test "sanitizes nested details for public transport payloads" do
+      long_value = String.duplicate("x", 700)
+
+      error =
+        Error.execution_error("Failed",
+          details: %{
+            token: "secret-token",
+            authorization: "Bearer secret-token",
+            stacktrace: [{__MODULE__, :test, 0, []}],
+            message: long_value,
+            labels: Enum.map(1..30, &"label-#{&1}"),
+            nested: %{password: "secret-password", value: :ok},
+            bad: %BadInspect{token: "secret-token"}
+          }
+        )
+
+      result = Error.to_map(error)
+
+      assert result.details.token == "[REDACTED]"
+      assert result.details.authorization == "[REDACTED]"
+      assert result.details.stacktrace == "[OMITTED]"
+      assert result.details.message =~ "(truncated)"
+      assert length(result.details.labels) == 20
+      refute "label-21" in result.details.labels
+      assert result.details.nested.password == "[REDACTED]"
+      refute inspect(result.details) =~ "secret-password"
+      refute inspect(result.details) =~ "secret-token"
+      assert result.details.bad.token == "[REDACTED]"
+      assert Jason.encode!(result)
+    end
+
+    test "handles foreign exceptions without leaking stacktraces" do
+      result = Error.to_map(%RuntimeError{message: "foreign failure"})
+
+      assert result.type == :internal
+      assert result.message == "foreign failure"
+      assert result.details == %{}
+      assert result.retryable? == true
+      refute Map.has_key?(result, :stacktrace)
+    end
+
+    test "derives retryability from type and structured hints" do
+      assert Error.to_map(Error.timeout_error("Timed out")).retryable? == true
+      assert Error.to_map(Error.validation_error("Invalid")).retryable? == false
+
+      retryable_error = Error.validation_error("Retry anyway", details: %{retry: true})
+      non_retryable_error = Error.execution_error("Do not retry", details: %{retryable?: false})
+
+      assert Error.to_map(retryable_error).retryable? == true
+      assert Error.to_map(non_retryable_error).retryable? == false
+      assert Error.retryable?({:error, :timeout}) == true
+      assert Error.retryable?({:error, %{type: :validation_error}}) == false
     end
 
     test "handles unknown struct" do
       result = Error.to_map(%{unknown: "struct"})
 
       assert result.type == :internal
+      assert result.details == %{}
     end
   end
 

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -276,6 +276,8 @@ defmodule JidoTest.ErrorTest do
             message: long_value,
             labels: Enum.map(1..30, &"label-#{&1}"),
             nested: %{password: "secret-password", value: :ok},
+            headers: [{"authorization", "Bearer header-secret"}, {"x-request-id", "req-123"}],
+            opts: [password: "keyword-secret", timeout: 500],
             bad: %BadInspect{token: "secret-token"}
           }
         )
@@ -293,8 +295,14 @@ defmodule JidoTest.ErrorTest do
       assert length(result.details.labels) == 20
       refute "label-21" in result.details.labels
       assert result.details.nested.password == "[REDACTED]"
+      assert result.details.headers["authorization"] == "[REDACTED]"
+      assert result.details.headers["x-request-id"] == "req-123"
+      assert result.details.opts.password == "[REDACTED]"
+      assert result.details.opts.timeout == 500
       refute inspect(result.details) =~ "secret-password"
       refute inspect(result.details) =~ "secret-token"
+      refute inspect(result.details) =~ "header-secret"
+      refute inspect(result.details) =~ "keyword-secret"
       assert result.details.bad.token == "[REDACTED]"
       assert Jason.encode!(result)
     end
@@ -320,6 +328,26 @@ defmodule JidoTest.ErrorTest do
       assert Error.to_map(non_retryable_error).retryable? == false
       assert Error.retryable?({:error, :timeout}) == true
       assert Error.retryable?({:error, %{type: :validation_error}}) == false
+    end
+
+    test "recognizes known string types from public payloads" do
+      payload = %{
+        "type" => "validation_error",
+        "message" => "Invalid",
+        "details" => %{"password" => "secret-password"}
+      }
+
+      result = Error.to_map(payload)
+
+      assert result.type == :validation_error
+      assert result.message == "Invalid"
+      assert result.details["password"] == "[REDACTED]"
+      assert result.retryable? == false
+
+      assert Error.retryable?(%{
+               "type" => "execution_error",
+               "details" => %{"retryable" => false}
+             }) == false
     end
 
     test "handles unknown struct" do

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -267,8 +267,12 @@ defmodule JidoTest.ErrorTest do
         Error.execution_error("Failed",
           details: %{
             token: "secret-token",
+            secretToken: "secret-token",
+            privateKey: "private-key",
+            accessToken: "access-token",
             authorization: "Bearer secret-token",
             stacktrace: [{__MODULE__, :test, 0, []}],
+            stackTrace: [{__MODULE__, :test, 0, []}],
             message: long_value,
             labels: Enum.map(1..30, &"label-#{&1}"),
             nested: %{password: "secret-password", value: :ok},
@@ -279,8 +283,12 @@ defmodule JidoTest.ErrorTest do
       result = Error.to_map(error)
 
       assert result.details.token == "[REDACTED]"
+      assert result.details.secretToken == "[REDACTED]"
+      assert result.details.privateKey == "[REDACTED]"
+      assert result.details.accessToken == "[REDACTED]"
       assert result.details.authorization == "[REDACTED]"
       assert result.details.stacktrace == "[OMITTED]"
+      assert result.details.stackTrace == "[OMITTED]"
       assert result.details.message =~ "(truncated)"
       assert length(result.details.labels) == 20
       refute "label-21" in result.details.labels


### PR DESCRIPTION
## Summary
- make `Jido.Error.to_map/1` return transport-safe public payloads without default stacktraces
- add bounded detail sanitization with sensitive-key redaction, stacktrace omission, collection/string limits, and struct/exception normalization
- centralize retryability with `Jido.Error.retryable?/1` and include `retryable?` in public payloads
- update error docs and tests for the new public payload contract

## Verification
- `mix test`
- `mix test test/jido/error_test.exs test/jido/error_coverage_test.exs`
- `mix q`

Closes #262