### PR TITLE
refactor(logging): localize lazy logger calls

### DIFF
--- a/lib/jido/agent/directive/cron.ex
+++ b/lib/jido/agent/directive/cron.ex
@@ -70,9 +70,9 @@ defmodule Jido.Agent.Directive.Cron do
          {:ok, pid} <- AgentServer.start_runtime_cron_job(state, logical_id, runtime_spec),
          {:ok, persisted_state} <-
            persist_then_commit_registration(state, pid, logical_id, cron_spec, runtime_spec) do
-      Logger.debug(
+      Logger.debug(fn ->
         "AgentServer #{agent_id} registered cron job #{inspect(logical_id)}: #{cron_expr}"
-      )
+      end)
 
       AgentServer.emit_cron_telemetry_event(persisted_state, :register, %{
         job_id: logical_id,
@@ -82,9 +82,9 @@ defmodule Jido.Agent.Directive.Cron do
       {:ok, persisted_state}
     else
       {:error, reason} ->
-        Logger.error(
+        Logger.error(fn ->
           "AgentServer #{agent_id} failed to register cron job #{inspect(logical_id)}: #{inspect(reason)}"
-        )
+        end)
 
         {:ok, handle_failed_registration(state, logical_id, on_failure)}
     end

--- a/lib/jido/agent/directive/cron_cancel.ex
+++ b/lib/jido/agent/directive/cron_cancel.ex
@@ -44,7 +44,9 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.CronCancel do
 
         new_state = %{runtime_state | cron_specs: proposed_specs}
 
-        Logger.debug("AgentServer #{agent_id} cancelled cron job #{inspect(logical_id)}")
+        Logger.debug(fn ->
+          "AgentServer #{agent_id} cancelled cron job #{inspect(logical_id)}"
+        end)
 
         emit_telemetry(new_state, :cancel, %{job_id: logical_id})
         {:ok, new_state}
@@ -53,9 +55,10 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.CronCancel do
         {_pid, runtime_state} = drop_runtime_job(state, logical_id)
         new_state = %{runtime_state | cron_specs: proposed_specs}
 
-        Logger.error(
-          "AgentServer #{agent_id} failed to persist cron cancellation for #{inspect(logical_id)}: #{inspect(reason)}"
-        )
+        Logger.error(fn ->
+          "AgentServer #{agent_id} cancelled cron job #{inspect(logical_id)} " <>
+            "after checkpoint persistence failure: #{inspect(reason)}"
+        end)
 
         emit_telemetry(state, :persist_failure, %{
           job_id: logical_id,
@@ -66,9 +69,10 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.CronCancel do
         {:ok, new_state}
 
       {:error, reason} ->
-        Logger.error(
-          "AgentServer #{agent_id} failed to persist cron cancellation for #{inspect(logical_id)}: #{inspect(reason)}"
-        )
+        Logger.error(fn ->
+          "AgentServer #{agent_id} failed to cancel cron job #{inspect(logical_id)} " <>
+            "because persistence failed: #{inspect(reason)}"
+        end)
 
         emit_telemetry(state, :persist_failure, %{
           job_id: logical_id,

--- a/lib/jido/agent/instance_manager.ex
+++ b/lib/jido/agent/instance_manager.ex
@@ -380,16 +380,16 @@ defmodule Jido.Agent.InstanceManager do
 
     case Persist.thaw(storage, agent_module, persistence_key) do
       {:ok, agent} ->
-        Logger.debug("InstanceManager thawed agent for key #{inspect(key)}")
+        Logger.debug(fn -> "InstanceManager thawed agent for key #{inspect(key)}" end)
         agent
 
       {:error, :not_found} ->
         nil
 
       {:error, reason} ->
-        Logger.warning(
+        Logger.warning(fn ->
           "InstanceManager failed to thaw agent for key #{inspect(key)}: #{inspect(reason)}"
-        )
+        end)
 
         nil
     end

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -812,9 +812,9 @@ defmodule Jido.AgentServer do
         {:ok, track_cron_job(state, logical_id, pid, runtime_spec: runtime_spec)}
 
       {:error, reason} ->
-        Logger.error(
+        Logger.error(fn ->
           "AgentServer #{state.id} failed to register #{runtime_cron_log_label(runtime_spec)} #{inspect(logical_id)}: #{inspect(reason)}"
-        )
+        end)
 
         {:error, reason, state}
     end
@@ -994,7 +994,10 @@ defmodule Jido.AgentServer do
             enq_state
 
           {:error, :queue_overflow} ->
-            Logger.warning("AgentServer #{state.id} queue overflow during strategy init")
+            Logger.warning(fn ->
+              "AgentServer #{state.id} queue overflow during strategy init"
+            end)
+
             state
         end
       else
@@ -1630,7 +1633,10 @@ defmodule Jido.AgentServer do
               metadata
             )
 
-            Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
+            Logger.warning(fn ->
+              "AgentServer #{state.id} queue overflow, dropping directives"
+            end)
+
             GenServer.reply(from, {:error, :queue_overflow})
             maybe_set_idle_status(state)
         end
@@ -1658,10 +1664,10 @@ defmodule Jido.AgentServer do
           Map.merge(metadata, %{kind: kind, error: reason})
         )
 
-        Logger.error(
+        Logger.error(fn ->
           "Signal call task failed for #{state.id}: #{inspect(kind)} #{inspect(reason)}\n" <>
             Exception.format_stacktrace(stacktrace)
-        )
+        end)
 
         GenServer.reply(from, {:error, reason})
         maybe_set_idle_status(state)
@@ -1945,7 +1951,7 @@ defmodule Jido.AgentServer do
           metadata
         )
 
-        Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
+        Logger.warning(fn -> "AgentServer #{state.id} queue overflow, dropping directives" end)
         {:error, :queue_overflow, state}
     end
   end
@@ -2301,9 +2307,9 @@ defmodule Jido.AgentServer do
       end
     rescue
       e ->
-        Logger.error(
+        Logger.error(fn ->
           "Plugin #{inspect(spec.module)} handle_signal crashed: #{Exception.message(e)}"
-        )
+        end)
 
         error =
           Jido.Error.execution_error(
@@ -2356,9 +2362,9 @@ defmodule Jido.AgentServer do
       end
     rescue
       e ->
-        Logger.error(
+        Logger.error(fn ->
           "Plugin #{inspect(spec.module)} prepare_signal crashed: #{Exception.message(e)}"
-        )
+        end)
 
         error =
           Jido.Error.execution_error(
@@ -2411,9 +2417,9 @@ defmodule Jido.AgentServer do
       end
     rescue
       e ->
-        Logger.error(
+        Logger.error(fn ->
           "Plugin #{inspect(spec.module)} prepare_action crashed: #{Exception.message(e)}"
-        )
+        end)
 
         error =
           Jido.Error.execution_error(
@@ -2476,9 +2482,9 @@ defmodule Jido.AgentServer do
       end
     rescue
       e ->
-        Logger.error(
+        Logger.error(fn ->
           "Plugin #{inspect(spec.module)} prepare_emit crashed: #{Exception.message(e)}"
-        )
+        end)
 
         error =
           Jido.Error.execution_error(
@@ -2517,9 +2523,9 @@ defmodule Jido.AgentServer do
         spec.module.transform_result(action_term, agent_acc, context)
       rescue
         e ->
-          Logger.error(
+          Logger.error(fn ->
             "Plugin #{inspect(spec.module)} transform_result crashed: #{Exception.message(e)}"
-          )
+          end)
 
           agent_acc
       end
@@ -2573,9 +2579,9 @@ defmodule Jido.AgentServer do
         end)
 
       other ->
-        Logger.warning(
+        Logger.warning(fn ->
           "Invalid child_spec from plugin #{inspect(plugin_module)}: #{inspect(other)}"
-        )
+        end)
 
         state
     end
@@ -2601,16 +2607,18 @@ defmodule Jido.AgentServer do
         %{state | children: new_children}
 
       {:error, reason} ->
-        Logger.error("Failed to start plugin child #{inspect(plugin_module)}: #{inspect(reason)}")
+        Logger.error(fn ->
+          "Failed to start plugin child #{inspect(plugin_module)}: #{inspect(reason)}"
+        end)
 
         state
     end
   end
 
   defp start_plugin_child(%State{} = state, plugin_module, spec) do
-    Logger.warning(
+    Logger.warning(fn ->
       "Plugin child_spec missing :start key for #{inspect(plugin_module)}: #{inspect(spec)}"
-    )
+    end)
 
     state
   end
@@ -2683,9 +2691,9 @@ defmodule Jido.AgentServer do
         %{state | children: new_children}
 
       {:error, reason} ->
-        Logger.warning(
+        Logger.warning(fn ->
           "Failed to start subscription sensor #{inspect(sensor_module)} for plugin #{inspect(plugin_module)}: #{inspect(reason)}"
-        )
+        end)
 
         state
     end
@@ -2697,7 +2705,7 @@ defmodule Jido.AgentServer do
 
   @doc false
   defp register_plugin_schedules(%State{skip_schedules: true} = state) do
-    Logger.debug("AgentServer #{state.id} skipping plugin schedules")
+    Logger.debug(fn -> "AgentServer #{state.id} skipping plugin schedules" end)
     state
   end
 
@@ -2730,9 +2738,10 @@ defmodule Jido.AgentServer do
          %{cron_expression: cron_expr, message: message, timezone: timezone}
        ) do
     if Map.has_key?(state.cron_jobs, job_id) do
-      Logger.warning(
-        "AgentServer #{state.id} skipping restored cron job #{inspect(job_id)} because declarative/plugin schedule already exists"
-      )
+      Logger.warning(fn ->
+        "AgentServer #{state.id} skipping restored cron job #{inspect(job_id)} " <>
+          "because declarative/plugin schedule already exists"
+      end)
 
       new_cron_specs = Map.delete(state.cron_specs, job_id)
       cleaned_state = %{state | cron_specs: new_cron_specs}
@@ -2758,9 +2767,9 @@ defmodule Jido.AgentServer do
   end
 
   defp register_restored_cron_spec(%State{} = state, job_id, invalid_spec) do
-    Logger.error(
+    Logger.error(fn ->
       "AgentServer #{state.id} skipped invalid persisted cron spec #{inspect(job_id)}: #{inspect(invalid_spec)}"
-    )
+    end)
 
     state
   end
@@ -2778,9 +2787,9 @@ defmodule Jido.AgentServer do
 
     case register_runtime_cron_job(state, job_id, runtime_spec) do
       {:ok, new_state} ->
-        Logger.debug(
+        Logger.debug(fn ->
           "AgentServer #{state.id} registered schedule #{inspect(job_id)}: #{cron_expr}"
-        )
+        end)
 
         new_state
 
@@ -2822,9 +2831,10 @@ defmodule Jido.AgentServer do
 
       timer_ref = :erlang.start_timer(delay, self(), {:cron_restart, logical_id})
 
-      Logger.warning(
-        "AgentServer #{state.id} scheduling cron restart for #{inspect(logical_id)} in #{delay}ms after #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "AgentServer #{state.id} scheduling cron restart for #{inspect(logical_id)} " <>
+          "in #{delay}ms after #{inspect(reason)}"
+      end)
 
       emit_cron_telemetry_event(state, :restart_scheduled, %{
         job_id: logical_id,
@@ -3076,9 +3086,10 @@ defmodule Jido.AgentServer do
     _ = clear_parent_binding(state.jido, state.id, state.partition)
     stop_reason = wrap_parent_down_reason(reason)
 
-    Logger.info(
-      "AgentServer #{state.id} stopping: parent died (#{inspect(reason)}), wrapped stop_reason: #{inspect(stop_reason)}"
-    )
+    Logger.info(fn ->
+      "AgentServer #{state.id} stopping: parent died (#{inspect(reason)}), " <>
+        "wrapped stop_reason: #{inspect(stop_reason)}"
+    end)
 
     {:stop, stop_reason, State.set_status(state, :stopping)}
   end
@@ -3086,9 +3097,10 @@ defmodule Jido.AgentServer do
   defp handle_parent_down(%State{on_parent_death: :continue} = state, _pid, reason) do
     {former_parent, orphaned_state} = transition_to_orphan(state, reason)
 
-    Logger.info(
-      "AgentServer #{state.id} continuing as orphan after parent #{former_parent.id} died (#{inspect(reason)})"
-    )
+    Logger.info(fn ->
+      "AgentServer #{state.id} continuing as orphan after parent #{former_parent.id} died " <>
+        "(#{inspect(reason)})"
+    end)
 
     {:noreply, orphaned_state}
   end
@@ -3124,7 +3136,9 @@ defmodule Jido.AgentServer do
     {tag, state} = State.remove_child_by_pid(state, pid)
 
     if tag do
-      Logger.debug("AgentServer #{state.id} child #{inspect(tag)} exited: #{inspect(reason)}")
+      Logger.debug(fn ->
+        "AgentServer #{state.id} child #{inspect(tag)} exited: #{inspect(reason)}"
+      end)
 
       signal =
         ChildExit.new!(
@@ -3208,9 +3222,9 @@ defmodule Jido.AgentServer do
             state
 
           {:error, reason} ->
-            Logger.warning(
+            Logger.warning(fn ->
               "AgentServer #{state.id} failed to persist parent binding: #{inspect(reason)}"
-            )
+            end)
 
             state
         end
@@ -3326,16 +3340,18 @@ defmodule Jido.AgentServer do
        when reason in [:normal, :completed, :ok, :done, :success] do
     directive_type = directive.__struct__ |> Module.split() |> List.last()
 
-    Logger.warning("""
-    AgentServer #{state.id} received {:stop, #{inspect(reason)}, ...} from directive #{directive_type}.
+    Logger.warning(fn ->
+      """
+      AgentServer #{state.id} received {:stop, #{inspect(reason)}, ...} from directive #{directive_type}.
 
-    This is a HARD STOP: pending directives and async work will be lost, and on_after_cmd/3 will NOT run.
+      This is a HARD STOP: pending directives and async work will be lost, and on_after_cmd/3 will NOT run.
 
-    For normal completion, set state.status to :completed/:failed instead and avoid returning {:stop, ...}.
-    External code should poll AgentServer.state/1 and check status, not rely on process death.
+      For normal completion, set state.status to :completed/:failed instead and avoid returning {:stop, ...}.
+      External code should poll AgentServer.state/1 and check status, not rely on process death.
 
-    {:stop, ...} should only be used for abnormal/framework-level termination.
-    """)
+      {:stop, ...} should only be used for abnormal/framework-level termination.
+      """
+    end)
   end
 
   defp warn_if_normal_stop(_reason, _directive, _state), do: :ok

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -48,7 +48,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.Emit do
         Jido.Signal.Dispatch.dispatch(traced_signal, cfg)
       end)
     else
-      Logger.warning("Jido.Signal.Dispatch not available, skipping emit")
+      Logger.warning(fn -> "Jido.Signal.Dispatch not available, skipping emit" end)
     end
   end
 end
@@ -110,7 +110,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.RunInstruction
         {:ok, state}
 
       {:error, :queue_overflow} ->
-        Logger.warning("AgentServer #{state.id} queue overflow, dropping directives")
+        Logger.warning(fn -> "AgentServer #{state.id} queue overflow, dropping directives" end)
         {:ok, state}
     end
   end
@@ -166,15 +166,21 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.Spawn do
 
     case result do
       {:ok, pid} ->
-        Logger.debug("Spawned child process #{inspect(pid)} with tag #{inspect(tag)}")
+        Logger.debug(fn ->
+          "Spawned child process #{inspect(pid)} with tag #{inspect(tag)}"
+        end)
+
         {:ok, state}
 
       {:ok, pid, _info} ->
-        Logger.debug("Spawned child process #{inspect(pid)} with tag #{inspect(tag)}")
+        Logger.debug(fn ->
+          "Spawned child process #{inspect(pid)} with tag #{inspect(tag)}"
+        end)
+
         {:ok, state}
 
       {:error, reason} ->
-        Logger.error("Failed to spawn child: #{inspect(reason)}")
+        Logger.error(fn -> "Failed to spawn child: #{inspect(reason)}" end)
         {:ok, state}
 
       :ignored ->
@@ -236,7 +242,10 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.SpawnAgent do
       spawn_child(state, agent, tag, opts, meta, restart)
     else
       {:error, reason} ->
-        Logger.error("AgentServer #{state.id} failed to spawn child: #{reason}")
+        Logger.error(fn ->
+          "AgentServer #{state.id} failed to spawn child: #{inspect(reason)}"
+        end)
+
         {:ok, state}
     end
   end
@@ -291,26 +300,26 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.SpawnAgent do
 
             new_state = State.add_child(state, tag, child_info)
 
-            Logger.debug(
+            Logger.debug(fn ->
               "AgentServer #{state.id} spawned child #{child_id} with tag #{inspect(tag)}"
-            )
+            end)
 
             {:ok, new_state}
 
           {:error, reason} ->
             _ = DynamicSupervisor.terminate_child(supervisor, pid)
 
-            Logger.error(
+            Logger.error(fn ->
               "AgentServer #{state.id} failed to persist relationship for child #{child_id}: #{inspect(reason)}"
-            )
+            end)
 
             {:ok, state}
         end
 
       {:error, reason} ->
-        Logger.error(
+        Logger.error(fn ->
           "AgentServer #{state.id} failed to spawn child with restart #{inspect(restart)}: #{inspect(reason)}"
-        )
+        end)
 
         {:ok, state}
     end
@@ -361,16 +370,17 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.AdoptChild do
           meta: meta
         })
 
-      Logger.debug(
+      Logger.debug(fn ->
         "AgentServer #{state.id} adopted child #{child_runtime.id} with tag #{inspect(tag)}"
-      )
+      end)
 
       {:ok, State.add_child(state, tag, child_info)}
     else
       {:error, reason} ->
-        Logger.warning(
-          "AgentServer #{state.id} failed to adopt child #{inspect(child)} with tag #{inspect(tag)}: #{inspect(reason)}"
-        )
+        Logger.warning(fn ->
+          "AgentServer #{state.id} failed to adopt child #{inspect(child)} " <>
+            "with tag #{inspect(tag)}: #{inspect(reason)}"
+        end)
 
         {:ok, state}
     end
@@ -437,7 +447,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Any do
   require Logger
 
   def exec(directive, _input_signal, state) do
-    Logger.debug("Ignoring unknown directive: #{inspect(directive.__struct__)}")
+    Logger.debug(fn -> "Ignoring unknown directive: #{inspect(directive.__struct__)}" end)
     {:ok, state}
   end
 end

--- a/lib/jido/agent_server/error_policy.ex
+++ b/lib/jido/agent_server/error_policy.ex
@@ -29,7 +29,7 @@ defmodule Jido.AgentServer.ErrorPolicy do
 
       :stop_on_error ->
         log_error(error, context, state)
-        Logger.error("Agent #{state.id} stopping due to error policy")
+        Logger.error(fn -> "Agent #{state.id} stopping due to error policy" end)
         {:stop, {:agent_error, error}, state}
 
       {:emit_signal, dispatch_cfg} ->
@@ -50,9 +50,11 @@ defmodule Jido.AgentServer.ErrorPolicy do
 
   defp log_error(error, context, state) do
     message = extract_message(error)
-    context_str = if context, do: " [#{context}]", else: ""
 
-    Logger.error("Agent #{state.id}#{context_str}: #{message}#{details_suffix(error)}")
+    Logger.error(fn ->
+      context_str = if context, do: " [#{inspect(context)}]", else: ""
+      "Agent #{state.id}#{context_str}: #{message}#{details_suffix(error)}"
+    end)
   end
 
   defp extract_message(%{message: message}) when is_binary(message), do: message
@@ -80,7 +82,7 @@ defmodule Jido.AgentServer.ErrorPolicy do
         SignalDispatch.dispatch(signal, dispatch_cfg)
       end)
     else
-      Logger.warning("Jido.Signal.Dispatch not available, skipping error signal emit")
+      Logger.warning(fn -> "Jido.Signal.Dispatch not available, skipping error signal emit" end)
     end
   end
 
@@ -102,12 +104,12 @@ defmodule Jido.AgentServer.ErrorPolicy do
 
     if count >= max do
       log_error(error, context, state)
-      Logger.error("Agent #{state.id} exceeded max errors (#{count}/#{max}), stopping")
+      Logger.error(fn -> "Agent #{state.id} exceeded max errors (#{count}/#{max}), stopping" end)
       {:stop, {:max_errors_exceeded, count}, state}
     else
-      Logger.warning(
+      Logger.warning(fn ->
         "Agent #{state.id} error #{count}/#{max}: #{extract_message(error)}#{details_suffix(error)}"
-      )
+      end)
 
       {:ok, state}
     end
@@ -125,16 +127,19 @@ defmodule Jido.AgentServer.ErrorPolicy do
           {:stop, reason, new_state}
 
         other ->
-          Logger.error("Custom error policy returned invalid result: #{inspect(other)}")
+          Logger.error(fn ->
+            "Custom error policy returned invalid result: #{inspect(other)}"
+          end)
+
           {:ok, state}
       end
     rescue
       e ->
-        Logger.error("Custom error policy crashed: #{Exception.message(e)}")
+        Logger.error(fn -> "Custom error policy crashed: #{Exception.message(e)}" end)
         {:ok, state}
     catch
       kind, reason ->
-        Logger.error("Custom error policy failed: #{kind} - #{inspect(reason)}")
+        Logger.error(fn -> "Custom error policy failed: #{kind} - #{inspect(reason)}" end)
         {:ok, state}
     end
   end

--- a/lib/jido/agent_server/error_policy.ex
+++ b/lib/jido/agent_server/error_policy.ex
@@ -52,7 +52,7 @@ defmodule Jido.AgentServer.ErrorPolicy do
     message = extract_message(error)
 
     Logger.error(fn ->
-      context_str = if context, do: " [#{inspect(context)}]", else: ""
+      context_str = if context, do: " [#{context}]", else: ""
       "Agent #{state.id}#{context_str}: #{message}#{details_suffix(error)}"
     end)
   end

--- a/lib/jido/agent_server/lifecycle/keyed.ex
+++ b/lib/jido/agent_server/lifecycle/keyed.ex
@@ -60,9 +60,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
       state = %{state | lifecycle: new_lifecycle}
       state = cancel_idle_timer(state)
 
-      Logger.debug(
+      Logger.debug(fn ->
         "Lifecycle attached pid #{inspect(pid)} to #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}"
-      )
+      end)
 
       {:cont, state}
     end
@@ -86,9 +86,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
 
       state = %{state | lifecycle: new_lifecycle}
 
-      Logger.debug(
+      Logger.debug(fn ->
         "Lifecycle detached pid #{inspect(pid)} from #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}"
-      )
+      end)
 
       if MapSet.size(new_lifecycle.attachments) == 0 do
         {:cont, maybe_start_idle_timer(state)}
@@ -118,9 +118,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
 
         state = %{state | lifecycle: new_lifecycle}
 
-        Logger.debug(
+        Logger.debug(fn ->
           "Lifecycle owner #{inspect(pid)} down for #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}"
-        )
+        end)
 
         if MapSet.size(new_lifecycle.attachments) == 0 do
           {:cont, maybe_start_idle_timer(state)}
@@ -136,7 +136,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
   def handle_event(:idle_timeout, state) do
     lifecycle = state.lifecycle
 
-    Logger.debug("Lifecycle idle timeout for #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}")
+    Logger.debug(fn ->
+      "Lifecycle idle timeout for #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}"
+    end)
 
     {:stop, {:shutdown, :idle_timeout}, state}
   end
@@ -206,9 +208,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
             state
 
           {:error, reason} ->
-            Logger.warning(
+            Logger.warning(fn ->
               "Lifecycle restore failed for #{lifecycle.pool}/#{inspect(lifecycle.pool_key)}: #{inspect(reason)}"
-            )
+            end)
 
             state
         end
@@ -225,12 +227,14 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
 
     case Persist.hibernate(storage, agent_module, persistence_key, agent) do
       :ok ->
-        Logger.debug("Lifecycle hibernated agent for #{lifecycle.pool}/#{inspect(pool_key)}")
+        Logger.debug(fn ->
+          "Lifecycle hibernated agent for #{lifecycle.pool}/#{inspect(pool_key)}"
+        end)
 
       {:error, reason} ->
-        Logger.error(
+        Logger.error(fn ->
           "Lifecycle hibernate failed for #{lifecycle.pool}/#{inspect(pool_key)}: #{inspect(reason)}"
-        )
+        end)
     end
   end
 
@@ -247,9 +251,9 @@ defmodule Jido.AgentServer.Lifecycle.Keyed do
     {cron_specs, invalid_cron_specs} = Jido.Scheduler.classify_cron_specs(staged_cron_specs)
 
     Enum.each(invalid_cron_specs, fn {job_id, spec, reason} ->
-      Logger.error(
+      Logger.error(fn ->
         "Lifecycle dropped malformed persisted cron spec #{inspect(job_id)} for #{inspect(agent_id)}: #{inspect(spec)} (#{inspect(reason)})"
-      )
+      end)
     end)
 
     {cleaned_agent, cron_specs}

--- a/lib/jido/agent_server/state.ex
+++ b/lib/jido/agent_server/state.ex
@@ -151,9 +151,9 @@ defmodule Jido.AgentServer.State do
       Jido.Scheduler.classify_cron_specs(staged_cron_specs)
 
     Enum.each(invalid_cron_specs, fn {job_id, spec, reason} ->
-      Logger.error(
+      Logger.error(fn ->
         "AgentServer #{opts.id} dropped malformed persisted cron spec #{inspect(job_id)}: #{inspect(spec)} (#{inspect(reason)})"
-      )
+      end)
     end)
 
     lifecycle_opts = [

--- a/lib/jido/agent_server/stop_child_runtime.ex
+++ b/lib/jido/agent_server/stop_child_runtime.ex
@@ -14,13 +14,16 @@ defmodule Jido.AgentServer.StopChildRuntime do
   def exec(tag, reason, %Signal{} = input_signal, %State{} = state) do
     case State.get_child(state, tag) do
       nil ->
-        Logger.debug("AgentServer #{state.id} cannot stop child #{inspect(tag)}: not found")
+        Logger.debug(fn ->
+          "AgentServer #{state.id} cannot stop child #{inspect(tag)}: not found"
+        end)
+
         {:ok, state}
 
       %{pid: pid, id: child_id, partition: child_partition} ->
-        Logger.debug(
+        Logger.debug(fn ->
           "AgentServer #{state.id} stopping child #{inspect(tag)} with reason #{inspect(reason)}"
-        )
+        end)
 
         case RuntimeStore.delete(
                state.jido,
@@ -31,9 +34,9 @@ defmodule Jido.AgentServer.StopChildRuntime do
             :ok
 
           {:error, delete_reason} ->
-            Logger.warning(
+            Logger.warning(fn ->
               "AgentServer #{state.id} failed to clear relationship for child #{child_id}: #{inspect(delete_reason)}"
-            )
+            end)
         end
 
         stop_signal =

--- a/lib/jido/observe.ex
+++ b/lib/jido/observe.ex
@@ -2,8 +2,8 @@ defmodule Jido.Observe do
   @moduledoc """
   Unified observability facade for Jido agents.
 
-  Wraps `:telemetry` events and `Logger` with a simple API for observing
-  agent execution, action invocations, and workflow iterations.
+  Wraps `:telemetry` and tracer callbacks with a simple API for observing agent
+  execution, action invocations, and workflow iterations.
 
   ## Features
 
@@ -11,7 +11,7 @@ defmodule Jido.Observe do
   - Duration measurement for all spans (nanoseconds)
   - Automatic correlation ID enrichment from `Jido.Tracing.Context`
   - Pluggable tracer callbacks via `Jido.Observe.Tracer`
-  - Threshold-based logging via `Jido.Observe.Log`
+  - Threshold-based logging compatibility via `Jido.Observe.Log`
 
   ## Correlation Tracing Integration
 
@@ -246,10 +246,6 @@ defmodule Jido.Observe do
   Conditionally logs a message based on the observability threshold.
 
   Delegates to `Jido.Observe.Log.log/3`.
-
-  ## Example
-
-      Jido.Observe.log(:debug, "Processing step", agent_id: agent.id)
   """
   @spec log(Logger.level(), Logger.message(), keyword()) :: :ok
   def log(level, message, metadata \\ []) do
@@ -695,21 +691,21 @@ defmodule Jido.Observe do
   end
 
   defp log_tracer_warning(%SpanCtx{} = span_ctx, callback_name, failure) do
-    Logger.warning(
+    Logger.warning(fn ->
       "Jido.Observe tracer #{callback_name} failed " <>
         "(tracer=#{inspect(span_ctx.tracer_module || tracer(span_ctx.metadata))}, " <>
         "event_prefix=#{inspect(span_ctx.event_prefix)}, " <>
         "failure_mode=#{tracer_failure_mode(span_ctx.metadata)}): #{format_tracer_failure(failure)}"
-    )
+    end)
   end
 
   defp log_scoped_contract_warning(%SpanCtx{} = span_ctx, message) do
-    Logger.warning(
+    Logger.warning(fn ->
       "Jido.Observe tracer with_span_scope/3 contract violation " <>
         "(tracer=#{inspect(span_ctx.tracer_module)}, " <>
         "event_prefix=#{inspect(span_ctx.event_prefix)}, " <>
         "failure_mode=#{tracer_failure_mode(span_ctx.metadata)}): #{message}"
-    )
+    end)
   end
 
   defp raise_tracer_failure(%SpanCtx{} = span_ctx, callback_name, failure) do

--- a/lib/jido/observe/log.ex
+++ b/lib/jido/observe/log.ex
@@ -1,41 +1,16 @@
 defmodule Jido.Observe.Log do
   @moduledoc """
-  Centralized log threshold for observability.
+  Threshold-based observability logging compatibility shim.
 
-  This module provides threshold-based logging for Jido's observability system.
-  The log threshold can be configured per-environment to control verbosity:
-
-  - `:debug` in development for verbose output
-  - `:info` or `:warning` in production for minimal noise
-
-  ## Configuration
-
-      # config/config.exs
-      config :jido, :observability,
-        log_level: :info
-      
-      # config/dev.exs
-      config :jido, :observability,
-        log_level: :debug
-
-  ## Usage
-
-      alias Jido.Observe.Log
-      
-      # Only logs if threshold allows :debug level
-      Log.log(:debug, "Processing step", agent_id: agent.id, step: 1)
-      
-      # Always logs in most configurations
-      Log.log(:info, "Agent completed", agent_id: agent.id)
+  This module preserves the historical public logging API while the runtime
+  continues to honor `config :jido, :observability, log_level: ...` and
+  per-instance `Jido.Debug` overrides.
   """
 
   @type level :: Logger.level()
 
   @doc """
   Returns the current observability log threshold.
-
-  Reads from application config `:jido, :observability, :log_level`.
-  Defaults to `:info` if not configured.
   """
   @spec threshold() :: level()
   def threshold do
@@ -45,22 +20,8 @@ defmodule Jido.Observe.Log do
   @doc """
   Conditionally logs a message based on the observability threshold.
 
-  The message is logged only if the threshold level allows it.
-  Uses `Jido.Util.cond_log/4` under the hood.
-
-  ## Parameters
-
-  - `level` - The log level for this message (:debug, :info, :warning, :error)
-  - `message` - The message to log (string or iodata)
-  - `metadata` - Keyword list of metadata to include
-
-  ## Examples
-
-      # With threshold at :info, this won't log
-      Log.log(:debug, "Verbose info", step: 1)
-      
-      # With threshold at :info, this will log
-      Log.log(:info, "Important info", agent_id: "abc")
+  When `:jido_instance` metadata is present, per-instance overrides from
+  `Jido.Debug` are honored.
   """
   @spec log(level(), Logger.message(), keyword()) :: :ok
   def log(level, message, metadata \\ []) do

--- a/lib/jido/persist.ex
+++ b/lib/jido/persist.ex
@@ -167,19 +167,24 @@ defmodule Jido.Persist do
   defp do_hibernate(adapter, opts, agent_module, key, agent) do
     thread = get_thread(agent)
 
-    Logger.debug("Persist.hibernate starting for #{inspect(agent_module)} key=#{inspect(key)}")
+    Logger.debug(fn ->
+      "Persist.hibernate starting for #{inspect(agent_module)} key=#{inspect(key)}"
+    end)
 
     with :ok <- flush_journal(adapter, opts, thread),
          {:ok, checkpoint} <- create_checkpoint(agent_module, agent, thread),
          checkpoint_key <- make_checkpoint_key(agent_module, key),
          :ok <- adapter.put_checkpoint(checkpoint_key, checkpoint, opts) do
-      Logger.debug("Persist.hibernate completed for #{inspect(agent_module)} key=#{inspect(key)}")
+      Logger.debug(fn ->
+        "Persist.hibernate completed for #{inspect(agent_module)} key=#{inspect(key)}"
+      end)
+
       :ok
     else
       {:error, reason} = error ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist.hibernate failed for #{inspect(agent_module)} key=#{inspect(key)}: #{inspect(reason)}"
-        )
+        end)
 
         error
     end
@@ -189,20 +194,25 @@ defmodule Jido.Persist do
   defp do_thaw(adapter, opts, agent_module, key) do
     checkpoint_key = make_checkpoint_key(agent_module, key)
 
-    Logger.debug("Persist.thaw starting for #{inspect(agent_module)} key=#{inspect(key)}")
+    Logger.debug(fn ->
+      "Persist.thaw starting for #{inspect(agent_module)} key=#{inspect(key)}"
+    end)
 
     case Jido.Storage.fetch_checkpoint(adapter, checkpoint_key, opts) do
       {:ok, checkpoint} ->
         restore_from_checkpoint(adapter, opts, agent_module, checkpoint)
 
       {:error, :not_found} ->
-        Logger.debug("Persist.thaw: checkpoint not found for #{inspect(checkpoint_key)}")
+        Logger.debug(fn ->
+          "Persist.thaw: checkpoint not found for #{inspect(checkpoint_key)}"
+        end)
+
         {:error, :not_found}
 
       {:error, reason} = error ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist.thaw failed to get checkpoint for #{inspect(checkpoint_key)}: #{inspect(reason)}"
-        )
+        end)
 
         error
     end
@@ -227,9 +237,9 @@ defmodule Jido.Persist do
     if thread.rev == entry_count do
       :ok
     else
-      Logger.error(
+      Logger.error(fn ->
         "Persist: invalid local thread revision for #{thread.id}: rev=#{thread.rev}, entries=#{entry_count}"
-      )
+      end)
 
       {:error, :invalid_thread_revision}
     end
@@ -258,21 +268,24 @@ defmodule Jido.Persist do
 
     cond do
       stored_rev > local_rev ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist: thread rev regression for #{thread.id}: local_rev=#{local_rev}, stored_rev=#{stored_rev}"
-        )
+        end)
 
         {:error, :thread_rev_regression}
 
       stored_rev > entry_count ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist: thread history truncated for #{thread.id}: entry_count=#{entry_count}, stored_rev=#{stored_rev}"
