### PR TITLE
docs: clarify purity and effect boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Jido helps you build agent systems as ordinary Elixir and OTP software.
 - Signals route events into the system
 - Directives describe effects for the runtime to execute
 
+The purity boundary is the agent's decision logic: Jido keeps agent decisions and
+state transitions explicit, actions may be pure or effectful, and directives are
+for effects you want the runtime to own.
+
 Use Jido when software needs to inspect context, choose among multiple steps,
 coordinate with other agents, and keep running reliably over time.
 
@@ -46,7 +50,10 @@ end
 {agent, directives} = MyAgent.cmd(agent, action)
 ```
 
-State changes are pure data transformations; side effects are described as directives and executed by an OTP runtime. You get deterministic agent logic, testability without processes, and a clear path to running those agents in production.
+State changes are explicit data transformations. If an action needs a result
+back immediately to continue reasoning or update state, it may perform that work
+itself. If the workflow has already decided on an outbound effect and wants the
+runtime or integration layer to own delivery, return a directive.
 <!-- package.jido.pure_cmd package.jido.runtime_separation -->
 
 ## The Jido Ecosystem
@@ -80,12 +87,13 @@ Jido isn't "better GenServer" - it's a formalized agent pattern built *on* GenSe
 ## Key Features
 
 ### Immutable Agent Architecture
-- Pure functional agent design inspired by Elm/Redux
+- Functional agent state model inspired by Elm/Redux
 - `cmd/2` as the core operation: actions in, updated agent + directives out
 - Schema-validated state with NimbleOptions or Zoi
 
 ### Directive-Based Effects
-- Actions transform state; directives describe external effects
+- Actions transform state and may perform required work
+- Directives describe runtime-owned external effects
 - Built-in directives: Emit, Spawn, SpawnAgent, StopChild, Schedule, Stop
 - Protocol-based extensibility for custom directives
 
@@ -248,14 +256,23 @@ The fundamental operation in Jido:
 
 Key invariants:
 - The returned `agent` is always complete - no "apply directives" step needed
-- `directives` describe external effects only - they never modify agent state
-- `cmd/2` is a pure function - same inputs always produce same outputs
+- `directives` describe runtime-owned external effects only - they never modify
+  agent state
+- Agent decision logic stays explicit and testable; deterministic actions produce
+  deterministic `cmd/2` results
+
+Use this rule of thumb for side effects:
+
+- If the step needs a result back now to continue reasoning or update state, an
+  effectful action is acceptable.
+- If the workflow has already decided on an outbound effect and wants the
+  runtime or integration layer to own delivery, return a directive.
 
 ### Actions vs Directives vs State Operations
 
 | Actions                                    | Directives                            | State Operations                |
 | ------------------------------------------ | ------------------------------------- | ------------------------------- |
-| Transform state, may perform side effects  | Describe external effects             | Describe internal state changes |
+| Transform state, may perform side effects  | Describe runtime-owned effects        | Describe internal state changes |
 | Executed by `cmd/2`, update `agent.state`  | Bare structs emitted by agents        | Applied by strategy layer       |
 | Can call APIs, read files, query databases | Runtime (AgentServer) interprets them | Never leave the strategy        |
 
@@ -317,9 +334,9 @@ State operations are internal state transitions handled by the strategy layer du
 
 A: Jido is an **autonomous agent framework for Elixir, built for workflows and multi-agent systems**. Key differentiators:
 - **OTP-native architecture**: Built on GenServer with supervision and fault tolerance built in
-- **Immutable agents**: Pure functional agent design inspired by Elm/Redux
+- **Immutable agents**: Functional state model inspired by Elm/Redux
 - **AI optional**: Core package provides agent architecture without requiring AI/LLM
-- **Directive-based effects**: Actions transform state; directives describe external effects
+- **Explicit effect boundaries**: actions may own immediate work; directives describe runtime-owned effects
 
 Compared to LangChain/CrewAI:
 - **LangChain**: Chain-based orchestration, Python-first
@@ -334,7 +351,10 @@ A:
 - **Signals**: CloudEvents-compliant messages routed into the system
 - **Directives**: Bare structs that describe effects for the runtime to execute
 
-`cmd/2` returns the updated agent plus directives. Directives never mutate agent state; the OTP runtime interprets them for external effects. Actions may still perform work such as API calls, file I/O, or database queries when that belongs in the action boundary.
+`cmd/2` returns the updated agent plus directives. Directives never mutate agent
+state; the OTP runtime interprets them for runtime-owned external effects.
+Actions may still perform work such as API calls, file I/O, or database queries
+when that result is needed immediately by the action or state transition.
 
 **Q: Is AI required for Jido?**
 

--- a/guides/actions.md
+++ b/guides/actions.md
@@ -4,9 +4,15 @@
 
 **After:** You can implement an Action module that transforms state and returns directives.
 
+Jido keeps agent decision logic pure. Actions may be pure or effectful.
+Directives are for effects you want the runtime to own.
+
 ## The Complete Picture
 
-An action receives validated params and context, then returns state updates and optional directives. Actions may perform side effects (API calls, file I/O, database queries):
+An action receives validated params and context, then returns state updates and
+optional directives. Actions may perform side effects such as API calls, file
+I/O, or database queries when they need the result to continue reasoning or
+update state:
 
 ```elixir
 defmodule MyApp.Actions.CreateOrder do
