### PR TITLE
feat(observe): centralize telemetry emission

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -207,6 +207,7 @@ defmodule Jido.AgentServer do
   alias Jido.Agent.Directive
   alias Jido.AgentServer.Signal.{ChildExit, ChildStarted, Orphaned}
   alias Jido.Config.Defaults
+  alias Jido.Observe
   alias Jido.Observe.Config, as: ObserveConfig
   alias Jido.RuntimeStore
   alias Jido.Sensor.Runtime, as: SensorRuntime
@@ -1661,7 +1662,7 @@ defmodule Jido.AgentServer do
         emit_telemetry(
           [:jido, :agent_server, :signal, :exception],
           %{duration: duration},
-          Map.merge(metadata, %{kind: kind, error: reason})
+          Map.merge(metadata, Observe.exception_metadata(kind, reason))
         )
 
         Logger.error(fn ->
@@ -1720,7 +1721,7 @@ defmodule Jido.AgentServer do
         emit_telemetry(
           [:jido, :agent_server, :signal, :exception],
           %{duration: System.monotonic_time() - start_time},
-          Map.merge(metadata, %{kind: kind, error: reason})
+          Map.merge(metadata, Observe.exception_metadata(kind, reason))
         )
 
         :erlang.raise(kind, reason, __STACKTRACE__)
@@ -3307,7 +3308,7 @@ defmodule Jido.AgentServer do
         emit_telemetry(
           [:jido, :agent_server, :directive, :exception],
           %{duration: System.monotonic_time() - start_time},
-          Map.merge(metadata, %{kind: kind, error: reason})
+          Map.merge(metadata, Observe.exception_metadata(kind, reason))
         )
 
         :erlang.raise(kind, reason, __STACKTRACE__)
@@ -3331,7 +3332,7 @@ defmodule Jido.AgentServer do
   defp result_type({:stop, _, _}), do: :stop
 
   defp emit_telemetry(event, measurements, metadata) do
-    :telemetry.execute(event, measurements, metadata)
+    Observe.emit_event(event, measurements, metadata)
   end
 
   # Warn when {:stop, ...} is used with normal-looking reasons.

--- a/lib/jido/observe.ex
+++ b/lib/jido/observe.ex
@@ -91,10 +91,15 @@ defmodule Jido.Observe do
   Metadata should be small, identifying data (IDs, step numbers, model names), not full
   prompts/responses. For large payloads, include derived measurements (`prompt_tokens`,
   `prompt_size_bytes`) rather than the raw content.
+
+  Exception telemetry uses bounded, public error metadata. Raw exceptions and
+  stacktraces are passed to tracer callbacks, but telemetry metadata exposes
+  low-cardinality fields such as `:error_type` and `:retryable?`.
   """
 
   require Logger
 
+  alias Jido.Error
   alias Jido.Observe.Config, as: ObserveConfig
   alias Jido.Observe.Log
   alias Jido.Observe.SpanCtx
@@ -282,6 +287,28 @@ defmodule Jido.Observe do
       when is_list(event_prefix) and is_map(measurements) and is_map(metadata) do
     :telemetry.execute(event_prefix, measurements, enrich_with_correlation(metadata))
     :ok
+  end
+
+  @doc """
+  Builds bounded exception metadata for telemetry events.
+
+  The returned metadata preserves the historical `:kind` and `:error` keys,
+  but `:error` is a public `Jido.Error.to_map/1` payload instead of a raw
+  exception term. Top-level fields stay low-cardinality for metrics and
+  alerting; richer bounded details remain under `:error`.
+
+  Stacktraces are intentionally excluded from telemetry metadata.
+  """
+  @spec exception_metadata(atom(), term()) :: metadata()
+  def exception_metadata(kind, reason) when is_atom(kind) do
+    error = Error.to_map(reason)
+
+    %{
+      kind: kind,
+      error: error,
+      error_type: error.type,
+      retryable?: error.retryable?
+    }
   end
 
   @doc """
@@ -610,11 +637,7 @@ defmodule Jido.Observe do
     start_time = System.monotonic_time(:nanosecond)
     start_system_time = System.system_time(:nanosecond)
 
-    :telemetry.execute(
-      event_prefix ++ [:start],
-      %{system_time: start_system_time},
-      metadata
-    )
+    emit_event(event_prefix ++ [:start], %{system_time: start_system_time}, metadata)
 
     %SpanCtx{
       event_prefix: event_prefix,
@@ -630,30 +653,18 @@ defmodule Jido.Observe do
     duration = System.monotonic_time(:nanosecond) - span_ctx.start_time
     measurements = Map.merge(%{duration: duration}, extra_measurements)
 
-    :telemetry.execute(
-      span_ctx.event_prefix ++ [:stop],
-      measurements,
-      span_ctx.metadata
-    )
+    emit_event(span_ctx.event_prefix ++ [:stop], measurements, span_ctx.metadata)
 
     measurements
   end
 
-  defp emit_exception_event(%SpanCtx{} = span_ctx, kind, reason, stacktrace) do
+  defp emit_exception_event(%SpanCtx{} = span_ctx, kind, reason, _stacktrace) do
     duration = System.monotonic_time(:nanosecond) - span_ctx.start_time
 
     error_metadata =
-      Map.merge(span_ctx.metadata, %{
-        kind: kind,
-        error: reason,
-        stacktrace: stacktrace
-      })
+      Map.merge(span_ctx.metadata, exception_metadata(kind, reason))
 
-    :telemetry.execute(
-      span_ctx.event_prefix ++ [:exception],
-      %{duration: duration},
-      error_metadata
-    )
+    emit_event(span_ctx.event_prefix ++ [:exception], %{duration: duration}, error_metadata)
   end
 
   defp invoke_tracer_callback(

--- a/lib/jido/telemetry.ex
+++ b/lib/jido/telemetry.ex
@@ -83,6 +83,7 @@ defmodule Jido.Telemetry do
 
   require Logger
 
+  alias Jido.Observe
   alias Jido.Observe.Config, as: ObserveConfig
   alias Jido.Telemetry.Formatter
 
@@ -695,7 +696,7 @@ defmodule Jido.Telemetry do
       jido_partition: nil
     }
 
-    :telemetry.execute(
+    Observe.emit_event(
       [:jido, :agent, :cmd, :start],
       %{system_time: System.system_time()},
       metadata
@@ -704,7 +705,7 @@ defmodule Jido.Telemetry do
     try do
       {updated_agent, directives} = func.()
 
-      :telemetry.execute(
+      Observe.emit_event(
         [:jido, :agent, :cmd, :stop],
         %{
           duration: System.monotonic_time() - start_time,
@@ -718,10 +719,10 @@ defmodule Jido.Telemetry do
       kind, reason ->
         stack = __STACKTRACE__
 
-        :telemetry.execute(
+        Observe.emit_event(
           [:jido, :agent, :cmd, :exception],
           %{duration: System.monotonic_time() - start_time},
-          Map.merge(metadata, %{kind: kind, error: reason, stacktrace: stack})
+          Map.merge(metadata, Observe.exception_metadata(kind, reason))
         )
 
         :erlang.raise(kind, reason, stack)
@@ -751,7 +752,7 @@ defmodule Jido.Telemetry do
       jido_partition: nil
     }
 
-    :telemetry.execute(
+    Observe.emit_event(
       [:jido, :agent, :strategy, operation, :start],
       %{system_time: System.system_time()},
       metadata
@@ -771,7 +772,7 @@ defmodule Jido.Telemetry do
             metadata
         end
 
-      :telemetry.execute(
+      Observe.emit_event(
         [:jido, :agent, :strategy, operation, :stop],
         measurements,
         final_metadata
@@ -782,10 +783,10 @@ defmodule Jido.Telemetry do
       kind, reason ->
         stack = __STACKTRACE__
 
-        :telemetry.execute(
+        Observe.emit_event(
           [:jido, :agent, :strategy, operation, :exception],
           %{duration: System.monotonic_time() - start_time},
-          Map.merge(metadata, %{kind: kind, error: reason, stacktrace: stack})
+          Map.merge(metadata, Observe.exception_metadata(kind, reason))
         )
 
         :erlang.raise(kind, reason, stack)

--- a/test/jido/agent_server/telemetry_test.exs
+++ b/test/jido/agent_server/telemetry_test.exs
@@ -103,6 +103,24 @@ defmodule JidoTest.AgentServer.TelemetryTest do
       strategy: InspectOptsStrategy
   end
 
+  defmodule RaisingStrategy do
+    @moduledoc false
+    use Jido.Agent.Strategy
+
+    @impl true
+    def cmd(_agent, _instructions, _ctx), do: raise("signal exploded")
+  end
+
+  defmodule RaisingAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "raising_agent",
+      schema: [],
+      strategy: RaisingStrategy
+
+    def signal_routes(_ctx), do: [{"explode", JidoTest.TestActions.IncrementAction}]
+  end
+
   setup context do
     test_pid = self()
 
@@ -185,6 +203,36 @@ defmodule JidoTest.AgentServer.TelemetryTest do
 
       assert metadata.directive_count == 1
       assert metadata.directive_types == %{"Emit" => 1}
+
+      GenServer.stop(pid)
+    end
+
+    test "emits bounded public metadata for signal exceptions", %{jido: jido} do
+      {:ok, pid} =
+        AgentServer.start_link(agent: RaisingAgent, id: "telemetry-signal-error", jido: jido)
+
+      signal = Signal.new!("explode", %{}, source: "/test")
+
+      capture_log(fn ->
+        assert {:error, %RuntimeError{message: "signal exploded"}} = AgentServer.call(pid, signal)
+      end)
+
+      assert_receive {:telemetry_event, [:jido, :agent_server, :signal, :start], _, _}
+
+      assert_receive {:telemetry_event, [:jido, :agent_server, :signal, :exception], measurements,
+                      metadata}
+
+      assert is_integer(measurements.duration)
+      assert metadata.agent_id == "telemetry-signal-error"
+      assert metadata.signal_type == "explode"
+      assert metadata.kind == :error
+
+      assert %{type: :internal, message: "signal exploded", details: %{}, retryable?: true} =
+               metadata.error
+
+      assert metadata.error_type == :internal
+      assert metadata.retryable? == true
+      refute Map.has_key?(metadata, :stacktrace)
 
       GenServer.stop(pid)
     end

--- a/test/jido/observe/observe_coverage_test.exs
+++ b/test/jido/observe/observe_coverage_test.exs
@@ -394,7 +394,12 @@ defmodule JidoTest.ObserveCoverageTest do
              ) == :test_exit_value
 
       assert_receive {:exception_event, [:jido, :test, :catch, :exception], %{duration: _},
-                      %{kind: :exit, error: :test_exit_value}}
+                      %{kind: :exit, error: error} = metadata}
+
+      assert %{type: :internal, message: ":test_exit_value", details: %{}, retryable?: true} =
+               error
+
+      refute Map.has_key?(metadata, :stacktrace)
     end
   end
 end

--- a/test/jido/observe/observe_test.exs
+++ b/test/jido/observe/observe_test.exs
@@ -111,8 +111,13 @@ defmodule JidoTest.ObserveTest do
       assert duration >= 0
       assert metadata.error_test == true
       assert metadata.kind == :error
-      assert %RuntimeError{message: "test error"} = metadata.error
-      assert is_list(metadata.stacktrace)
+
+      assert %{type: :internal, message: "test error", details: %{}, retryable?: true} =
+               metadata.error
+
+      assert metadata.error_type == :internal
+      assert metadata.retryable? == true
+      refute Map.has_key?(metadata, :stacktrace)
     end
 
     test "emits :exception event on throw and re-throws" do
@@ -129,7 +134,11 @@ defmodule JidoTest.ObserveTest do
                       metadata}
 
       assert metadata.kind == :throw
-      assert metadata.error == :my_throw
+
+      assert %{type: :internal, message: ":my_throw", details: %{}, retryable?: true} =
+               metadata.error
+
+      refute Map.has_key?(metadata, :stacktrace)
     end
 
     test "emits :exception event on exit and re-exits" do
@@ -145,7 +154,11 @@ defmodule JidoTest.ObserveTest do
                       metadata}
 
       assert metadata.kind == :exit
-      assert metadata.error == :my_exit
+
+      assert %{type: :internal, message: ":my_exit", details: %{}, retryable?: true} =
+               metadata.error
+
+      refute Map.has_key?(metadata, :stacktrace)
     end
 
     test "passes metadata to all events" do
@@ -292,10 +305,15 @@ defmodule JidoTest.ObserveTest do
                       _}
     end
 
-    test "includes kind, error, stacktrace in metadata" do
+    test "includes bounded public error metadata without stacktrace" do
       span_ctx = Observe.start_span([:jido, :test, :error_span], %{original: "meta"})
 
-      error = %ArgumentError{message: "invalid argument"}
+      error =
+        Jido.Error.validation_error("invalid argument",
+          field: :password,
+          details: %{password: "secret", stacktrace: ["raw frame"]}
+        )
+
       stacktrace = [{__MODULE__, :some_fun, 2, [file: ~c"test.ex", line: 42]}]
 
       Observe.finish_span_error(span_ctx, :error, error, stacktrace)
@@ -305,8 +323,14 @@ defmodule JidoTest.ObserveTest do
 
       assert metadata.original == "meta"
       assert metadata.kind == :error
-      assert metadata.error == error
-      assert metadata.stacktrace == stacktrace
+      assert metadata.error_type == :validation_error
+      assert metadata.error.message == "invalid argument"
+      assert metadata.error.details.password == "[REDACTED]"
+      assert metadata.error.details.stacktrace == "[OMITTED]"
+      assert metadata.error.details.kind == :input
+      assert metadata.error.details.subject == :password
+      assert metadata.retryable? == false
+      refute Map.has_key?(metadata, :stacktrace)
     end
 
     test "supports different error kinds" do

--- a/test/jido/pod/telemetry_test.exs
+++ b/test/jido/pod/telemetry_test.exs
@@ -294,18 +294,41 @@ defmodule JidoTest.Pod.TelemetryTest do
                     %{node_name: :planner, source: :started}}
 
     assert_receive {:telemetry_event, [:jido, :pod, :node, :ensure, :exception], %{duration: _},
-                    %{pod_module: RecursiveReviewPod, node_name: :nested, error: inner_error}}
+                    %{
+                      pod_module: RecursiveReviewPod,
+                      node_name: :nested,
+                      error: inner_error
+                    } = metadata}
 
-    assert inspect(inner_error) =~ "Recursive pod runtime is not supported"
+    assert inner_error.type == :validation_error
+    assert inner_error.message =~ "Recursive pod runtime is not supported"
+    assert metadata.retryable? == false
+    refute Map.has_key?(metadata, :stacktrace)
 
     assert_receive {:telemetry_event, [:jido, :pod, :node, :ensure, :exception], %{duration: _},
-                    %{pod_module: BrokenReviewPod, node_name: :nested, error: error}}
+                    %{
+                      pod_module: BrokenReviewPod,
+                      node_name: :nested,
+                      error_type: :internal,
+                      error: error
+                    } = metadata}
 
-    assert error.stage == :nested_reconcile
-    assert inspect(error.reason) =~ "Recursive pod runtime is not supported"
+    assert error.message =~ "nested_reconcile"
+    assert error.message =~ "Recursive pod runtime is not supported"
+    assert metadata.retryable? == true
+    refute Map.has_key?(metadata, :stacktrace)
 
     assert_receive {:telemetry_event, [:jido, :pod, :reconcile, :exception], %{duration: _},
-                    %{pod_id: ^pod_key, pod_module: BrokenReviewPod, error: ^report}}
+                    %{
+                      pod_id: ^pod_key,
+                      pod_module: BrokenReviewPod,
+                      error_type: :internal,
+                      error: reconcile_error
+                    } = metadata}
+
+    assert reconcile_error.message =~ "nested"
+    assert metadata.retryable? == true
+    refute Map.has_key?(metadata, :stacktrace)
 
     assert report.completed == [:planner]
     assert report.failed == [:nested]

--- a/test/jido/telemetry_test.exs
+++ b/test/jido/telemetry_test.exs
@@ -119,7 +119,13 @@ defmodule JidoTest.TelemetryTest do
       assert_receive {:telemetry_event, [:jido, :agent, :cmd, :exception], measurements, metadata}
       assert is_integer(measurements.duration)
       assert metadata.kind == :error
-      assert %RuntimeError{message: "test error"} = metadata.error
+
+      assert %{type: :internal, message: "test error", details: %{}, retryable?: true} =
+               metadata.error
+
+      assert metadata.error_type == :internal
+      assert metadata.retryable? == true
+      refute Map.has_key?(metadata, :stacktrace)
     end
   end
 
@@ -218,7 +224,13 @@ defmodule JidoTest.TelemetryTest do
 
       assert is_integer(measurements.duration)
       assert metadata.kind == :error
-      assert %RuntimeError{message: "strategy error"} = metadata.error
+
+      assert %{type: :internal, message: "strategy error", details: %{}, retryable?: true} =
+               metadata.error
+
+      assert metadata.error_type == :internal
+      assert metadata.retryable? == true
+      refute Map.has_key?(metadata, :stacktrace)
     end
 
     test "handles non-tuple result gracefully" do


### PR DESCRIPTION
## Summary
- Make `Jido.Observe` the canonical telemetry emission boundary for span lifecycle events and AgentServer telemetry.
- Add bounded `Jido.Observe.exception_metadata/2` so exception events carry sanitized public error maps without stacktraces.
- Keep legacy `Jido.Telemetry` event names and measurements while routing emission through `Jido.Observe`.
- Keep top-level exception metadata low-cardinality with `kind`, `error_type`, and `retryable?`; richer bounded details remain under `metadata.error`.
- Update regression coverage for Observe, Telemetry compatibility helpers, AgentServer, and Pod telemetry exception contracts.

## Tests
- `mix test test/jido/observe/observe_test.exs test/jido/telemetry_test.exs test/jido/agent_server/telemetry_test.exs test/jido/pod/telemetry_test.exs test/jido/observe/observe_coverage_test.exs`
- `mix test`
- `mix q`

Closes #263