-        )
+        end)
 
         {:error, :thread_history_truncated}
 
       stored_rev == local_rev ->
-        Logger.debug("Persist: thread #{thread.id} already persisted at rev=#{stored_rev}")
+        Logger.debug(fn ->
+          "Persist: thread #{thread.id} already persisted at rev=#{stored_rev}"
+        end)
+
         :ok
 
       true ->
@@ -283,9 +296,9 @@ defmodule Jido.Persist do
           |> maybe_put_thread_metadata(stored_rev, thread.metadata)
           |> Kernel.++(opts)
 
-        Logger.debug(
+        Logger.debug(fn ->
           "Persist: flushing #{length(missing_entries)} new entries for thread #{thread.id} from rev=#{stored_rev}"
-        )
+        end)
 
         case adapter.append_thread(thread.id, missing_entries, append_opts) do
           {:ok, _updated_thread} ->
@@ -295,9 +308,9 @@ defmodule Jido.Persist do
             handle_thread_append_conflict(adapter, opts, thread.id, local_rev)
 
           {:error, reason} = error ->
-            Logger.error(
+            Logger.error(fn ->
               "Persist: failed to flush journal for thread #{thread.id}: #{inspect(reason)}"
-            )
+            end)
 
             error
         end
@@ -315,23 +328,23 @@ defmodule Jido.Persist do
   defp handle_thread_append_conflict(adapter, opts, thread_id, local_rev) do
     case Jido.Storage.fetch_thread(adapter, thread_id, opts) do
       {:ok, %Thread{rev: stored_rev}} when stored_rev >= local_rev ->