@@ -72,6 +78,19 @@ end
 |-----|-------|
 | `:state` | Current agent state as a map |
 | `:agent` | The agent struct (when running via `emit_to_parent`) |
+
+## Effect Boundary
+
+Use this rule when deciding between action code and a directive:
+
+- If the step needs a result back now to continue reasoning or update state, keep
+  the work in the action.
+- If the workflow has already decided on an outbound effect and wants the
+  runtime or integration layer to own delivery, return a directive.
+
+For example, an action can call an API and use the response to update state. If
+the action only needs to announce that an order was created, return an
+`%Jido.Agent.Directive.Emit{}` and let the runtime dispatch the signal.
 
 ## Return Shapes
 

--- a/guides/agents.md
+++ b/guides/agents.md
@@ -4,7 +4,12 @@
 
 **After:** You can define agents with schemas, hooks, and the `cmd/2`/`cmd/3` contract.
 
-Agents are immutable data structures that hold state and respond to actions. The core operation is `cmd/2` (or `cmd/3` with options), which processes actions and returns an updated agent plus directives for external effects.
+Agents are immutable data structures that hold state and respond to actions. The
+core operation is `cmd/2` (or `cmd/3` with options), which processes actions and
+returns an updated agent plus any runtime-owned directives.
+
+Jido keeps agent decision logic pure. Actions may be pure or effectful.
+Directives are for effects you want the runtime to own.
 
 ## Defining an Agent
 
@@ -41,8 +46,13 @@ The fundamental operation:
 **Key invariants:**
 
 - The returned `agent` is always complete—no "apply directives" step needed
-- `directives` describe external effects only—they never modify agent state
-- `cmd/2` and `cmd/3` are pure functions—given same inputs, always same outputs
+- `directives` describe runtime-owned external effects only—they never modify
+  agent state
+- Agent decision logic stays explicit and testable
+
+Use an effectful action when the current step needs a result back now to continue
+reasoning or update state. Use a directive when the workflow has already decided
+on an outbound effect and wants the runtime or integration layer to own delivery.
 
 **Action formats:**
 

--- a/guides/core-loop.md
+++ b/guides/core-loop.md
@@ -8,9 +8,12 @@ for Elixir built for workflows and multi-agent systems.
 Jido combines immutable agents, actions, signals, directives, and an OTP
 runtime so you can build agent systems as ordinary Elixir software.
 
+The core boundary is: Jido keeps agent decision logic pure. Actions may be pure
+or effectful. Directives are for effects you want the runtime to own.
+
 ## The Elm/Redux Pattern
 
-Jido agents follow a pure functional architecture:
+Jido agents follow a functional state architecture:
 
 ```elixir
 {agent, directives} = MyAgent.cmd(agent, action)
@@ -19,9 +22,10 @@ Jido agents follow a pure functional architecture:
 **Key principles:**
 
 1. **Agents are immutable structs** — `cmd/2` never mutates; it returns a new agent
-2. **State changes and effects are separated** — the returned agent has updated state; directives describe effects
+2. **State changes are explicit** — the returned agent has updated state
 3. **Directives are not executed by agents** — the runtime (AgentServer) interprets them
-4. **Same inputs → same outputs** — `cmd/2` is deterministic and testable
+4. **Actions own immediate work** — an action may perform I/O when it needs the result to update state
+5. **Runtime-owned effects are directives** — emit, spawn, schedule, and stop decisions leave `cmd/2` as data
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -39,8 +43,8 @@ Jido agents follow a pure functional architecture:
                                 │
                                 ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Agent.cmd/2 (pure function)                                    │
-│  ───────────────────────────                                    │
+│  Agent.cmd/2 (agent decision boundary)                          │
+│  ─────────────────────────────────────                          │
 │  Input:  agent struct + action                                  │
 │  Output: {updated_agent, directives}                            │
 └─────────────────────────────────────────────────────────────────┘
@@ -50,7 +54,7 @@ Jido agents follow a pure functional architecture:
 
 | Concept | What It Is | Responsibility |
 |---------|------------|----------------|
-| **Agent** | Immutable struct + module | Defines schema, handles `cmd/2`, pure logic |
+| **Agent** | Immutable struct + module | Defines schema, handles `cmd/2`, pure decision logic |
 | **AgentServer** | GenServer process | Holds agent state, executes directives, routes signals |
 
 ```elixir