-        Logger.debug(
+        Logger.debug(fn ->
           "Persist: append conflict resolved for #{thread_id}; stored_rev=#{stored_rev} >= local_rev=#{local_rev}"
-        )
+        end)
 
         :ok
 
       {:ok, %Thread{rev: stored_rev}} ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist: append conflict for #{thread_id}; stored_rev=#{stored_rev}, local_rev=#{local_rev}"
-        )
+        end)
 
         {:error, :conflict}
 
       {:error, reason} = error ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist: append conflict but failed to reload thread #{thread_id}: #{inspect(reason)}"
-        )
+        end)
 
         error
     end
@@ -398,7 +411,11 @@ defmodule Jido.Persist do
          {:ok, agent} <- restore_agent(agent_module, checkpoint, ctx),
          {:ok, agent} <- rehydrate_thread(adapter, opts, agent, checkpoint) do
       agent = attach_scheduler_manifest(agent, checkpoint)
-      Logger.debug("Persist.thaw completed for #{inspect(agent_module)} id=#{checkpoint.id}")
+
+      Logger.debug(fn ->
+        "Persist.thaw completed for #{inspect(agent_module)} id=#{checkpoint.id}"
+      end)
+
       {:ok, agent}
     end
   end
@@ -433,7 +450,9 @@ defmodule Jido.Persist do
   defp rehydrate_thread(_adapter, _opts, agent, %{thread: nil}), do: {:ok, agent}
 
   defp rehydrate_thread(adapter, opts, agent, %{thread: %{id: thread_id, rev: expected_rev}}) do
-    Logger.debug("Persist: rehydrating thread #{thread_id} with expected rev=#{expected_rev}")
+    Logger.debug(fn ->
+      "Persist: rehydrating thread #{thread_id} with expected rev=#{expected_rev}"
+    end)
 
     case Jido.Storage.fetch_thread(adapter, thread_id, opts) do
       {:ok, %Thread{rev: ^expected_rev} = thread} ->
@@ -441,18 +460,21 @@ defmodule Jido.Persist do
         {:ok, agent_with_thread}
 
       {:ok, %Thread{rev: actual_rev}} ->
-        Logger.error(
+        Logger.error(fn ->
           "Persist: thread rev mismatch for #{thread_id}: expected=#{expected_rev}, actual=#{actual_rev}"
-        )
+        end)
 
         {:error, :thread_mismatch}
 
       {:error, :not_found} ->
-        Logger.error("Persist: thread #{thread_id} not found but referenced in checkpoint")
+        Logger.error(fn ->
+          "Persist: thread #{thread_id} not found but referenced in checkpoint"
+        end)
+
         {:error, :missing_thread}
 
       {:error, reason} = error ->
-        Logger.error("Persist: failed to load thread #{thread_id}: #{inspect(reason)}")
+        Logger.error(fn -> "Persist: failed to load thread #{thread_id}: #{inspect(reason)}" end)
         error
     end
   end