@@ -94,12 +98,24 @@ This enables:
 
 | Term | Definition |
 |------|------------|
-| **Agent** | Immutable struct with state and schema. Defines `cmd/2` for pure transformations. |
+| **Agent** | Immutable struct with state and schema. Defines `cmd/2` for explicit state transitions. |
 | **Action** | Function that transforms agent state (may perform side effects). Defined in [jido_action](https://hexdocs.pm/jido_action). |
 | **Directive** | Effect description for runtime execution (Emit, Spawn, Schedule, etc.). Never modifies state. |
 | **Plugin** | Composable capability module bundling actions, state, and routing rules. |
 | **Strategy** | Execution pattern (Direct, FSM, custom) that controls how actions are processed. |
 | **Signal** | CloudEvents-compliant message. Defined in [jido_signal](https://hexdocs.pm/jido_signal). |
+
+## Action Or Directive?
+
+Use an effectful action when the current step needs a result back now to continue
+reasoning or update state. Use a directive when the workflow has already decided
+on an outbound effect and wants the runtime or integration layer to own delivery.
+
+Examples:
+
+- Reading a file so the action can parse it and update state can live in the action.
+- Dispatching a domain event, spawning a child, scheduling future work, or
+  stopping an agent should be returned as a directive.
 
 ## The Core Flow
 
@@ -127,7 +143,8 @@ assert match?([%Directive.Emit{}], directives)
 
 **Composability**: Directives are data — inspect, transform, filter, or mock them.
 
-**Separation of concerns**: Pure logic (Agent) vs. effectful runtime (AgentServer).
+**Separation of concerns**: Pure agent decisions, explicit action work, and
+runtime-owned directive execution.
 
 ## Further Reading
 

--- a/guides/directives.md
+++ b/guides/directives.md
@@ -2,11 +2,17 @@
 
 <!-- covers: jido.signals_and_directives.directive_effect_boundary jido.signals_and_directives.scheduling_support -->
 
-**After:** You can emit directives from actions to perform effects without polluting pure logic.
+**After:** You can emit directives from actions when an effect should be owned by the runtime.
 
-Directives are **pure descriptions of external effects**. Agents emit them from `cmd/2` callbacks; the runtime (`AgentServer`) executes them.
+Directives are **pure descriptions of runtime-owned external effects**. Agents
+emit them from `cmd/2` callbacks; the runtime (`AgentServer`) executes them.
 
 **Key principle**: Directives never mutate state directly; state changes happen through `cmd/2` return values (including `result_action` callbacks used by `RunInstruction`).
+
+Directives are not the only place side effects can happen. Jido keeps agent
+decision logic pure; actions may be pure or effectful. Use a directive when the
+workflow has already decided on an outbound effect and wants the runtime or
+integration layer to own delivery.
 
 ## Directives vs State Operations
 
@@ -14,7 +20,7 @@ Jido separates two distinct concerns:
 
 | Concept | Module | Purpose | Handled By |
 |---------|--------|---------|------------|
-| **Directives** | `Jido.Agent.Directive` | External effects (emit signals, spawn processes) | Runtime (AgentServer) |
+| **Directives** | `Jido.Agent.Directive` | Runtime-owned effects (emit signals, spawn processes) | Runtime (AgentServer) |
 | **State Operations** | `Jido.Agent.StateOp` | Internal state transitions (set, replace, delete) | Strategy layer |
 
 State operations are applied during `cmd/2` and never leave the strategy layer. Directives are passed through to the runtime for execution. See the [State Operations guide](state-ops.md) for details on `SetState`, `SetPath`, and other state ops.
@@ -93,9 +99,10 @@ Non-persistent lifecycles keep cron state runtime-only.
 
 ## RunInstruction
 
-`RunInstruction` is used by strategies that keep `cmd/2` pure. Instead of calling
-`Jido.Exec.run/1` inline, the strategy emits `%Directive.RunInstruction{}` and the
-runtime executes it, then routes the result back through `cmd/2` using `result_action`.
+`RunInstruction` is used by strategies that want runtime-owned instruction
+execution. Instead of calling `Jido.Exec.run/1` inline, the strategy emits
+`%Directive.RunInstruction{}` and the runtime executes it, then routes the result
+back through `cmd/2` using `result_action`.
 
 ## Spawn vs SpawnAgent
 

--- a/guides/getting-started.livemd
+++ b/guides/getting-started.livemd
@@ -72,7 +72,8 @@ end
 
 ## Step 3: Use cmd/2 for State Transformations
 
-The core pattern in Jido is `cmd/2` - a pure function that takes an agent and an action, returning the updated agent and any directives:
+The core pattern in Jido is `cmd/2`: pass an agent and an action, then receive
+the updated agent and any directives for runtime-owned effects:
 
 ```elixir
 {agent, directives} = MyAgent.cmd(agent, action)
@@ -111,9 +112,9 @@ IO.inspect(agent.state, label: "After increment by 1")
 ```
 
 Key points:
-- `cmd/2` is **pure** - same inputs always produce same outputs
 - The returned agent is fully updated
-- Directives describe side effects but don't modify state
+- Actions may be pure or effectful when they need a result back now
+- Directives describe runtime-owned effects and never modify state
 
 ## Step 4: Handle Signals with AgentServer
 

--- a/guides/migration.md
+++ b/guides/migration.md
@@ -470,16 +470,17 @@ V2 emits telemetry events for observability:
 
 ## Common Migration Patterns
 
-### Pattern 1: Gradual Directive Adoption
+### Pattern 1: Gradual Runtime-Owned Effect Adoption
 
-You don't need to convert all side effects at once. Start with the most critical paths:
+You don't need to move every side effect behind a directive. Start with effects
+the runtime should own, such as signal dispatch, scheduling, and spawned work:
 
 ```elixir
 def cmd(agent, signal) do
-  # New code uses directives
+  # New code returns runtime-owned effects as directives
   result = process(signal)
   
-  # Legacy code still works (but should be migrated)
+  # Immediate work can still happen at the action/command boundary
   LegacyNotifier.notify(result)
   
   {%{agent | state: result}, [

--- a/lib/jido.ex
+++ b/lib/jido.ex
@@ -35,8 +35,14 @@ defmodule Jido do
       {agent, directives} = MyAgent.cmd(agent, MyAction)
 
   - **Agents** — Immutable structs updated via commands
-  - **Actions** — Functions that transform agent state (may perform side effects)
-  - **Directives** — Descriptions of external effects (signals, processes, etc.)
+  - **Actions** — Functions that transform agent state and may perform work
+  - **Directives** — Runtime-owned external effects (signals, processes, etc.)
+
+  Jido keeps agent decision logic pure. Actions may be pure or effectful.
+  Directives are for effects you want the runtime to own. If a step needs a
+  result back now to continue reasoning or update state, an effectful action is
+  acceptable; if delivery should belong to the runtime or an integration layer,
+  return a directive.
 
   ## For Tests
 

--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -1,7 +1,7 @@
 defmodule Jido.Agent do
   @moduledoc """
   An Agent is an immutable data structure that holds state and can be updated
-  via commands. This module provides a minimal, purely functional API:
+  via commands. This module provides a minimal, data-first API:
 
   - `new/1` - Create a new agent
   - `set/2` - Update state directly
@@ -18,8 +18,14 @@ defmodule Jido.Agent do
 
   Key invariants:
   - The returned `agent` is **always complete** — no "apply directives" step needed
-  - `directives` are **external effects only** — they never modify agent state
-  - `cmd/2` is a **pure function** — given same inputs, always same outputs
+  - `directives` are **runtime-owned external effects only** — they never modify agent state
+  - Agent decision logic stays explicit and testable
+
+  Jido keeps agent decision logic pure. Actions may be pure or effectful.
+  Directives are for effects you want the runtime to own. If a step needs a
+  result back now to continue reasoning or update state, an effectful action is
+  acceptable; if delivery should belong to the runtime or an integration layer,
+  return a directive.
 
   ## Action Formats
 
@@ -253,7 +259,7 @@ defmodule Jido.Agent do
   # Action input types
   @type action :: module() | {module(), map()} | Instruction.t() | [action()]
 
-  # Directive types (external effects only - never modify agent state)
+  # Directive types (runtime-owned external effects only - never modify agent state)
   # See Jido.Agent.Directive for structured payload modules
   @type directive :: Directive.t()
 
@@ -842,9 +848,10 @@ defmodule Jido.Agent do
   def __quoted_cmd_function__ do
     quote location: :keep do
       @doc """
-      Execute actions against the agent. Pure: `(agent, action) -> {agent, directives}`
+      Execute actions against the agent: `(agent, action) -> {agent, directives}`
 
-      This is the core operation. Actions modify state, directives are external effects.
+      This is the core operation. Actions modify state and may perform required
+      work; directives are runtime-owned external effects.
       Execution is delegated to the configured strategy (default: Direct).
 
       ## Action Formats


### PR DESCRIPTION
## Summary

- establish the canonical purity/effects wording from #248 in README, guides, and moduledocs
- clarify that actions may own immediate work while directives represent runtime-owned effects
- update getting-started and migration wording so they no longer imply every side effect must become a directive

## Verification

- mix test
- mix docs
- git diff --check

Closes #248