--- a/lib/jido/scheduler/job.ex
+++ b/lib/jido/scheduler/job.ex
@@ -200,11 +200,11 @@ defmodule Jido.Scheduler.Job do
       :ok
     rescue
       error ->
-        Logger.error("Scheduler callback raised: #{Exception.message(error)}")
+        Logger.error(fn -> "Scheduler callback raised: #{Exception.message(error)}" end)
         :ok
     catch
       kind, reason ->
-        Logger.error("Scheduler callback #{kind}: #{inspect(reason)}")
+        Logger.error(fn -> "Scheduler callback #{kind}: #{inspect(reason)}" end)
         :ok
     end
   end
@@ -234,9 +234,10 @@ defmodule Jido.Scheduler.Job do
   @spec enter_retry(state(), term()) :: state()
   defp enter_retry(state, reason) do
     if not state.retrying? do
-      Logger.warning(
-        "Scheduler job entering retry mode for #{inspect(state.cron_expr)} after schedule failure: #{inspect(reason)}"
-      )
+      Logger.warning(fn ->
+        "Scheduler job entering retry mode for #{inspect(state.cron_expr)} " <>
+          "after schedule failure: #{inspect(reason)}"
+      end)
     end
 
     timer_ref = Process.send_after(self(), @retry_schedule, @retry_delay_ms)
@@ -246,7 +247,9 @@ defmodule Jido.Scheduler.Job do
   @spec clear_retry(state(), reference()) :: state()
   defp clear_retry(state, timer_ref) do
     if state.retrying? do
-      Logger.info("Scheduler job recovered schedule resolution for #{inspect(state.cron_expr)}")
+      Logger.debug(fn ->
+        "Scheduler job recovered schedule resolution for #{inspect(state.cron_expr)}"
+      end)
     end
 
     %{state | timer_ref: timer_ref, retrying?: false}

--- a/lib/jido/scheduler/job.ex
+++ b/lib/jido/scheduler/job.ex
@@ -247,7 +247,7 @@ defmodule Jido.Scheduler.Job do
   @spec clear_retry(state(), reference()) :: state()
   defp clear_retry(state, timer_ref) do
     if state.retrying? do
-      Logger.debug(fn ->
+      Logger.info(fn ->
         "Scheduler job recovered schedule resolution for #{inspect(state.cron_expr)}"
       end)
     end

--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -157,7 +157,10 @@ defmodule Jido.Sensor.Runtime do
 
   @impl GenServer
   def handle_info(msg, state) do
-    Logger.debug("Sensor.Runtime #{state.id} received unexpected message: #{inspect(msg)}")
+    Logger.debug(fn ->
+      "Sensor.Runtime #{state.id} received unexpected message: #{inspect(msg)}"
+    end)
+
     {:noreply, state}
   end
 
@@ -241,14 +244,16 @@ defmodule Jido.Sensor.Runtime do
           {:noreply, new_state}
 
         {:error, reason} ->
-          Logger.warning("Sensor.Runtime #{state.id} handle_event error: #{inspect(reason)}")
+          Logger.warning(fn ->
+            "Sensor.Runtime #{state.id} handle_event error: #{inspect(reason)}"
+          end)
 
           {:noreply, state}
 
         other ->
-          Logger.warning(
+          Logger.warning(fn ->
             "Sensor.Runtime #{state.id} handle_event returned invalid result: #{inspect(other)}"
-          )
+          end)
 
           {:noreply, state}
       end
@@ -281,7 +286,9 @@ defmodule Jido.Sensor.Runtime do
   end
 
   defp apply_directive(directive, state) do
-    Logger.warning("Sensor.Runtime #{state.id} ignoring unknown directive: #{inspect(directive)}")
+    Logger.warning(fn ->
+      "Sensor.Runtime #{state.id} ignoring unknown directive: #{inspect(directive)}"
+    end)
 
     state
   end
@@ -312,7 +319,9 @@ defmodule Jido.Sensor.Runtime do
         dispatch_signal_async(signal, agent_ref, state)
 
       true ->
-        Logger.debug("Sensor.Runtime #{state.id} has no agent_ref, signal not delivered")
+        Logger.debug(fn ->
+          "Sensor.Runtime #{state.id} has no agent_ref, signal not delivered"
+        end)
     end
   end
 
@@ -322,9 +331,9 @@ defmodule Jido.Sensor.Runtime do
         dispatch_fun(state).(signal, agent_ref)
       rescue
         e ->
-          Logger.warning(
+          Logger.warning(fn ->
             "Sensor.Runtime #{state.id} async dispatch failed: #{Exception.message(e)}"
-          )
+          end)
       end
     end
 

--- a/lib/jido/telemetry.ex
+++ b/lib/jido/telemetry.ex
@@ -255,10 +255,12 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[agent.cmd.error] #{format_module(metadata[:agent_module])} " <>
-        "action=#{Formatter.format_action(metadata[:action])} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[agent.cmd.error] #{format_module(metadata[:agent_module])} " <>
+          "action=#{Formatter.format_action(metadata[:action])} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       span_id: metadata[:jido_span_id],
@@ -301,9 +303,11 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[strategy.init.error] #{format_module(metadata[:strategy])} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[strategy.init.error] #{format_module(metadata[:strategy])} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       stacktrace: metadata[:stacktrace]
@@ -344,9 +348,11 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[strategy.cmd.error] #{format_module(metadata[:strategy])} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[strategy.cmd.error] #{format_module(metadata[:strategy])} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       stacktrace: metadata[:stacktrace]
@@ -386,9 +392,11 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[strategy.tick.error] #{format_module(metadata[:strategy])} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[strategy.tick.error] #{format_module(metadata[:strategy])} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       stacktrace: metadata[:stacktrace]
@@ -437,9 +445,11 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[signal.error] type=#{Formatter.format_signal_type(metadata[:signal_type])} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[signal.error] type=#{Formatter.format_signal_type(metadata[:signal_type])} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       span_id: metadata[:jido_span_id],
@@ -488,9 +498,11 @@ defmodule Jido.Telemetry do
     duration = Map.get(measurements, :duration, 0)
 
     Logger.warning(
-      "[directive.error] type=#{metadata[:directive_type]} " <>
-        "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
-        "duration=#{Formatter.format_duration(duration)}",
+      fn ->
+        "[directive.error] type=#{metadata[:directive_type]} " <>
+          "error=#{Formatter.safe_inspect(metadata[:error], 200)} " <>
+          "duration=#{Formatter.format_duration(duration)}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id],
       span_id: metadata[:jido_span_id],
@@ -500,25 +512,26 @@ defmodule Jido.Telemetry do
 
   def handle_event([:jido, :agent_server, :queue, :overflow], measurements, metadata, _config) do
     Logger.warning(
-      "[queue.overflow] signal_type=#{Formatter.format_signal_type(metadata[:signal_type])} " <>
-        "queue_size=#{measurements[:queue_size]}",
+      fn ->
+        "[queue.overflow] signal_type=#{Formatter.format_signal_type(metadata[:signal_type])} " <>
+          "queue_size=#{measurements[:queue_size]}"
+      end,
       agent_id: metadata[:agent_id],
       trace_id: metadata[:jido_trace_id]
     )
   end
 
   def handle_event([:jido, :agent_server, :cron, :register], _measurements, metadata, _config) do
-    Logger.debug(
-      "[cron.register] job_id=#{inspect(metadata[:job_id])} cron=#{inspect(metadata[:cron_expression])}",
-      agent_id: metadata[:agent_id]
-    )
+    maybe_log_cron_debug(metadata, fn ->
+      "[cron.register] job_id=#{inspect(metadata[:job_id])} " <>
+        "cron=#{inspect(metadata[:cron_expression])}"
+    end)
   end
 
   def handle_event([:jido, :agent_server, :cron, :cancel], _measurements, metadata, _config) do
-    Logger.debug(
-      "[cron.cancel] job_id=#{inspect(metadata[:job_id])}",
-      agent_id: metadata[:agent_id]
-    )
+    maybe_log_cron_debug(metadata, fn ->
+      "[cron.cancel] job_id=#{inspect(metadata[:job_id])}"
+    end)
   end
 
   def handle_event(
@@ -527,10 +540,11 @@ defmodule Jido.Telemetry do
         metadata,
         _config
       ) do
-    Logger.debug(
-      "[cron.restart_scheduled] job_id=#{inspect(metadata[:job_id])} reason=#{Formatter.safe_inspect(metadata[:reason], 120)} delay_ms=#{inspect(metadata[:delay_ms])}",
-      agent_id: metadata[:agent_id]
-    )
+    maybe_log_cron_debug(metadata, fn ->
+      "[cron.restart_scheduled] job_id=#{inspect(metadata[:job_id])} " <>
+        "reason=#{Formatter.safe_inspect(metadata[:reason], 120)} " <>
+        "delay_ms=#{inspect(metadata[:delay_ms])}"
+    end)
   end
 
   def handle_event(
@@ -539,10 +553,10 @@ defmodule Jido.Telemetry do
         metadata,
         _config
       ) do
-    Logger.debug(
-      "[cron.restart_succeeded] job_id=#{inspect(metadata[:job_id])} cron=#{inspect(metadata[:cron_expression])}",
-      agent_id: metadata[:agent_id]
-    )
+    maybe_log_cron_debug(metadata, fn ->
+      "[cron.restart_succeeded] job_id=#{inspect(metadata[:job_id])} " <>
+        "cron=#{inspect(metadata[:cron_expression])}"
+    end)
   end
 
   def handle_event(
@@ -552,7 +566,10 @@ defmodule Jido.Telemetry do
         _config
       ) do
     Logger.warning(
-      "[cron.persist_failure] job_id=#{inspect(metadata[:job_id])} reason=#{Formatter.safe_inspect(metadata[:reason], 200)}",
+      fn ->
+        "[cron.persist_failure] job_id=#{inspect(metadata[:job_id])} " <>
+          "reason=#{Formatter.safe_inspect(metadata[:reason], 200)}"
+      end,
       agent_id: metadata[:agent_id]
     )
   end
@@ -634,6 +651,14 @@ defmodule Jido.Telemetry do
     has_directives = directive_count > 0
 
     is_slow or has_directives
+  end
+
+  defp maybe_log_cron_debug(metadata, message_fun) when is_function(message_fun, 0) do
+    if ObserveConfig.debug_enabled?(metadata[:jido_instance]) do
+      Logger.debug(message_fun, agent_id: metadata[:agent_id])
+    end
+
+    :ok
   end
 
   defp format_module(nil), do: "unknown"

--- a/test/jido/agent_server/error_policy_test.exs
+++ b/test/jido/agent_server/error_policy_test.exs
@@ -48,7 +48,12 @@ defmodule JidoTest.AgentServer.ErrorPolicyTest do
       state = build_state(:log_only)
       directive = build_error_directive("Error message", :validation)
 
-      assert {:ok, ^state} = ErrorPolicy.handle(directive, state)
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, ^state} = ErrorPolicy.handle(directive, state)
+        end)
+
+      assert log =~ "Agent error-policy-test-agent [validation]: Error message"
     end
   end
 

--- a/test/jido/observe/observe_test.exs
+++ b/test/jido/observe/observe_test.exs
@@ -6,6 +6,7 @@ defmodule JidoTest.ObserveTest do
 
   import ExUnit.CaptureLog
 
+  alias Jido.Debug
   alias Jido.Observe
   alias Jido.Observe.Log
   alias Jido.Observe.NoopTracer
@@ -525,6 +526,21 @@ defmodule JidoTest.ObserveTest do
         end)
 
       assert log =~ "debug level message"
+    end
+
+    test "honors per-instance debug override from metadata" do
+      test_instance = :"observe_log_#{System.unique_integer([:positive])}"
+      Application.put_env(:jido, :observability, log_level: :warning)
+      Debug.enable(test_instance, :on)
+
+      on_exit(fn -> Debug.reset(test_instance) end)
+
+      log =
+        capture_log(fn ->
+          Log.log(:debug, "debug override message", jido_instance: test_instance)
+        end)
+
+      assert log =~ "debug override message"
     end
   end
 


### PR DESCRIPTION
## Summary
- salvage the standards-aligned logging cleanup from #249 onto current `main`
- convert expensive/interpolated runtime logs to direct lazy `Logger` callbacks at owning boundaries
- keep `Jido.Observe.Log` as a compatibility shim while documenting it that way
- add coverage that the compatibility shim honors per-instance debug overrides

## Verification
- `mix test test/jido/observe/observe_test.exs test/jido/telemetry_test.exs test/jido/agent_server/telemetry_test.exs test/jido/agent_server/agent_server_test.exs test/jido/scheduler_test.exs`
- `mix test`
- `mix q`

Supersedes #249
Refs #263