### PR TITLE
feat(sensor): add tagged sensor lifecycle directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Jido isn't "better GenServer" - it's a formalized agent pattern built *on* GenSe
 ### Directive-Based Effects
 - Actions transform state and may perform required work
 - Directives describe runtime-owned external effects
-- Built-in directives: Emit, Spawn, SpawnAgent, StopChild, Schedule, Stop
+- Built-in directives: Emit, Spawn, SpawnAgent, StopChild, StartSensor, StopSensor, Schedule, Stop
 - Protocol-based extensibility for custom directives
 
 ### OTP Runtime Integration
@@ -297,6 +297,8 @@ State operations are internal state transitions handled by the strategy layer du
 | `Spawn`      | Spawn a generic BEAM child process               |
 | `SpawnAgent` | Spawn a tracked child Jido agent (`restart: :transient` by default) |
 | `StopChild`  | Gracefully stop and remove a tracked child agent                      |
+| `StartSensor` | Start or replace a tagged sensor runtime        |
+| `StopSensor` | Stop a tagged sensor runtime                     |
 | `Schedule`   | Schedule a delayed message                       |
 | `Stop`       | Stop the agent process                           |
 
@@ -426,6 +428,8 @@ A: Built-in directives:
 - **SpawnAgent**: Spawn child agents
 - **AdoptChild**: Attach an orphaned or unattached child to the current parent
 - **StopChild**: Stop child processes/agents
+- **StartSensor**: Start or replace tagged sensor runtimes
+- **StopSensor**: Stop tagged sensor runtimes
 - **Schedule**: Schedule future actions
 - **RunInstruction**: Execute an instruction at runtime and route the result back to `cmd/2`
 - **Stop**: Stop the agent

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ State operations are internal state transitions handled by the strategy layer du
 | `Schedule`   | Schedule a delayed message                       |
 | `Stop`       | Stop the agent process                           |
 
+Sensor runtimes started by `StartSensor` are tracked under `{:sensor, tag}` and
+are owner-monitored by default. Unexpected sensor exits emit
+`jido.agent.sensor.exit` back to the owning agent; controlled `StopSensor`
+shutdowns do not. Use `link?: true` only when a sensor should fail fast with
+its owning `AgentServer`.
+
 ## Documentation
 
 **Start here:**
@@ -428,7 +434,7 @@ A: Built-in directives:
 - **SpawnAgent**: Spawn child agents
 - **AdoptChild**: Attach an orphaned or unattached child to the current parent
 - **StopChild**: Stop child processes/agents
-- **StartSensor**: Start or replace tagged sensor runtimes
+- **StartSensor**: Start or replace owner-monitored tagged sensor runtimes
 - **StopSensor**: Stop tagged sensor runtimes
 - **Schedule**: Schedule future actions
 - **RunInstruction**: Execute an instruction at runtime and route the result back to `cmd/2`

--- a/guides/directives.md
+++ b/guides/directives.md
@@ -72,6 +72,8 @@ Directive.adopt_child(child_pid, :recovered_worker, meta: %{restored: true})
 
 # Stop processes
 Directive.stop_child(:worker_1)
+
+# Sensor lifecycles
 Directive.start_sensor(:market_data, MyApp.MarketDataSensor,
   config: %{symbol: "AAPL", interval: 1000},
   link?: false

--- a/guides/directives.md
+++ b/guides/directives.md
@@ -43,6 +43,8 @@ end
 | `SpawnAgent` | Spawn child Jido agent with hierarchy | Full (monitoring, exit signals, `restart: :transient` default) |
 | `AdoptChild` | Attach an orphaned or unattached child to the current parent | Full (monitoring, parent ref refresh, children map update) |
 | `StopChild` | Gracefully stop and remove a tracked child agent | Uses children map |
+| `StartSensor` | Start or replace a tagged sensor runtime | Tracked under `{:sensor, tag}` |
+| `StopSensor` | Stop a tagged sensor runtime | Uses sensor tag |
 | `Schedule` | Schedule a delayed message | — |
 | `RunInstruction` | Execute `%Instruction{}` at runtime and route result back through `cmd/2` | — |
 | `Stop` | Stop the agent process (self) | — |
@@ -70,6 +72,10 @@ Directive.adopt_child(child_pid, :recovered_worker, meta: %{restored: true})
 
 # Stop processes
 Directive.stop_child(:worker_1)
+Directive.start_sensor(:market_data, MyApp.MarketDataSensor,
+  config: %{symbol: "AAPL", interval: 1000}
+)
+Directive.stop_sensor(:market_data)
 Directive.stop()
 Directive.stop(:shutdown)
 

--- a/guides/directives.md
+++ b/guides/directives.md
@@ -73,7 +73,8 @@ Directive.adopt_child(child_pid, :recovered_worker, meta: %{restored: true})
 # Stop processes
 Directive.stop_child(:worker_1)
 Directive.start_sensor(:market_data, MyApp.MarketDataSensor,
-  config: %{symbol: "AAPL", interval: 1000}
+  config: %{symbol: "AAPL", interval: 1000},
+  link?: false
 )
 Directive.stop_sensor(:market_data)
 Directive.stop()
@@ -143,6 +144,23 @@ to `:continue` or `:emit_orphan`. In that case, `Directive.adopt_child/3` is
 the explicit way to reattach the live child to a new logical parent. Jido keeps
 the active logical binding in `Jido.RuntimeStore`, so child restarts continue
 to use the current parent relationship after adoption.
+
+## Sensor Lifecycle
+
+`StartSensor` starts or replaces a tagged `Jido.Sensor` runtime and tracks it
+under `{:sensor, tag}` in the owning `AgentServer`. Sensor signals are delivered
+back to that owning agent by default.
+
+Managed sensors default to `link?: false` with explicit owner monitoring:
+
+- if the owning `AgentServer` exits, the sensor stops itself
+- if the sensor exits unexpectedly, the owner receives `jido.agent.sensor.exit`
+- controlled `StopSensor` shutdowns do not emit `jido.agent.sensor.exit`
+
+Use `link?: true` only for fail-fast input paths where an abnormal sensor exit
+should also take down the owning `AgentServer`. Even then, controlled
+replacement and `StopSensor` unlink before shutdown so intentional lifecycle
+changes stay local.
 
 ## Parent-Aware Communication
 

--- a/guides/sensors.md
+++ b/guides/sensors.md
@@ -123,7 +123,27 @@ Sensors that need external connections or subscriptions should establish them in
 
 ## Starting Sensors
 
-Use `Jido.Sensor.Runtime` to run a sensor:
+When a sensor is owned by an agent, prefer `StartSensor` and let the
+`AgentServer` manage delivery, monitoring, replacement, and cleanup:
+
+```elixir
+def run(_params, _context) do
+  {:ok, %{},
+   [
+     Jido.Agent.Directive.start_sensor(:metrics, MetricSensor,
+       config: %{metric: "cpu_usage", threshold: 80}
+     )
+   ]}
+end
+```
+
+The owning `AgentServer` supplies runtime context such as `:agent_ref`,
+`:agent_id`, and `:sensor_tag`. Sensors started this way are tracked under
+`{:sensor, tag}`, stop when the owning agent exits, and emit
+`jido.agent.sensor.exit` to the owner on unexpected sensor exits.
+
+Use `Jido.Sensor.Runtime` directly for standalone sensors or supervised
+application children:
 
 ```elixir
 {:ok, sensor_pid} = Jido.Sensor.Runtime.start_link(
@@ -141,6 +161,7 @@ Use `Jido.Sensor.Runtime` to run a sensor:
 | `:config` | Configuration map, validated against sensor's schema |
 | `:context` | Runtime context, including `:agent_ref` for signal delivery |
 | `:id` | Instance ID (auto-generated if not provided) |
+| `:owner_pid` | Optional owner process to monitor; the runtime stops if the owner exits |
 
 ### In Supervision Trees
 

--- a/guides/sensors.md
+++ b/guides/sensors.md
@@ -116,11 +116,10 @@ Callbacks return directives that the Runtime executes:
 | `{:schedule, ms}` | Schedule a `:tick` event after `ms` milliseconds |
 | `{:schedule, ms, payload}` | Schedule a custom event after `ms` milliseconds |
 | `{:emit, signal}` | Deliver signal to the agent immediately |
-| `{:connect, adapter}` | Connect to an external source |
-| `{:connect, adapter, opts}` | Connect with options |
-| `{:disconnect, adapter}` | Disconnect from a source |
-| `{:subscribe, topic}` | Subscribe to a topic/pattern |
-| `{:unsubscribe, topic}` | Unsubscribe from a topic |
+
+Sensors that need external connections or subscriptions should establish them in
+`init/2`, keep connection handles in their sensor state, and clean them up in
+`terminate/2`.
 
 ## Starting Sensors
 

--- a/lib/jido/agent/directive.ex
+++ b/lib/jido/agent/directive.ex
@@ -487,6 +487,11 @@ defmodule Jido.Agent.Directive do
     Sensors are tracked separately from child agents under `{:sensor, tag}` and
     do not participate in child-agent hierarchy signals.
 
+    By default sensors are unlinked but owner-monitored: a sensor crash emits
+    `jido.agent.sensor.exit` to the owning agent, and the sensor stops itself if
+    the owner exits. Use `link?: true` only for fail-fast input paths where a
+    sensor crash should also crash the owning agent runtime.
+
     ## Fields
 
     - `tag` - Agent-local tag for the sensor runtime
@@ -542,7 +547,9 @@ defmodule Jido.Agent.Directive do
     Stop a tagged sensor runtime owned by the current agent runtime.
 
     The sensor is identified by the same tag used by `StartSensor`. Missing
-    sensors are a no-op. Stopping a sensor does not emit `jido.agent.child.exit`.
+    sensors are a no-op. Stopping a sensor does not emit `jido.agent.child.exit`
+    or `jido.agent.sensor.exit`; the sensor exit signal is reserved for
+    unexpected runtime exits.
 
     ## Fields
 

--- a/lib/jido/agent/directive.ex
+++ b/lib/jido/agent/directive.ex
@@ -494,6 +494,8 @@ defmodule Jido.Agent.Directive do
     - `config` - Sensor configuration map (default: `%{}`)
     - `meta` - Metadata stored on the tracked sensor child info (default: `%{}`)
     - `replace?` - Stop and replace an existing sensor with this tag (default: `true`)
+    - `link?` - Link the sensor to the owning AgentServer so abnormal sensor
+      exits can take the owner down (default: `false`)
 
     ## Examples
 
@@ -514,7 +516,10 @@ defmodule Jido.Agent.Directive do
                 meta: Zoi.map(description: "Metadata for sensor tracking") |> Zoi.default(%{}),
                 replace?:
                   Zoi.boolean(description: "Replace an existing sensor with the same tag")
-                  |> Zoi.default(true)
+                  |> Zoi.default(true),
+                link?:
+                  Zoi.boolean(description: "Link sensor failure to owning AgentServer")
+                  |> Zoi.default(false)
               },
               coerce: true
             )
@@ -817,6 +822,8 @@ defmodule Jido.Agent.Directive do
   - `:config` - Sensor configuration map (default: `%{}`)
   - `:meta` - Metadata stored with the tracked sensor (default: `%{}`)
   - `:replace?` - Whether to replace an existing sensor for the tag (default: `true`)
+  - `:link?` - Link the sensor to the owning AgentServer so abnormal sensor
+    exits can take the owner down (default: `false`)
 
   ## Examples
 
@@ -832,7 +839,8 @@ defmodule Jido.Agent.Directive do
       sensor: sensor,
       config: Keyword.get(opts, :config, %{}),
       meta: Keyword.get(opts, :meta, %{}),
-      replace?: Keyword.get(opts, :replace?, true)
+      replace?: Keyword.get(opts, :replace?, true),
+      link?: Keyword.get(opts, :link?, false)
     }
   end
 

--- a/lib/jido/agent/directive.ex
+++ b/lib/jido/agent/directive.ex
@@ -27,6 +27,8 @@ defmodule Jido.Agent.Directive do
     * `%SpawnAgent{}` - Spawn a child Jido agent with full hierarchy tracking
     * `%AdoptChild{}` - Attach an orphaned or unattached child to the current parent
     * `%StopChild{}` - Request a tracked child agent to stop gracefully
+    * `%StartSensor{}` - Start or replace a tagged sensor runtime
+    * `%StopSensor{}` - Stop a tagged sensor runtime
     * `%Schedule{}` - Schedule a delayed message
     * `%RunInstruction{}` - Execute an instruction at runtime and route result to `cmd/2`
     * `%Stop{}` - Stop the agent process (self)
@@ -64,6 +66,8 @@ defmodule Jido.Agent.Directive do
     SpawnAgent,
     AdoptChild,
     StopChild,
+    StartSensor,
+    StopSensor,
     Schedule,
     RunInstruction,
     Stop,
@@ -87,6 +91,8 @@ defmodule Jido.Agent.Directive do
           | SpawnAgent.t()
           | AdoptChild.t()
           | StopChild.t()
+          | StartSensor.t()
+          | StopSensor.t()
           | Schedule.t()
           | RunInstruction.t()
           | Stop.t()
@@ -471,6 +477,98 @@ defmodule Jido.Agent.Directive do
   end
 
   # ============================================================================
+  # StartSensor - Start a tagged sensor runtime
+  # ============================================================================
+
+  defmodule StartSensor do
+    @moduledoc """
+    Start or replace a tagged sensor runtime owned by the current agent runtime.
+
+    Sensors are tracked separately from child agents under `{:sensor, tag}` and
+    do not participate in child-agent hierarchy signals.
+
+    ## Fields
+
+    - `tag` - Agent-local tag for the sensor runtime
+    - `sensor` - Sensor module to run under `Jido.Sensor.Runtime`
+    - `config` - Sensor configuration map (default: `%{}`)
+    - `meta` - Metadata stored on the tracked sensor child info (default: `%{}`)
+    - `replace?` - Stop and replace an existing sensor with this tag (default: `true`)
+
+    ## Examples
+
+        %StartSensor{tag: :market_data, sensor: MyApp.MarketDataSensor}
+        %StartSensor{
+          tag: {:poller, "AAPL"},
+          sensor: MyApp.MarketDataSensor,
+          config: %{symbol: "AAPL", interval: 1000}
+        }
+    """
+
+    @schema Zoi.struct(
+              __MODULE__,
+              %{
+                tag: Zoi.any(description: "Agent-local tag for the sensor runtime"),
+                sensor: Zoi.atom(description: "Sensor module to start"),
+                config: Zoi.map(description: "Sensor configuration") |> Zoi.default(%{}),
+                meta: Zoi.map(description: "Metadata for sensor tracking") |> Zoi.default(%{}),
+                replace?:
+                  Zoi.boolean(description: "Replace an existing sensor with the same tag")
+                  |> Zoi.default(true)
+              },
+              coerce: true
+            )
+
+    @type t :: unquote(Zoi.type_spec(@schema))
+    @enforce_keys Zoi.Struct.enforce_keys(@schema)
+    defstruct Zoi.Struct.struct_fields(@schema)
+
+    @doc "Returns the Zoi schema for StartSensor."
+    @spec schema() :: Zoi.schema()
+    def schema, do: @schema
+  end
+
+  # ============================================================================
+  # StopSensor - Stop a tagged sensor runtime
+  # ============================================================================
+
+  defmodule StopSensor do
+    @moduledoc """
+    Stop a tagged sensor runtime owned by the current agent runtime.
+
+    The sensor is identified by the same tag used by `StartSensor`. Missing
+    sensors are a no-op. Stopping a sensor does not emit `jido.agent.child.exit`.
+
+    ## Fields
+
+    - `tag` - Agent-local tag for the sensor runtime
+    - `reason` - Reason for stopping (default: `:normal`)
+
+    ## Examples
+
+        %StopSensor{tag: :market_data}
+        %StopSensor{tag: {:poller, "AAPL"}, reason: :reconfigured}
+    """
+
+    @schema Zoi.struct(
+              __MODULE__,
+              %{
+                tag: Zoi.any(description: "Agent-local tag for the sensor runtime"),
+                reason: Zoi.any(description: "Reason for stopping") |> Zoi.default(:normal)
+              },
+              coerce: true
+            )
+
+    @type t :: unquote(Zoi.type_spec(@schema))
+    @enforce_keys Zoi.Struct.enforce_keys(@schema)
+    defstruct Zoi.Struct.struct_fields(@schema)
+
+    @doc "Returns the Zoi schema for StopSensor."
+    @spec schema() :: Zoi.schema()
+    def schema, do: @schema
+  end
+
+  # ============================================================================
   # Schedule - Delayed message scheduling
   # ============================================================================
 
@@ -709,6 +807,46 @@ defmodule Jido.Agent.Directive do
   @spec stop_child(term(), term()) :: StopChild.t()
   def stop_child(tag, reason \\ :normal) do
     %StopChild{tag: tag, reason: reason}
+  end
+
+  @doc """
+  Creates a StartSensor directive to start or replace a tagged sensor runtime.
+
+  ## Options
+
+  - `:config` - Sensor configuration map (default: `%{}`)
+  - `:meta` - Metadata stored with the tracked sensor (default: `%{}`)
+  - `:replace?` - Whether to replace an existing sensor for the tag (default: `true`)
+
+  ## Examples
+
+      Directive.start_sensor(:market_data, MyApp.MarketDataSensor)
+      Directive.start_sensor({:poller, "AAPL"}, MyApp.MarketDataSensor,
+        config: %{symbol: "AAPL", interval: 1000}
+      )
+  """
+  @spec start_sensor(term(), module(), keyword()) :: StartSensor.t()
+  def start_sensor(tag, sensor, opts \\ []) do
+    %StartSensor{
+      tag: tag,
+      sensor: sensor,
+      config: Keyword.get(opts, :config, %{}),
+      meta: Keyword.get(opts, :meta, %{}),
+      replace?: Keyword.get(opts, :replace?, true)
+    }
+  end
+
+  @doc """
+  Creates a StopSensor directive to stop a tagged sensor runtime.
+
+  ## Examples
+
+      Directive.stop_sensor(:market_data)
+      Directive.stop_sensor({:poller, "AAPL"}, :reconfigured)
+  """
+  @spec stop_sensor(term(), term()) :: StopSensor.t()
+  def stop_sensor(tag, reason \\ :normal) do
+    %StopSensor{tag: tag, reason: reason}
   end
 
   @doc """

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -206,7 +206,7 @@ defmodule Jido.AgentServer do
   }
 
   alias Jido.Agent.Directive
-  alias Jido.AgentServer.Signal.{ChildExit, ChildStarted, Orphaned}
+  alias Jido.AgentServer.Signal.{ChildExit, ChildStarted, Orphaned, SensorExit}
   alias Jido.Config.Defaults
   alias Jido.Observe
   alias Jido.Observe.Config, as: ObserveConfig
@@ -3167,7 +3167,22 @@ defmodule Jido.AgentServer do
           "AgentServer #{state.id} sensor #{inspect(tag)} exited: #{inspect(reason)}"
         end)
 
-        {:noreply, state}
+        signal =
+          SensorExit.new!(
+            sensor_exit_data(tag, child_info, pid, reason),
+            source: "/agent/#{state.id}"
+          )
+
+        traced_signal =
+          case Trace.put(signal, Trace.new_root()) do
+            {:ok, s} -> s
+            {:error, _} -> signal
+          end
+
+        case process_signal(traced_signal, state) do
+          {:ok, new_state, _resolved_action} -> {:noreply, new_state}
+          {:error, _reason, ns} -> {:noreply, ns}
+        end
 
       tag ->
         Logger.debug(fn ->
@@ -3194,6 +3209,23 @@ defmodule Jido.AgentServer do
       true ->
         {:noreply, state}
     end
+  end
+
+  defp sensor_exit_data({:sensor, sensor_tag}, child_info, pid, reason) do
+    sensor_exit_data(sensor_tag, child_info, pid, reason)
+  end
+
+  defp sensor_exit_data(tag, child_info, pid, reason) do
+    meta = child_info.meta || %{}
+
+    %{
+      tag: Map.get(meta, :sensor_tag, tag),
+      pid: pid,
+      reason: reason,
+      sensor: Map.get(meta, :sensor, child_info.module),
+      origin: Map.get(meta, :origin, :unknown),
+      meta: meta
+    }
   end
 
   # Wraps parent-down reasons so OTP treats them as clean shutdowns.

--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -198,6 +198,7 @@ defmodule Jido.AgentServer do
     DirectiveExec,
     Options,
     ParentRef,
+    SensorLifecycle,
     SignalRouter,
     State,
     StopChildRuntime,
@@ -210,7 +211,6 @@ defmodule Jido.AgentServer do
   alias Jido.Observe
   alias Jido.Observe.Config, as: ObserveConfig
   alias Jido.RuntimeStore
-  alias Jido.Sensor.Runtime, as: SensorRuntime
   alias Jido.Signal
   alias Jido.Signal.Router, as: JidoRouter
   alias Jido.Telemetry.Formatter
@@ -1433,6 +1433,9 @@ defmodule Jido.AgentServer do
       end
     end)
 
+    # Managed sensors are monitored, not linked, so stop them explicitly.
+    SensorLifecycle.stop_all(state, reason)
+
     :ok
   end
 
@@ -2654,50 +2657,66 @@ defmodule Jido.AgentServer do
           do: spec.module.subscriptions(config, context),
           else: []
 
-      Enum.reduce(subscriptions, acc_state, fn {sensor_module, sensor_config}, inner_state ->
-        start_subscription_sensor(inner_state, spec.module, sensor_module, sensor_config, context)
+      subscriptions
+      |> List.wrap()
+      |> Enum.reduce(acc_state, fn subscription, inner_state ->
+        case normalize_plugin_subscription(subscription, spec.module) do
+          {:ok, tag, sensor_module, sensor_config} ->
+            start_subscription_sensor(
+              inner_state,
+              spec.module,
+              tag,
+              sensor_module,
+              sensor_config,
+              context
+            )
+
+          {:error, reason} ->
+            Logger.warning(fn ->
+              "Ignoring invalid subscription for plugin #{inspect(spec.module)}: #{inspect(reason)}"
+            end)
+
+            inner_state
+        end
       end)
     end)
+  end
+
+  defp normalize_plugin_subscription({sensor_module, sensor_config}, plugin_module)
+       when is_atom(sensor_module) do
+    {:ok, {:plugin, plugin_module, sensor_module}, sensor_module, sensor_config}
+  end
+
+  defp normalize_plugin_subscription({tag, sensor_module, sensor_config}, _plugin_module)
+       when is_atom(sensor_module) do
+    {:ok, tag, sensor_module, sensor_config}
+  end
+
+  defp normalize_plugin_subscription(subscription, _plugin_module) do
+    {:error, {:invalid_subscription, subscription}}
   end
 
   defp start_subscription_sensor(
          %State{} = state,
          plugin_module,
+         tag,
          sensor_module,
          sensor_config,
          context
        ) do
-    opts = [
-      sensor: sensor_module,
-      config: sensor_config,
-      context: context
-    ]
+    {:ok, state} =
+      SensorLifecycle.start(
+        state,
+        tag,
+        sensor_module,
+        sensor_config,
+        %{plugin: plugin_module, sensor: sensor_module},
+        context: context,
+        origin: {:plugin, plugin_module},
+        replace?: false
+      )
 
-    case SensorRuntime.start_link(opts) do
-      {:ok, pid} ->
-        ref = Process.monitor(pid)
-        tag = {:sensor, plugin_module, sensor_module}
-
-        child_info =
-          ChildInfo.new!(%{
-            pid: pid,
-            ref: ref,
-            module: sensor_module,
-            id: "#{plugin_module}-#{sensor_module}-#{inspect(pid)}",
-            tag: tag,
-            meta: %{plugin: plugin_module, sensor: sensor_module}
-          })
-
-        new_children = Map.put(state.children, tag, child_info)
-        %{state | children: new_children}
-
-      {:error, reason} ->
-        Logger.warning(fn ->
-          "Failed to start subscription sensor #{inspect(sensor_module)} for plugin #{inspect(plugin_module)}: #{inspect(reason)}"
-        end)
-
-        state
-    end
+    state
   end
 
   # ---------------------------------------------------------------------------
@@ -3134,31 +3153,46 @@ defmodule Jido.AgentServer do
   end
 
   defp handle_child_down(%State{} = state, pid, reason) do
-    {tag, state} = State.remove_child_by_pid(state, pid)
-
-    if tag do
-      Logger.debug(fn ->
-        "AgentServer #{state.id} child #{inspect(tag)} exited: #{inspect(reason)}"
+    child_info =
+      Enum.find_value(state.children, fn
+        {_tag, %{pid: ^pid} = child_info} -> child_info
+        _entry -> nil
       end)
 
-      signal =
-        ChildExit.new!(
-          %{tag: tag, pid: pid, reason: reason},
-          source: "/agent/#{state.id}"
-        )
+    {tag, state} = State.remove_child_by_pid(state, pid)
 
-      traced_signal =
-        case Trace.put(signal, Trace.new_root()) do
-          {:ok, s} -> s
-          {:error, _} -> signal
+    cond do
+      tag && SensorLifecycle.sensor_child?(child_info) ->
+        Logger.debug(fn ->
+          "AgentServer #{state.id} sensor #{inspect(tag)} exited: #{inspect(reason)}"
+        end)
+
+        {:noreply, state}
+
+      tag ->
+        Logger.debug(fn ->
+          "AgentServer #{state.id} child #{inspect(tag)} exited: #{inspect(reason)}"
+        end)
+
+        signal =
+          ChildExit.new!(
+            %{tag: tag, pid: pid, reason: reason},
+            source: "/agent/#{state.id}"
+          )
+
+        traced_signal =
+          case Trace.put(signal, Trace.new_root()) do
+            {:ok, s} -> s
+            {:error, _} -> signal
+          end
+
+        case process_signal(traced_signal, state) do
+          {:ok, new_state, _resolved_action} -> {:noreply, new_state}
+          {:error, _reason, ns} -> {:noreply, ns}
         end
 
-      case process_signal(traced_signal, state) do
-        {:ok, new_state, _resolved_action} -> {:noreply, new_state}
-        {:error, _reason, ns} -> {:noreply, ns}
-      end
-    else
-      {:noreply, state}
+      true ->
+        {:noreply, state}
     end
   end
 

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -439,13 +439,14 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.StartSensor do
   alias Jido.AgentServer.SensorLifecycle
 
   def exec(
-        %{tag: tag, sensor: sensor, config: config, meta: meta, replace?: replace?},
+        %{tag: tag, sensor: sensor, config: config, meta: meta, replace?: replace?, link?: link?},
         _input_signal,
         state
       ) do
     SensorLifecycle.start(state, tag, sensor, config, meta,
       origin: :directive,
-      replace?: replace?
+      replace?: replace?,
+      link?: link?
     )
   end
 end

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -433,6 +433,33 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.StopChild do
   end
 end
 
+defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.StartSensor do
+  @moduledoc false
+
+  alias Jido.AgentServer.SensorLifecycle
+
+  def exec(
+        %{tag: tag, sensor: sensor, config: config, meta: meta, replace?: replace?},
+        _input_signal,
+        state
+      ) do
+    SensorLifecycle.start(state, tag, sensor, config, meta,
+      origin: :directive,
+      replace?: replace?
+    )
+  end
+end
+
+defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.StopSensor do
+  @moduledoc false
+
+  alias Jido.AgentServer.SensorLifecycle
+
+  def exec(%{tag: tag, reason: reason}, _input_signal, state) do
+    SensorLifecycle.stop(state, tag, reason)
+  end
+end
+
 defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.Stop do
   @moduledoc false
 

--- a/lib/jido/agent_server/directive_executors.ex
+++ b/lib/jido/agent_server/directive_executors.ex
@@ -439,14 +439,14 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.Agent.Directive.StartSensor do
   alias Jido.AgentServer.SensorLifecycle
 
   def exec(
-        %{tag: tag, sensor: sensor, config: config, meta: meta, replace?: replace?, link?: link?},
+        %{tag: tag, sensor: sensor, config: config, meta: meta, replace?: replace?} = directive,
         _input_signal,
         state
       ) do
     SensorLifecycle.start(state, tag, sensor, config, meta,
       origin: :directive,
       replace?: replace?,
-      link?: link?
+      link?: Map.get(directive, :link?, false)
     )
   end
 end

--- a/lib/jido/agent_server/sensor_lifecycle.ex
+++ b/lib/jido/agent_server/sensor_lifecycle.ex
@@ -19,6 +19,20 @@ defmodule Jido.AgentServer.SensorLifecycle do
   @spec start(State.t(), term(), module(), map() | keyword(), map(), keyword()) ::
           {:ok, State.t()}
   def start(%State{} = state, tag, sensor, config, meta, opts \\ []) do
+    case validate_sensor_module(sensor) do
+      :ok ->
+        start_validated(state, tag, sensor, config, meta, opts)
+
+      {:error, reason} ->
+        Logger.warning(fn ->
+          "AgentServer #{state.id} cannot start sensor #{inspect(tag)}: #{inspect(reason)}"
+        end)
+
+        {:ok, state}
+    end
+  end
+
+  defp start_validated(state, tag, sensor, config, meta, opts) do
     replace? = Keyword.get(opts, :replace?, true)
     key = child_key(tag)
 
@@ -73,54 +87,55 @@ defmodule Jido.AgentServer.SensorLifecycle do
   end
 
   defp start_new(state, tag, sensor, config, meta, opts) do
-    if is_atom(sensor) do
-      id = sensor_id(state, tag)
-      origin = Keyword.get(opts, :origin, :directive)
+    id = sensor_id(state, tag)
+    origin = Keyword.get(opts, :origin, :directive)
 
-      runtime_opts = [
-        sensor: sensor,
-        config: config,
-        context: sensor_context(state, tag, origin, Keyword.get(opts, :context, %{})),
-        id: id
-      ]
+    runtime_opts = [
+      sensor: sensor,
+      config: config,
+      context: sensor_context(state, tag, origin, Keyword.get(opts, :context, %{})),
+      id: id
+    ]
 
-      case SensorRuntime.start(runtime_opts) do
-        {:ok, pid} ->
-          ref = Process.monitor(pid)
-          key = child_key(tag)
+    case SensorRuntime.start(runtime_opts) do
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+        key = child_key(tag)
 
-          child_info =
-            ChildInfo.new!(%{
-              pid: pid,
-              ref: ref,
-              module: sensor,
-              id: id,
-              partition: state.partition,
-              tag: key,
-              meta: sensor_meta(tag, sensor, config, origin, meta)
-            })
+        child_info =
+          ChildInfo.new!(%{
+            pid: pid,
+            ref: ref,
+            module: sensor,
+            id: id,
+            partition: state.partition,
+            tag: key,
+            meta: sensor_meta(tag, sensor, config, origin, meta)
+          })
 
-          Logger.debug(fn ->
-            "AgentServer #{state.id} started sensor #{inspect(tag)} with #{inspect(sensor)}"
-          end)
+        Logger.debug(fn ->
+          "AgentServer #{state.id} started sensor #{inspect(tag)} with #{inspect(sensor)}"
+        end)
 
-          {:ok, State.add_child(state, key, child_info)}
+        {:ok, State.add_child(state, key, child_info)}
 
-        {:error, reason} ->
-          Logger.warning(fn ->
-            "AgentServer #{state.id} failed to start sensor #{inspect(tag)} with #{inspect(sensor)}: #{inspect(reason)}"
-          end)
+      {:error, reason} ->
+        Logger.warning(fn ->
+          "AgentServer #{state.id} failed to start sensor #{inspect(tag)} with #{inspect(sensor)}: #{inspect(reason)}"
+        end)
 
-          {:ok, state}
-      end
-    else
-      Logger.warning(fn ->
-        "AgentServer #{state.id} cannot start sensor #{inspect(tag)}: invalid sensor module #{inspect(sensor)}"
-      end)
-
-      {:ok, state}
+        {:ok, state}
     end
   end
+
+  defp validate_sensor_module(sensor) when is_atom(sensor) and not is_nil(sensor) do
+    case Code.ensure_loaded(sensor) do
+      {:module, _module} -> :ok
+      {:error, reason} -> {:error, {:sensor_not_loaded, sensor, reason}}
+    end
+  end
+
+  defp validate_sensor_module(sensor), do: {:error, {:invalid_sensor_module, sensor}}
 
   defp stop_by_key(state, key, reason) do
     case State.get_child(state, key) do

--- a/lib/jido/agent_server/sensor_lifecycle.ex
+++ b/lib/jido/agent_server/sensor_lifecycle.ex
@@ -89,15 +89,17 @@ defmodule Jido.AgentServer.SensorLifecycle do
   defp start_new(state, tag, sensor, config, meta, opts) do
     id = sensor_id(state, tag)
     origin = Keyword.get(opts, :origin, :directive)
+    link? = Keyword.get(opts, :link?, false) == true
 
     runtime_opts = [
       sensor: sensor,
       config: config,
       context: sensor_context(state, tag, origin, Keyword.get(opts, :context, %{})),
-      id: id
+      id: id,
+      owner_pid: self()
     ]
 
-    case SensorRuntime.start(runtime_opts) do
+    case start_sensor_runtime(runtime_opts, link?) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         key = child_key(tag)
@@ -110,7 +112,7 @@ defmodule Jido.AgentServer.SensorLifecycle do
             id: id,
             partition: state.partition,
             tag: key,
-            meta: sensor_meta(tag, sensor, config, origin, meta)
+            meta: sensor_meta(tag, sensor, config, origin, meta, link?)
           })
 
         Logger.debug(fn ->
@@ -136,6 +138,9 @@ defmodule Jido.AgentServer.SensorLifecycle do
   end
 
   defp validate_sensor_module(sensor), do: {:error, {:invalid_sensor_module, sensor}}
+
+  defp start_sensor_runtime(runtime_opts, true), do: SensorRuntime.start_link(runtime_opts)
+  defp start_sensor_runtime(runtime_opts, _linked?), do: SensorRuntime.start(runtime_opts)
 
   defp stop_by_key(state, key, reason) do
     case State.get_child(state, key) do
@@ -169,13 +174,15 @@ defmodule Jido.AgentServer.SensorLifecycle do
     end
   end
 
-  defp stop_child_info(%ChildInfo{pid: pid, ref: ref}, reason) do
+  defp stop_child_info(%ChildInfo{pid: pid, ref: ref} = child_info, reason) do
     cond do
       not is_pid(pid) or not Process.alive?(pid) ->
         demonitor(ref)
         :ok
 
       true ->
+        unlinked? = maybe_unlink(child_info)
+
         case stop_sensor_pid(pid, normalize_stop_reason(reason)) do
           :ok ->
             demonitor(ref)
@@ -183,6 +190,7 @@ defmodule Jido.AgentServer.SensorLifecycle do
 
           {:error, _reason} = error ->
             if Process.alive?(pid) do
+              maybe_relink(child_info, unlinked?)
               error
             else
               demonitor(ref)
@@ -208,6 +216,21 @@ defmodule Jido.AgentServer.SensorLifecycle do
   defp demonitor(ref) when is_reference(ref), do: Process.demonitor(ref, [:flush])
   defp demonitor(_ref), do: false
 
+  defp maybe_unlink(%ChildInfo{pid: pid, meta: %{link?: true}}) when is_pid(pid) do
+    Process.unlink(pid)
+    true
+  end
+
+  defp maybe_unlink(_child_info), do: false
+
+  defp maybe_relink(%ChildInfo{pid: pid}, true) when is_pid(pid) do
+    Process.link(pid)
+  catch
+    :exit, :noproc -> :ok
+  end
+
+  defp maybe_relink(_child_info, _unlinked?), do: :ok
+
   defp normalize_stop_reason(:normal), do: :normal
   defp normalize_stop_reason(:shutdown), do: :shutdown
   defp normalize_stop_reason({:shutdown, _} = reason), do: reason
@@ -229,12 +252,13 @@ defmodule Jido.AgentServer.SensorLifecycle do
     |> Map.put(:sensor_origin, origin)
   end
 
-  defp sensor_meta(tag, sensor, config, origin, meta) do
+  defp sensor_meta(tag, sensor, config, origin, meta, link?) do
     Map.merge(normalize_map(meta), %{
       kind: :sensor,
       sensor: sensor,
       sensor_tag: tag,
       origin: origin,
+      link?: link?,
       config_hash: :erlang.phash2(config)
     })
   end

--- a/lib/jido/agent_server/sensor_lifecycle.ex
+++ b/lib/jido/agent_server/sensor_lifecycle.ex
@@ -26,8 +26,10 @@ defmodule Jido.AgentServer.SensorLifecycle do
       %ChildInfo{} = child_info ->
         cond do
           sensor_child?(child_info) and replace? ->
-            {:ok, state} = stop_by_key(state, key, :replace)
-            start_new(state, tag, sensor, config, meta, opts)
+            case stop_by_key(state, key, :replace) do
+              {:stopped, state} -> start_new(state, tag, sensor, config, meta, opts)
+              {_result, state} -> {:ok, state}
+            end
 
           sensor_child?(child_info) ->
             {:ok, state}
@@ -47,13 +49,24 @@ defmodule Jido.AgentServer.SensorLifecycle do
 
   @spec stop(State.t(), term(), term()) :: {:ok, State.t()}
   def stop(%State{} = state, tag, reason \\ :normal) do
-    stop_by_key(state, child_key(tag), reason)
+    {_result, state} = stop_by_key(state, child_key(tag), reason)
+    {:ok, state}
   end
 
   @spec stop_all(State.t(), term()) :: :ok
   def stop_all(%State{} = state, reason) do
     Enum.each(state.children, fn {_key, child_info} ->
-      if sensor_child?(child_info), do: stop_child_info(child_info, reason)
+      if sensor_child?(child_info) do
+        case stop_child_info(child_info, reason) do
+          :ok ->
+            :ok
+
+          {:error, stop_reason} ->
+            Logger.warning(fn ->
+              "AgentServer #{state.id} failed to stop sensor #{inspect(child_info.tag)} during shutdown: #{inspect(stop_reason)}"
+            end)
+        end
+      end
     end)
 
     :ok
@@ -116,27 +129,51 @@ defmodule Jido.AgentServer.SensorLifecycle do
           "AgentServer #{state.id} cannot stop sensor #{inspect(key)}: not found"
         end)
 
-        {:ok, state}
+        {:missing, state}
 
       %ChildInfo{} = child_info ->
         if sensor_child?(child_info) do
-          stop_child_info(child_info, reason)
-          {:ok, State.remove_child(state, key)}
+          case stop_child_info(child_info, reason) do
+            :ok ->
+              {:stopped, State.remove_child(state, key)}
+
+            {:error, stop_reason} ->
+              Logger.warning(fn ->
+                "AgentServer #{state.id} failed to stop sensor #{inspect(key)}: #{inspect(stop_reason)}"
+              end)
+
+              {:kept, state}
+          end
         else
           Logger.warning(fn ->
             "AgentServer #{state.id} cannot stop sensor #{inspect(key)}: child key is not a sensor"
           end)
 
-          {:ok, state}
+          {:kept, state}
         end
     end
   end
 
   defp stop_child_info(%ChildInfo{pid: pid, ref: ref}, reason) do
-    if is_reference(ref), do: Process.demonitor(ref, [:flush])
+    cond do
+      not is_pid(pid) or not Process.alive?(pid) ->
+        demonitor(ref)
+        :ok
 
-    if is_pid(pid) and Process.alive?(pid) do
-      stop_sensor_pid(pid, normalize_stop_reason(reason))
+      true ->
+        case stop_sensor_pid(pid, normalize_stop_reason(reason)) do
+          :ok ->
+            demonitor(ref)
+            :ok
+
+          {:error, _reason} = error ->
+            if Process.alive?(pid) do
+              error
+            else
+              demonitor(ref)
+              :ok
+            end
+        end
     end
   end
 
@@ -150,9 +187,11 @@ defmodule Jido.AgentServer.SensorLifecycle do
       :ok
 
     :exit, reason ->
-      Logger.debug(fn -> "Failed to stop sensor #{inspect(pid)}: #{inspect(reason)}" end)
-      :ok
+      {:error, reason}
   end
+
+  defp demonitor(ref) when is_reference(ref), do: Process.demonitor(ref, [:flush])
+  defp demonitor(_ref), do: false
 
   defp normalize_stop_reason(:normal), do: :normal
   defp normalize_stop_reason(:shutdown), do: :shutdown

--- a/lib/jido/agent_server/sensor_lifecycle.ex
+++ b/lib/jido/agent_server/sensor_lifecycle.ex
@@ -1,0 +1,194 @@
+defmodule Jido.AgentServer.SensorLifecycle do
+  @moduledoc false
+
+  require Logger
+
+  alias Jido.AgentServer
+  alias Jido.AgentServer.{ChildInfo, State}
+  alias Jido.Sensor.Runtime, as: SensorRuntime
+
+  @stop_timeout 5_000
+
+  @spec child_key(term()) :: {:sensor, term()}
+  def child_key(tag), do: {:sensor, tag}
+
+  @spec sensor_child?(ChildInfo.t() | term()) :: boolean()
+  def sensor_child?(%ChildInfo{meta: %{kind: :sensor}}), do: true
+  def sensor_child?(_child), do: false
+
+  @spec start(State.t(), term(), module(), map() | keyword(), map(), keyword()) ::
+          {:ok, State.t()}
+  def start(%State{} = state, tag, sensor, config, meta, opts \\ []) do
+    replace? = Keyword.get(opts, :replace?, true)
+    key = child_key(tag)
+
+    case State.get_child(state, key) do
+      %ChildInfo{} = child_info ->
+        cond do
+          sensor_child?(child_info) and replace? ->
+            {:ok, state} = stop_by_key(state, key, :replace)
+            start_new(state, tag, sensor, config, meta, opts)
+
+          sensor_child?(child_info) ->
+            {:ok, state}
+
+          true ->
+            Logger.warning(fn ->
+              "AgentServer #{state.id} cannot start sensor #{inspect(tag)}: child key already in use"
+            end)
+
+            {:ok, state}
+        end
+
+      nil ->
+        start_new(state, tag, sensor, config, meta, opts)
+    end
+  end
+
+  @spec stop(State.t(), term(), term()) :: {:ok, State.t()}
+  def stop(%State{} = state, tag, reason \\ :normal) do
+    stop_by_key(state, child_key(tag), reason)
+  end
+
+  @spec stop_all(State.t(), term()) :: :ok
+  def stop_all(%State{} = state, reason) do
+    Enum.each(state.children, fn {_key, child_info} ->
+      if sensor_child?(child_info), do: stop_child_info(child_info, reason)
+    end)
+
+    :ok
+  end
+
+  defp start_new(state, tag, sensor, config, meta, opts) do
+    if is_atom(sensor) do
+      id = sensor_id(state, tag)
+      origin = Keyword.get(opts, :origin, :directive)
+
+      runtime_opts = [
+        sensor: sensor,
+        config: config,
+        context: sensor_context(state, tag, origin, Keyword.get(opts, :context, %{})),
+        id: id
+      ]
+
+      case SensorRuntime.start(runtime_opts) do
+        {:ok, pid} ->
+          ref = Process.monitor(pid)
+          key = child_key(tag)
+
+          child_info =
+            ChildInfo.new!(%{
+              pid: pid,
+              ref: ref,
+              module: sensor,
+              id: id,
+              partition: state.partition,
+              tag: key,
+              meta: sensor_meta(tag, sensor, config, origin, meta)
+            })
+
+          Logger.debug(fn ->
+            "AgentServer #{state.id} started sensor #{inspect(tag)} with #{inspect(sensor)}"
+          end)
+
+          {:ok, State.add_child(state, key, child_info)}
+
+        {:error, reason} ->
+          Logger.warning(fn ->
+            "AgentServer #{state.id} failed to start sensor #{inspect(tag)} with #{inspect(sensor)}: #{inspect(reason)}"
+          end)
+
+          {:ok, state}
+      end
+    else
+      Logger.warning(fn ->
+        "AgentServer #{state.id} cannot start sensor #{inspect(tag)}: invalid sensor module #{inspect(sensor)}"
+      end)
+
+      {:ok, state}
+    end
+  end
+
+  defp stop_by_key(state, key, reason) do
+    case State.get_child(state, key) do
+      nil ->
+        Logger.debug(fn ->
+          "AgentServer #{state.id} cannot stop sensor #{inspect(key)}: not found"
+        end)
+
+        {:ok, state}
+
+      %ChildInfo{} = child_info ->
+        if sensor_child?(child_info) do
+          stop_child_info(child_info, reason)
+          {:ok, State.remove_child(state, key)}
+        else
+          Logger.warning(fn ->
+            "AgentServer #{state.id} cannot stop sensor #{inspect(key)}: child key is not a sensor"
+          end)
+
+          {:ok, state}
+        end
+    end
+  end
+
+  defp stop_child_info(%ChildInfo{pid: pid, ref: ref}, reason) do
+    if is_reference(ref), do: Process.demonitor(ref, [:flush])
+
+    if is_pid(pid) and Process.alive?(pid) do
+      stop_sensor_pid(pid, normalize_stop_reason(reason))
+    end
+  end
+
+  defp stop_sensor_pid(pid, reason) do
+    GenServer.stop(pid, reason, @stop_timeout)
+  catch
+    :exit, {:noproc, _} ->
+      :ok
+
+    :exit, {:normal, _} ->
+      :ok
+
+    :exit, reason ->
+      Logger.debug(fn -> "Failed to stop sensor #{inspect(pid)}: #{inspect(reason)}" end)
+      :ok
+  end
+
+  defp normalize_stop_reason(:normal), do: :normal
+  defp normalize_stop_reason(:shutdown), do: :shutdown
+  defp normalize_stop_reason({:shutdown, _} = reason), do: reason
+  defp normalize_stop_reason(:replace), do: {:shutdown, :replace}
+  defp normalize_stop_reason(reason), do: {:shutdown, reason}
+
+  defp sensor_context(state, tag, origin, extra_context) do
+    base_context = %{
+      agent_ref: AgentServer.via_tuple(state.id, state.registry, partition: state.partition),
+      agent_id: state.id,
+      agent_module: state.agent_module,
+      jido_instance: state.jido,
+      partition: state.partition
+    }
+
+    base_context
+    |> Map.merge(normalize_map(extra_context))
+    |> Map.put(:sensor_tag, tag)
+    |> Map.put(:sensor_origin, origin)
+  end
+
+  defp sensor_meta(tag, sensor, config, origin, meta) do
+    Map.merge(normalize_map(meta), %{
+      kind: :sensor,
+      sensor: sensor,
+      sensor_tag: tag,
+      origin: origin,
+      config_hash: :erlang.phash2(config)
+    })
+  end
+
+  defp normalize_map(value) when is_map(value), do: value
+  defp normalize_map(_value), do: %{}
+
+  defp sensor_id(state, tag) do
+    "#{state.id}/sensor/#{inspect(tag)}"
+  end
+end

--- a/lib/jido/agent_server/signal/sensor_exit.ex
+++ b/lib/jido/agent_server/signal/sensor_exit.ex
@@ -1,0 +1,34 @@
+defmodule Jido.AgentServer.Signal.SensorExit do
+  @moduledoc """
+  Emitted when a managed sensor runtime exits unexpectedly.
+
+  Delivered to the owning agent as `jido.agent.sensor.exit` after the sensor has
+  already been removed from the runtime children map. This lets the agent route
+  the lifecycle event to restart, degrade, alert, or ignore without treating the
+  sensor as a child agent.
+
+  ## Fields
+
+  - `:tag` - Agent-local tag assigned to the sensor runtime
+  - `:pid` - PID of the sensor process that exited
+  - `:reason` - Exit reason from the sensor process
+  - `:sensor` - Sensor module that was running
+  - `:origin` - Origin that started the sensor, such as `:directive` or a plugin
+  - `:meta` - Metadata stored with the sensor child info
+  """
+
+  use Jido.Signal,
+    type: "jido.agent.sensor.exit",
+    extension_policy: [
+      {Jido.Signal.Ext.Trace, :optional},
+      {Jido.Signal.Ext.Dispatch, :optional}
+    ],
+    schema: [
+      tag: [type: :any, required: true, doc: "Tag assigned to the sensor runtime"],
+      pid: [type: :any, required: true, doc: "PID of the sensor process that exited"],
+      reason: [type: :any, required: true, doc: "Exit reason from the sensor process"],
+      sensor: [type: :any, required: true, doc: "Sensor module that was running"],
+      origin: [type: :any, required: true, doc: "Origin that started the sensor"],
+      meta: [type: :map, default: %{}, doc: "Metadata stored with the sensor"]
+    ]
+end

--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -70,7 +70,7 @@ defmodule Jido.Plugin do
   - `capabilities` - List of atoms describing what the plugin provides (default: []).
   - `requires` - List of requirements like `{:config, :token}`, `{:app, :req}`, `{:plugin, :http}` (default: []).
   - `signal_routes` - List of signal route tuples like `{"post", ActionModule}` (default: []).
-  - `subscriptions` - List of sensor subscription tuples like `{SensorModule, config}` (default: []).
+  - `subscriptions` - List of sensor subscription tuples like `{SensorModule, config}` or `{tag, SensorModule, config}` (default: []).
   - `schedules` - List of schedule tuples like `{"*/5 * * * *", ActionModule}` (default: []).
 
   For static routes and subscriptions, prefer the compile-time `signal_routes:` and `subscriptions:` options in `use Jido.Plugin`.
@@ -139,7 +139,7 @@ defmodule Jido.Plugin do
                             subscriptions:
                               Zoi.list(Zoi.any(),
                                 description:
-                                  "Sensor subscription tuples like {SensorModule, config}."
+                                  "Sensor subscription tuples like {SensorModule, config} or {tag, SensorModule, config}."
                               )
                               |> Zoi.default([]),
                             schedules:

--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -402,8 +402,8 @@ defmodule Jido.Plugin do
   Returns a list of sensors to be started for this plugin.
 
   Called during `AgentServer.init/1` to start and monitor
-  plugin-specific sensors. These sensors are automatically linked to
-  the agent and can emit signals back to it.
+  plugin-specific sensors. These sensors are managed and monitored by the
+  agent runtime and can emit signals back to it.
 
   ## Parameters
 
@@ -417,8 +417,9 @@ defmodule Jido.Plugin do
 
   ## Returns
 
-  List of `{sensor_module, sensor_opts}` tuples. Each sensor will be
-  started under a `Jido.Sensor.Runtime`.
+  List of `{sensor_module, sensor_opts}` tuples or `{tag, sensor_module, sensor_opts}`
+  tuples. Each sensor will be started under a `Jido.Sensor.Runtime`. Use the
+  tagged form when a plugin starts multiple instances of the same sensor module.
 
   ## Example
 
@@ -429,8 +430,11 @@ defmodule Jido.Plugin do
         ]
       end
   """
+  @type sensor_subscription ::
+          {module(), keyword() | map()} | {term(), module(), keyword() | map()}
+
   @callback subscriptions(config :: map(), context :: map()) ::
-              [{module(), keyword() | map()}]
+              [sensor_subscription()]
 
   @doc """
   Called during checkpoint to determine how this plugin's state should be persisted.
@@ -737,7 +741,7 @@ defmodule Jido.Plugin do
       def child_spec(_config), do: nil
 
       @doc false
-      @spec subscriptions(map(), map()) :: [{module(), keyword() | map()}]
+      @spec subscriptions(map(), map()) :: [Jido.Plugin.sensor_subscription()]
       @impl Jido.Plugin
       def subscriptions(_config, _context), do: subscriptions()
 

--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -607,7 +607,7 @@ defmodule Jido.Plugin do
       def signal_routes, do: @validated_opts[:signal_routes] || []
 
       @doc "Returns the sensor subscriptions for this plugin."
-      @spec subscriptions() :: [tuple()]
+      @spec subscriptions() :: [Jido.Plugin.sensor_subscription()]
       def subscriptions, do: @validated_opts[:subscriptions] || []
 
       @doc "Returns the schedules for this plugin."

--- a/lib/jido/sensor.ex
+++ b/lib/jido/sensor.ex
@@ -4,7 +4,7 @@ defmodule Jido.Sensor do
 
   A Sensor is a pure behaviour that transforms external events into Signals.
   Sensors are stateless modules that define how to initialize, handle events,
-  and emit signals. The runtime execution is handled by a separate SensorServer.
+  and emit signals. Runtime execution is handled by `Jido.Sensor.Runtime`.
 
   ## Usage
 
@@ -30,7 +30,7 @@ defmodule Jido.Sensor do
             type: "metric.updated",
             data: %{value: value, previous: state.last_value}
           })
-          {:ok, %{state | last_value: value}, [signal]}
+          {:ok, %{state | last_value: value}, [{:emit, signal}]}
         end
       end
 

--- a/lib/jido/sensor.ex
+++ b/lib/jido/sensor.ex
@@ -51,12 +51,10 @@ defmodule Jido.Sensor do
 
   - `{:schedule, interval}` - Schedule next poll after interval ms
   - `{:schedule, interval, payload}` - Schedule with custom payload
-  - `{:connect, adapter}` - Connect to an external source
-  - `{:connect, adapter, opts}` - Connect with options
-  - `{:disconnect, adapter}` - Disconnect from a source
-  - `{:subscribe, topic}` - Subscribe to a topic/pattern
-  - `{:unsubscribe, topic}` - Unsubscribe from a topic
   - `{:emit, signal}` - Emit a signal immediately
+
+  Sensor modules that need external subscriptions or connections should establish
+  them in `init/2` and clean them up in `terminate/2`.
   """
 
   alias Jido.Sensor.Spec
@@ -64,11 +62,6 @@ defmodule Jido.Sensor do
   @type sensor_directive ::
           {:schedule, pos_integer()}
           | {:schedule, pos_integer(), term()}
-          | {:connect, atom()}
-          | {:connect, atom(), keyword()}
-          | {:disconnect, atom()}
-          | {:subscribe, term()}
-          | {:unsubscribe, term()}
           | {:emit, Jido.Signal.t()}
 
   @doc """

--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -26,6 +26,7 @@ defmodule Jido.Sensor.Runtime do
   - `:config` - Configuration map or keyword list for the sensor
   - `:context` - Context map including `:agent_ref`
   - `:id` - Instance ID (auto-generated if not provided)
+  - `:owner_pid` - Optional owner process to monitor; runtime stops if owner exits
 
   ## Signal Delivery
 
@@ -73,6 +74,7 @@ defmodule Jido.Sensor.Runtime do
   - `:config` - Configuration map or keyword list for the sensor (default: %{})
   - `:context` - Context map including `:agent_ref` (default: %{})
   - `:id` - Instance ID (auto-generated if not provided)
+  - `:owner_pid` - Optional owner process to monitor; runtime stops if owner exits
 
   ## Examples
 
@@ -133,12 +135,16 @@ defmodule Jido.Sensor.Runtime do
          {:ok, config} <- parse_config(sensor, opts[:config] || %{}),
          context = opts[:context] || %{},
          id = opts[:id] || Jido.Util.generate_id(),
+         owner_pid = opts[:owner_pid],
+         owner_ref = monitor_owner(owner_pid),
          {:ok, state, directives} <- call_sensor_init(sensor, config, context, id) do
       runtime_state = %{
         sensor: sensor,
         config: config,
         context: context,
         id: id,
+        owner_pid: owner_pid,
+        owner_ref: owner_ref,
         sensor_state: state,
         timers: %{}
       }
@@ -168,6 +174,16 @@ defmodule Jido.Sensor.Runtime do
   end
 
   @impl GenServer
+  def handle_info({:DOWN, ref, :process, owner_pid, reason}, state)
+      when ref == state.owner_ref and owner_pid == state.owner_pid do
+    Logger.debug(fn ->
+      "Sensor.Runtime #{state.id} owner #{inspect(owner_pid)} exited: #{inspect(reason)}"
+    end)
+
+    {:stop, {:owner_down, reason}, state}
+  end
+
+  @impl GenServer
   def handle_info(msg, state) do
     Logger.debug(fn ->
       "Sensor.Runtime #{state.id} received unexpected message: #{inspect(msg)}"
@@ -191,6 +207,9 @@ defmodule Jido.Sensor.Runtime do
 
   defp normalize_opts(opts) when is_map(opts), do: Map.to_list(opts)
   defp normalize_opts(opts) when is_list(opts), do: opts
+
+  defp monitor_owner(owner_pid) when is_pid(owner_pid), do: Process.monitor(owner_pid)
+  defp monitor_owner(_owner_pid), do: nil
 
   defp ensure_sensor_loaded(sensor) do
     case Code.ensure_loaded(sensor) do

--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -175,7 +175,7 @@ defmodule Jido.Sensor.Runtime do
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, owner_pid, reason}, state)
-      when ref == state.owner_ref and owner_pid == state.owner_pid do
+      when is_reference(ref) and ref == state.owner_ref and owner_pid == state.owner_pid do
     Logger.debug(fn ->
       "Sensor.Runtime #{state.id} owner #{inspect(owner_pid)} exited: #{inspect(reason)}"
     end)

--- a/lib/jido/sensor/runtime.ex
+++ b/lib/jido/sensor/runtime.ex
@@ -15,6 +15,7 @@ defmodule Jido.Sensor.Runtime do
 
   ## Public API
 
+  - `start/1` - Start unlinked to caller
   - `start_link/1` - Start linked to caller
   - `child_spec/1` - Returns a proper child spec with stable id
   - `event/2` - Inject an external event into the sensor
@@ -51,6 +52,17 @@ defmodule Jido.Sensor.Runtime do
   alias Jido.Signal.Dispatch
 
   @type server :: pid() | atom() | {:via, module(), term()}
+
+  @doc """
+  Starts a Sensor.Runtime unlinked to the calling process.
+
+  Use this when another runtime will monitor and manage the sensor lifecycle
+  itself. Use `start_link/1` for direct supervision tree children.
+  """
+  @spec start(keyword() | map()) :: GenServer.on_start()
+  def start(opts) when is_list(opts) or is_map(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
 
   @doc """
   Starts a Sensor.Runtime linked to the calling process.

--- a/test/jido/agent/directive_test.exs
+++ b/test/jido/agent/directive_test.exs
@@ -111,6 +111,35 @@ defmodule JidoTest.Agent.DirectiveTest do
     end
   end
 
+  describe "start_sensor/3" do
+    test "creates StartSensor directive with defaults" do
+      directive = Directive.start_sensor(:market_data, MySensor)
+
+      assert %Directive.StartSensor{} = directive
+      assert directive.tag == :market_data
+      assert directive.sensor == MySensor
+      assert directive.config == %{}
+      assert directive.meta == %{}
+      assert directive.replace? == true
+      assert directive.link? == false
+    end
+
+    test "creates StartSensor directive with lifecycle options" do
+      directive =
+        Directive.start_sensor(:market_data, MySensor,
+          config: %{symbol: "AAPL"},
+          meta: %{purpose: :quotes},
+          replace?: false,
+          link?: true
+        )
+
+      assert directive.config == %{symbol: "AAPL"}
+      assert directive.meta == %{purpose: :quotes}
+      assert directive.replace? == false
+      assert directive.link? == true
+    end
+  end
+
   describe "adopt_child/3" do
     test "creates AdoptChild directive for pid" do
       directive = Directive.adopt_child(self(), :worker_1)

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -108,6 +108,18 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
     end
   end
 
+  defmodule StopRoundTripSensorAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "stop_round_trip_sensor",
+      schema: []
+
+    def run(_params, _context) do
+      directive = Directive.stop_sensor(:round_trip, :controlled_stop)
+      {:ok, %{sensor_stop_requested: true}, [directive]}
+    end
+  end
+
   defmodule RecordRoundTripSensorAction do
     @moduledoc false
     use Jido.Action,
@@ -128,20 +140,39 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
     end
   end
 
+  defmodule RecordRoundTripSensorExitAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "record_round_trip_sensor_exit",
+      schema: [
+        tag: [type: :any, required: true],
+        reason: [type: :any, required: true]
+      ]
+
+    def run(params, context) do
+      events = Map.get(context.state, :sensor_exit_events, [])
+      {:ok, %{sensor_exit_events: events ++ [params]}}
+    end
+  end
+
   defmodule RoundTripSensorAgent do
     @moduledoc false
     use Jido.Agent,
       name: "directive_exec_round_trip_sensor_agent",
       schema: [
         sensor_start_requested: [type: :boolean, default: false],
+        sensor_stop_requested: [type: :boolean, default: false],
         last_sensor_value: [type: :any, default: nil],
         last_sensor_agent_id: [type: :any, default: nil],
-        last_sensor_tag: [type: :any, default: nil]
+        last_sensor_tag: [type: :any, default: nil],
+        sensor_exit_events: [type: {:list, :any}, default: []]
       ],
       signal_routes: [
         {"directive.sensor.start", StartRoundTripSensorAction},
+        {"directive.sensor.stop", StopRoundTripSensorAction},
         {"directive.linked_sensor.start", StartLinkedRoundTripSensorAction},
-        {"directive.sensor.event", RecordRoundTripSensorAction}
+        {"directive.sensor.event", RecordRoundTripSensorAction},
+        {"jido.agent.sensor.exit", RecordRoundTripSensorExitAction}
       ]
   end
 
@@ -798,6 +829,41 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
 
       assert state.agent.state.last_sensor_agent_id == state.id
       assert state.agent.state.last_sensor_tag == :round_trip
+
+      GenServer.stop(pid)
+    end
+
+    test "controlled stop does not emit sensor exit lifecycle signal", context do
+      pid =
+        start_server(context, RoundTripSensorAgent,
+          id: unique_id("directive-sensor-controlled-stop")
+        )
+
+      start_signal = Signal.new!(%{source: "/test", type: "directive.sensor.start", data: %{}})
+      stop_signal = Signal.new!(%{source: "/test", type: "directive.sensor.stop", data: %{}})
+
+      assert :ok = Jido.AgentServer.cast(pid, start_signal)
+
+      state =
+        eventually_state(pid, fn state ->
+          Map.has_key?(state.children, {:sensor, :round_trip})
+        end)
+
+      sensor_pid = state.children[{:sensor, :round_trip}].pid
+      sensor_ref = Process.monitor(sensor_pid)
+
+      assert :ok = Jido.AgentServer.cast(pid, stop_signal)
+
+      assert_receive {:DOWN, ^sensor_ref, :process, ^sensor_pid, {:shutdown, :controlled_stop}},
+                     1_000
+
+      state =
+        eventually_state(pid, fn state ->
+          state.agent.state.sensor_stop_requested == true and
+            not Map.has_key?(state.children, {:sensor, :round_trip})
+        end)
+
+      assert state.agent.state.sensor_exit_events == []
 
       GenServer.stop(pid)
     end

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -14,6 +14,42 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       ]
   end
 
+  defmodule LifecycleSensor do
+    @moduledoc false
+    use Jido.Sensor,
+      name: "directive_exec_lifecycle_sensor",
+      description: "Sensor used to test StartSensor and StopSensor directives",
+      schema:
+        Zoi.object(
+          %{
+            label: Zoi.string() |> Zoi.default("default")
+          },
+          coerce: true
+        )
+
+    @impl Jido.Sensor
+    def init(config, context) do
+      {:ok, %{config: config, context: context}}
+    end
+
+    @impl Jido.Sensor
+    def handle_event(_event, state), do: {:ok, state}
+  end
+
+  defmodule FailingLifecycleSensor do
+    @moduledoc false
+    use Jido.Sensor,
+      name: "directive_exec_failing_lifecycle_sensor",
+      description: "Sensor that fails during init",
+      schema: Zoi.object(%{}, coerce: true)
+
+    @impl Jido.Sensor
+    def init(_config, _context), do: {:error, :init_failed}
+
+    @impl Jido.Sensor
+    def handle_event(_event, state), do: {:ok, state}
+  end
+
   defmodule StopOnSignalAction do
     @moduledoc false
     use Jido.Action,
@@ -599,6 +635,114 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
 
     test "returns ok when child tag not found", %{state: state, input_signal: input_signal} do
       directive = %Directive.StopChild{tag: :nonexistent_child, reason: :normal}
+
+      assert {:ok, ^state} = DirectiveExec.exec(directive, input_signal, state)
+    end
+  end
+
+  describe "StartSensor and StopSensor directives" do
+    test "starts a tagged sensor runtime", %{state: state, input_signal: input_signal} do
+      directive =
+        Directive.start_sensor(:market_data, LifecycleSensor,
+          config: %{label: "prices"},
+          meta: %{purpose: :quotes}
+        )
+
+      assert {:ok, new_state} = DirectiveExec.exec(directive, input_signal, state)
+
+      key = {:sensor, :market_data}
+      assert Map.has_key?(new_state.children, key)
+
+      child_info = new_state.children[key]
+      assert child_info.module == LifecycleSensor
+      assert child_info.tag == key
+      assert child_info.meta.kind == :sensor
+      assert child_info.meta.sensor == LifecycleSensor
+      assert child_info.meta.sensor_tag == :market_data
+      assert child_info.meta.purpose == :quotes
+      assert Process.alive?(child_info.pid)
+
+      runtime_state = :sys.get_state(child_info.pid)
+      assert runtime_state.config.label == "prices"
+      assert runtime_state.context.agent_id == state.id
+      assert runtime_state.context.sensor_tag == :market_data
+      assert runtime_state.context.sensor_origin == :directive
+
+      GenServer.stop(child_info.pid)
+    end
+
+    test "leaves state unchanged when sensor init fails", %{
+      state: state,
+      input_signal: input_signal
+    } do
+      directive = Directive.start_sensor(:bad_sensor, FailingLifecycleSensor)
+
+      assert {:ok, ^state} = DirectiveExec.exec(directive, input_signal, state)
+      refute Map.has_key?(state.children, {:sensor, :bad_sensor})
+    end
+
+    test "replaces an existing sensor by default", %{state: state, input_signal: input_signal} do
+      start_a =
+        Directive.start_sensor(:replaceable, LifecycleSensor, config: %{label: "a"})
+
+      {:ok, state_with_sensor} = DirectiveExec.exec(start_a, input_signal, state)
+      old_pid = state_with_sensor.children[{:sensor, :replaceable}].pid
+
+      start_b =
+        Directive.start_sensor(:replaceable, LifecycleSensor, config: %{label: "b"})
+
+      assert {:ok, replaced_state} = DirectiveExec.exec(start_b, input_signal, state_with_sensor)
+
+      new_pid = replaced_state.children[{:sensor, :replaceable}].pid
+      assert new_pid != old_pid
+      assert Process.alive?(new_pid)
+      refute_eventually(Process.alive?(old_pid))
+      assert :sys.get_state(new_pid).config.label == "b"
+
+      GenServer.stop(new_pid)
+    end
+
+    test "does not replace an existing sensor when replace? is false", %{
+      state: state,
+      input_signal: input_signal
+    } do
+      start_a =
+        Directive.start_sensor(:sticky, LifecycleSensor, config: %{label: "a"})
+
+      {:ok, state_with_sensor} = DirectiveExec.exec(start_a, input_signal, state)
+      old_pid = state_with_sensor.children[{:sensor, :sticky}].pid
+
+      start_b =
+        Directive.start_sensor(:sticky, LifecycleSensor,
+          config: %{label: "b"},
+          replace?: false
+        )
+
+      assert {:ok, unchanged_state} = DirectiveExec.exec(start_b, input_signal, state_with_sensor)
+
+      assert unchanged_state.children[{:sensor, :sticky}].pid == old_pid
+      assert :sys.get_state(old_pid).config.label == "a"
+
+      GenServer.stop(old_pid)
+    end
+
+    test "stops an existing tagged sensor", %{state: state, input_signal: input_signal} do
+      start_directive = Directive.start_sensor(:temporary, LifecycleSensor)
+      {:ok, state_with_sensor} = DirectiveExec.exec(start_directive, input_signal, state)
+
+      sensor_pid = state_with_sensor.children[{:sensor, :temporary}].pid
+
+      stop_directive = Directive.stop_sensor(:temporary, :cleanup)
+
+      assert {:ok, stopped_state} =
+               DirectiveExec.exec(stop_directive, input_signal, state_with_sensor)
+
+      refute Map.has_key?(stopped_state.children, {:sensor, :temporary})
+      refute_eventually(Process.alive?(sensor_pid))
+    end
+
+    test "returns ok when sensor tag is not found", %{state: state, input_signal: input_signal} do
+      directive = Directive.stop_sensor(:missing_sensor)
 
       assert {:ok, ^state} = DirectiveExec.exec(directive, input_signal, state)
     end

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -3,6 +3,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
 
   alias Jido.Agent.Directive
   alias Jido.AgentServer.{DirectiveExec, Options, State}
+  alias Jido.Sensor.Runtime, as: SensorRuntime
   alias Jido.Signal
 
   defmodule TestAgent do
@@ -48,6 +49,85 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
 
     @impl Jido.Sensor
     def handle_event(_event, state), do: {:ok, state}
+  end
+
+  defmodule RoundTripSensor do
+    @moduledoc false
+    use Jido.Sensor,
+      name: "directive_exec_round_trip_sensor",
+      description: "Sensor used to prove StartSensor delivers signals back to the owning agent",
+      schema: Zoi.object(%{}, coerce: true)
+
+    @impl Jido.Sensor
+    def init(_config, context) do
+      {:ok, %{context: context}}
+    end
+
+    @impl Jido.Sensor
+    def handle_event({:trigger, value}, state) do
+      signal =
+        Signal.new!(%{
+          source: "/sensor/directive-round-trip",
+          type: "directive.sensor.event",
+          data: %{
+            value: value,
+            agent_id: state.context.agent_id,
+            sensor_tag: state.context.sensor_tag
+          }
+        })
+
+      {:ok, state, [{:emit, signal}]}
+    end
+
+    def handle_event(_event, state), do: {:ok, state}
+  end
+
+  defmodule StartRoundTripSensorAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "start_round_trip_sensor",
+      schema: []
+
+    def run(_params, _context) do
+      directive = Directive.start_sensor(:round_trip, RoundTripSensor)
+      {:ok, %{sensor_start_requested: true}, [directive]}
+    end
+  end
+
+  defmodule RecordRoundTripSensorAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "record_round_trip_sensor",
+      schema: [
+        value: [type: :any, required: true],
+        agent_id: [type: :any, required: true],
+        sensor_tag: [type: :any, required: true]
+      ]
+
+    def run(params, _context) do
+      {:ok,
+       %{
+         last_sensor_value: params.value,
+         last_sensor_agent_id: params.agent_id,
+         last_sensor_tag: params.sensor_tag
+       }}
+    end
+  end
+
+  defmodule RoundTripSensorAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "directive_exec_round_trip_sensor_agent",
+      schema: [
+        sensor_start_requested: [type: :boolean, default: false],
+        last_sensor_value: [type: :any, default: nil],
+        last_sensor_agent_id: [type: :any, default: nil],
+        last_sensor_tag: [type: :any, default: nil]
+      ],
+      signal_routes: [
+        {"directive.sensor.start", StartRoundTripSensorAction},
+        {"directive.sensor.event", RecordRoundTripSensorAction}
+      ]
   end
 
   defmodule StopOnSignalAction do
@@ -669,6 +749,42 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       assert runtime_state.context.sensor_origin == :directive
 
       GenServer.stop(child_info.pid)
+    end
+
+    test "sensor started by directive emits back into the owning agent", context do
+      pid =
+        start_server(context, RoundTripSensorAgent, id: unique_id("directive-sensor-round-trip"))
+
+      start_signal =
+        Signal.new!(%{
+          source: "/test",
+          type: "directive.sensor.start",
+          data: %{}
+        })
+
+      assert :ok = Jido.AgentServer.cast(pid, start_signal)
+
+      state =
+        eventually_state(pid, fn state ->
+          state.agent.state.sensor_start_requested == true and
+            Map.has_key?(state.children, {:sensor, :round_trip})
+        end)
+
+      child_info = state.children[{:sensor, :round_trip}]
+      assert child_info.module == RoundTripSensor
+      assert Process.alive?(child_info.pid)
+
+      assert :ok = SensorRuntime.event(child_info.pid, {:trigger, :from_sensor})
+
+      state =
+        eventually_state(pid, fn state ->
+          state.agent.state.last_sensor_value == :from_sensor
+        end)
+
+      assert state.agent.state.last_sensor_agent_id == state.id
+      assert state.agent.state.last_sensor_tag == :round_trip
+
+      GenServer.stop(pid)
     end
 
     test "leaves state unchanged when sensor init fails", %{

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -1032,6 +1032,36 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       end
     end
 
+    test "stops linked sensors without propagating controlled stop exits", %{
+      state: state,
+      input_signal: input_signal
+    } do
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        start_directive =
+          Directive.start_sensor(:linked_temporary, LifecycleSensor, link?: true)
+
+        {:ok, state_with_sensor} = DirectiveExec.exec(start_directive, input_signal, state)
+        sensor_pid = state_with_sensor.children[{:sensor, :linked_temporary}].pid
+        sensor_ref = Process.monitor(sensor_pid)
+
+        stop_directive = Directive.stop_sensor(:linked_temporary, :cleanup)
+
+        assert {:ok, stopped_state} =
+                 DirectiveExec.exec(stop_directive, input_signal, state_with_sensor)
+
+        refute Map.has_key?(stopped_state.children, {:sensor, :linked_temporary})
+
+        assert_receive {:DOWN, ^sensor_ref, :process, ^sensor_pid, {:shutdown, :cleanup}},
+                       1_000
+
+        refute_receive {:EXIT, ^sensor_pid, _reason}, 100
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+      end
+    end
+
     test "does not stop existing sensor when replacement module is invalid", %{
       state: state,
       input_signal: input_signal

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -726,6 +726,29 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       GenServer.stop(old_pid)
     end
 
+    test "does not stop existing sensor when replacement module is invalid", %{
+      state: state,
+      input_signal: input_signal
+    } do
+      start_directive =
+        Directive.start_sensor(:protected, LifecycleSensor, config: %{label: "active"})
+
+      {:ok, state_with_sensor} = DirectiveExec.exec(start_directive, input_signal, state)
+      old_pid = state_with_sensor.children[{:sensor, :protected}].pid
+
+      invalid_replacement =
+        Directive.start_sensor(:protected, NonExistentSensorModule, config: %{label: "bad"})
+
+      assert {:ok, unchanged_state} =
+               DirectiveExec.exec(invalid_replacement, input_signal, state_with_sensor)
+
+      assert unchanged_state.children[{:sensor, :protected}].pid == old_pid
+      assert Process.alive?(old_pid)
+      assert :sys.get_state(old_pid).config.label == "active"
+
+      GenServer.stop(old_pid)
+    end
+
     test "stops an existing tagged sensor", %{state: state, input_signal: input_signal} do
       start_directive = Directive.start_sensor(:temporary, LifecycleSensor)
       {:ok, state_with_sensor} = DirectiveExec.exec(start_directive, input_signal, state)

--- a/test/jido/agent_server/directive_exec_test.exs
+++ b/test/jido/agent_server/directive_exec_test.exs
@@ -64,6 +64,8 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
     end
 
     @impl Jido.Sensor
+    def handle_event(:crash, _state), do: raise("linked sensor crash")
+
     def handle_event({:trigger, value}, state) do
       signal =
         Signal.new!(%{
@@ -90,6 +92,18 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
 
     def run(_params, _context) do
       directive = Directive.start_sensor(:round_trip, RoundTripSensor)
+      {:ok, %{sensor_start_requested: true}, [directive]}
+    end
+  end
+
+  defmodule StartLinkedRoundTripSensorAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "start_linked_round_trip_sensor",
+      schema: []
+
+    def run(_params, _context) do
+      directive = Directive.start_sensor(:linked_round_trip, RoundTripSensor, link?: true)
       {:ok, %{sensor_start_requested: true}, [directive]}
     end
   end
@@ -126,6 +140,7 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       ],
       signal_routes: [
         {"directive.sensor.start", StartRoundTripSensorAction},
+        {"directive.linked_sensor.start", StartLinkedRoundTripSensorAction},
         {"directive.sensor.event", RecordRoundTripSensorAction}
       ]
   end
@@ -787,6 +802,77 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       GenServer.stop(pid)
     end
 
+    test "unlinked directive sensor stops when the owning agent exits abnormally", context do
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        pid =
+          start_server(context, RoundTripSensorAgent,
+            id: unique_id("directive-sensor-owner-down")
+          )
+
+        start_signal =
+          Signal.new!(%{
+            source: "/test",
+            type: "directive.sensor.start",
+            data: %{}
+          })
+
+        assert :ok = Jido.AgentServer.cast(pid, start_signal)
+
+        state =
+          eventually_state(pid, fn state ->
+            Map.has_key?(state.children, {:sensor, :round_trip})
+          end)
+
+        sensor_pid = state.children[{:sensor, :round_trip}].pid
+        sensor_ref = Process.monitor(sensor_pid)
+
+        Process.exit(pid, :kill)
+
+        assert_receive {:EXIT, ^pid, :killed}, 500
+
+        assert_receive {:DOWN, ^sensor_ref, :process, ^sensor_pid, {:owner_down, :killed}},
+                       1_000
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+      end
+    end
+
+    test "link? true makes sensor failure fail the owning agent", context do
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        pid =
+          start_server(context, RoundTripSensorAgent, id: unique_id("directive-linked-sensor"))
+
+        start_signal =
+          Signal.new!(%{
+            source: "/test",
+            type: "directive.linked_sensor.start",
+            data: %{}
+          })
+
+        assert :ok = Jido.AgentServer.cast(pid, start_signal)
+
+        state =
+          eventually_state(pid, fn state ->
+            Map.has_key?(state.children, {:sensor, :linked_round_trip})
+          end)
+
+        sensor_pid = state.children[{:sensor, :linked_round_trip}].pid
+        agent_ref = Process.monitor(pid)
+
+        assert :ok = SensorRuntime.event(sensor_pid, :crash)
+
+        assert_receive {:DOWN, ^agent_ref, :process, ^pid,
+                        {%RuntimeError{message: "linked sensor crash"}, _stack}},
+                       1_000
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+      end
+    end
+
     test "leaves state unchanged when sensor init fails", %{
       state: state,
       input_signal: input_signal
@@ -840,6 +926,44 @@ defmodule JidoTest.AgentServer.DirectiveExecTest do
       assert :sys.get_state(old_pid).config.label == "a"
 
       GenServer.stop(old_pid)
+    end
+
+    test "replaces linked sensors without propagating controlled stop exits", %{
+      state: state,
+      input_signal: input_signal
+    } do
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        start_a =
+          Directive.start_sensor(:linked_replaceable, LifecycleSensor,
+            config: %{label: "a"},
+            link?: true
+          )
+
+        {:ok, state_with_sensor} = DirectiveExec.exec(start_a, input_signal, state)
+        old_pid = state_with_sensor.children[{:sensor, :linked_replaceable}].pid
+
+        start_b =
+          Directive.start_sensor(:linked_replaceable, LifecycleSensor,
+            config: %{label: "b"},
+            link?: true
+          )
+
+        assert {:ok, replaced_state} =
+                 DirectiveExec.exec(start_b, input_signal, state_with_sensor)
+
+        new_pid = replaced_state.children[{:sensor, :linked_replaceable}].pid
+        assert new_pid != old_pid
+        assert Process.alive?(new_pid)
+        refute_receive {:EXIT, ^old_pid, {:shutdown, :replace}}, 100
+        refute_eventually(Process.alive?(old_pid))
+        assert :sys.get_state(new_pid).config.label == "b"
+
+        GenServer.stop(new_pid)
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+      end
     end
 
     test "does not stop existing sensor when replacement module is invalid", %{

--- a/test/jido/agent_server/plugin_subscriptions_test.exs
+++ b/test/jido/agent_server/plugin_subscriptions_test.exs
@@ -121,6 +121,18 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     end
   end
 
+  defmodule RecordChildExitAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "record_child_exit",
+      schema: []
+
+    def run(params, context) do
+      events = Map.get(context.state, :child_exit_events, [])
+      {:ok, %{child_exit_events: events ++ [params]}}
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Test Plugin Modules
   # ---------------------------------------------------------------------------
@@ -155,6 +167,24 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
          %{emit_on_init: true, signal_type: "first.sensor.event", agent_ref: context.agent_ref}},
         {JidoTest.AgentServer.PluginSubscriptionsTest.SecondTestSensor,
          %{sensor_id: "multi-test", agent_ref: context.agent_ref}}
+      ]
+    end
+  end
+
+  defmodule PluginWithTaggedDuplicateSensors do
+    @moduledoc false
+    use Jido.Plugin,
+      name: "plugin_with_tagged_duplicate_sensors",
+      state_key: :tagged_duplicate_sensors,
+      actions: [JidoTest.AgentServer.PluginSubscriptionsTest.SimpleAction]
+
+    @impl Jido.Plugin
+    def subscriptions(_config, context) do
+      [
+        {:fast_quotes, JidoTest.AgentServer.PluginSubscriptionsTest.TestSensor,
+         %{emit_on_init: false, signal_type: "fast.sensor.event", agent_ref: context.agent_ref}},
+        {:slow_quotes, JidoTest.AgentServer.PluginSubscriptionsTest.TestSensor,
+         %{emit_on_init: false, signal_type: "slow.sensor.event", agent_ref: context.agent_ref}}
       ]
     end
   end
@@ -226,6 +256,20 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       ]
   end
 
+  defmodule AgentWithChildExitSensorPlugin do
+    @moduledoc false
+    use Jido.Agent,
+      name: "agent_with_child_exit_sensor_plugin",
+      schema: [
+        child_exit_events: [type: {:list, :any}, default: []]
+      ],
+      plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithSensor],
+      signal_routes: [
+        {"jido.agent.child.exit",
+         JidoTest.AgentServer.PluginSubscriptionsTest.RecordChildExitAction}
+      ]
+  end
+
   defmodule PluginWithStaticSubscriptions do
     @moduledoc false
     use Jido.Plugin,
@@ -250,6 +294,13 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     use Jido.Agent,
       name: "agent_with_multi_sensor_plugin",
       plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithMultipleSensors]
+  end
+
+  defmodule AgentWithTaggedDuplicateSensorPlugin do
+    @moduledoc false
+    use Jido.Agent,
+      name: "agent_with_tagged_duplicate_sensor_plugin",
+      plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithTaggedDuplicateSensors]
   end
 
   defmodule AgentWithNoSubscriptionsPlugin do
@@ -289,13 +340,13 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       sensor_children =
         state.children
         |> Enum.filter(fn {tag, _} ->
-          match?({:sensor, _, _}, tag)
+          match?({:sensor, _}, tag)
         end)
 
       assert length(sensor_children) == 1
 
       [{tag, child_info}] = sensor_children
-      assert {:sensor, PluginWithSensor, TestSensor} = tag
+      assert {:sensor, {:plugin, PluginWithSensor, TestSensor}} = tag
       assert Process.alive?(child_info.pid)
 
       GenServer.stop(pid)
@@ -308,7 +359,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       [{_tag, child_info}] = sensor_children
       assert child_info.ref != nil
@@ -318,10 +369,35 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       eventually_state(pid, fn state ->
         sensor_count =
           state.children
-          |> Enum.count(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+          |> Enum.count(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
         sensor_count == 0
       end)
+
+      GenServer.stop(pid)
+    end
+
+    test "unexpected sensor exits do not emit child-agent exit signals", %{jido: jido} do
+      {:ok, pid} = Jido.AgentServer.start_link(agent: AgentWithChildExitSensorPlugin, jido: jido)
+
+      {:ok, state} = Jido.AgentServer.state(pid)
+
+      [{_tag, child_info}] =
+        state.children
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
+
+      Process.exit(child_info.pid, :boom)
+
+      state =
+        eventually_state(pid, fn state ->
+          sensor_count =
+            state.children
+            |> Enum.count(fn {tag, _} -> match?({:sensor, _}, tag) end)
+
+          sensor_count == 0
+        end)
+
+      assert state.agent.state.child_exit_events == []
 
       GenServer.stop(pid)
     end
@@ -337,7 +413,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       [{_tag, child_info}] = sensor_children
 
@@ -363,7 +439,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       [{_tag, child_info}] = sensor_children
 
@@ -390,13 +466,13 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       assert length(sensor_children) == 2
 
       sensor_modules =
         sensor_children
-        |> Enum.map(fn {{:sensor, _plugin, sensor_mod}, _} -> sensor_mod end)
+        |> Enum.map(fn {{:sensor, {:plugin, _plugin, sensor_mod}}, _} -> sensor_mod end)
         |> Enum.sort()
 
       assert sensor_modules == [SecondTestSensor, TestSensor]
@@ -404,6 +480,26 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       Enum.each(sensor_children, fn {_tag, child_info} ->
         assert Process.alive?(child_info.pid)
       end)
+
+      GenServer.stop(pid)
+    end
+
+    test "tagged subscriptions allow multiple instances of the same sensor module", %{jido: jido} do
+      {:ok, pid} =
+        Jido.AgentServer.start_link(agent: AgentWithTaggedDuplicateSensorPlugin, jido: jido)
+
+      {:ok, state} = Jido.AgentServer.state(pid)
+
+      sensor_children =
+        state.children
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
+
+      assert length(sensor_children) == 2
+      assert Map.has_key?(state.children, {:sensor, :fast_quotes})
+      assert Map.has_key?(state.children, {:sensor, :slow_quotes})
+
+      assert state.children[{:sensor, :fast_quotes}].module == TestSensor
+      assert state.children[{:sensor, :slow_quotes}].module == TestSensor
 
       GenServer.stop(pid)
     end
@@ -417,13 +513,13 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       assert length(sensor_children) == 3
 
       plugin_sensor_pairs =
         sensor_children
-        |> Enum.map(fn {{:sensor, plugin, sensor}, _} -> {plugin, sensor} end)
+        |> Enum.map(fn {{:sensor, {:plugin, plugin, sensor}}, _} -> {plugin, sensor} end)
         |> Enum.sort()
 
       assert {PluginWithMultipleSensors, SecondTestSensor} in plugin_sensor_pairs
@@ -442,7 +538,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       assert sensor_children == []
 
@@ -456,7 +552,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       assert sensor_children == []
 
@@ -470,7 +566,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       {:ok, state} = Jido.AgentServer.state(pid)
 
-      tag = {:sensor, PluginWithSensor, TestSensor}
+      tag = {:sensor, {:plugin, PluginWithSensor, TestSensor}}
       assert Map.has_key?(state.children, tag)
 
       child_info = Map.get(state.children, tag)
@@ -490,7 +586,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       sensor_children =
         state.children
-        |> Enum.filter(fn {tag, _} -> match?({:sensor, _, _}, tag) end)
+        |> Enum.filter(fn {tag, _} -> match?({:sensor, _}, tag) end)
 
       sensor_pids = Enum.map(sensor_children, fn {_, info} -> info.pid end)
 
@@ -500,6 +596,10 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       eventually(fn ->
         not Process.alive?(pid)
+      end)
+
+      Enum.each(sensor_pids, fn sensor_pid ->
+        refute_eventually(Process.alive?(sensor_pid))
       end)
     end
   end
@@ -514,7 +614,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       sensor_children =
         state.children
         |> Enum.filter(fn {tag, _} ->
-          match?({:sensor, PluginWithStaticSubscriptions, TestSensor}, tag)
+          match?({:sensor, {:plugin, PluginWithStaticSubscriptions, TestSensor}}, tag)
         end)
 
       assert length(sensor_children) == 1

--- a/test/jido/agent_server/plugin_subscriptions_test.exs
+++ b/test/jido/agent_server/plugin_subscriptions_test.exs
@@ -133,6 +133,25 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     end
   end
 
+  defmodule RecordSensorExitAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "record_sensor_exit",
+      schema: [
+        tag: [type: :any, required: true],
+        pid: [type: :any, required: true],
+        reason: [type: :any, required: true],
+        sensor: [type: :any, required: true],
+        origin: [type: :any, required: true],
+        meta: [type: :map, default: %{}]
+      ]
+
+    def run(params, context) do
+      events = Map.get(context.state, :sensor_exit_events, [])
+      {:ok, %{sensor_exit_events: events ++ [params]}}
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Test Plugin Modules
   # ---------------------------------------------------------------------------
@@ -261,12 +280,15 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
     use Jido.Agent,
       name: "agent_with_child_exit_sensor_plugin",
       schema: [
-        child_exit_events: [type: {:list, :any}, default: []]
+        child_exit_events: [type: {:list, :any}, default: []],
+        sensor_exit_events: [type: {:list, :any}, default: []]
       ],
       plugins: [JidoTest.AgentServer.PluginSubscriptionsTest.PluginWithSensor],
       signal_routes: [
         {"jido.agent.child.exit",
-         JidoTest.AgentServer.PluginSubscriptionsTest.RecordChildExitAction}
+         JidoTest.AgentServer.PluginSubscriptionsTest.RecordChildExitAction},
+        {"jido.agent.sensor.exit",
+         JidoTest.AgentServer.PluginSubscriptionsTest.RecordSensorExitAction}
       ]
   end
 
@@ -377,7 +399,7 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
       GenServer.stop(pid)
     end
 
-    test "unexpected sensor exits do not emit child-agent exit signals", %{jido: jido} do
+    test "unexpected sensor exits emit sensor lifecycle signals only", %{jido: jido} do
       {:ok, pid} = Jido.AgentServer.start_link(agent: AgentWithChildExitSensorPlugin, jido: jido)
 
       {:ok, state} = Jido.AgentServer.state(pid)
@@ -390,14 +412,26 @@ defmodule JidoTest.AgentServer.PluginSubscriptionsTest do
 
       state =
         eventually_state(pid, fn state ->
-          sensor_count =
-            state.children
-            |> Enum.count(fn {tag, _} -> match?({:sensor, _}, tag) end)
-
-          sensor_count == 0
+          state.agent.state.sensor_exit_events != []
         end)
 
+      refute Map.has_key?(state.children, {:sensor, {:plugin, PluginWithSensor, TestSensor}})
       assert state.agent.state.child_exit_events == []
+
+      assert [
+               %{
+                 tag: {:plugin, PluginWithSensor, TestSensor},
+                 pid: sensor_pid,
+                 reason: :boom,
+                 sensor: TestSensor,
+                 origin: {:plugin, PluginWithSensor},
+                 meta: meta
+               }
+             ] = state.agent.state.sensor_exit_events
+
+      assert sensor_pid == child_info.pid
+      assert meta.kind == :sensor
+      assert meta.sensor_tag == {:plugin, PluginWithSensor, TestSensor}
 
       GenServer.stop(pid)
     end

--- a/test/jido/sensor/runtime_test.exs
+++ b/test/jido/sensor/runtime_test.exs
@@ -631,6 +631,28 @@ defmodule JidoTest.Sensor.RuntimeTest do
     end
   end
 
+  describe "start/1" do
+    test "starts the runtime unlinked to the caller" do
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        {:ok, pid} =
+          Runtime.start(
+            sensor: SimpleSensor,
+            config: %{prefix: "unlinked"},
+            context: %{agent_ref: self()}
+          )
+
+        assert Process.alive?(pid)
+
+        GenServer.stop(pid)
+        refute_receive {:EXIT, ^pid, _reason}, 100
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+      end
+    end
+  end
+
   describe "child_spec/1" do
     test "returns valid child spec with default id" do
       spec = Runtime.child_spec(sensor: SimpleSensor)

--- a/test/jido/sensor/runtime_test.exs
+++ b/test/jido/sensor/runtime_test.exs
@@ -668,6 +668,21 @@ defmodule JidoTest.Sensor.RuntimeTest do
 
       assert_receive {:DOWN, ^ref, :process, ^pid, {:owner_down, :killed}}, 500
     end
+
+    test "ignores DOWN-shaped messages when no owner monitor exists" do
+      {:ok, pid} =
+        Runtime.start(
+          sensor: MinimalSensor,
+          context: %{agent_ref: self()}
+        )
+
+      send(pid, {:DOWN, nil, :process, nil, :boom})
+
+      assert %{owner_ref: nil} = :sys.get_state(pid)
+      assert Process.alive?(pid)
+
+      GenServer.stop(pid)
+    end
   end
 
   describe "child_spec/1" do

--- a/test/jido/sensor/runtime_test.exs
+++ b/test/jido/sensor/runtime_test.exs
@@ -651,6 +651,23 @@ defmodule JidoTest.Sensor.RuntimeTest do
         Process.flag(:trap_exit, previous_trap_exit)
       end
     end
+
+    test "stops when monitored owner exits" do
+      owner = spawn(fn -> Process.sleep(:infinity) end)
+
+      {:ok, pid} =
+        Runtime.start(
+          sensor: MinimalSensor,
+          context: %{agent_ref: self()},
+          owner_pid: owner
+        )
+
+      ref = Process.monitor(pid)
+
+      Process.exit(owner, :kill)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:owner_down, :killed}}, 500
+    end
   end
 
   describe "child_spec/1" do


### PR DESCRIPTION
## Summary
- add StartSensor and StopSensor core directives for agent-local sensor lifecycle control
- manage sensors through an unlinked, monitored SensorLifecycle path with explicit shutdown cleanup
- preserve existing plugin subscription tuples and add tagged subscription tuples for multiple sensor instances
- align sensor docs with currently supported runtime directives

Closes #253

## Validation
- mix test
- mix docs
- git diff --check
- mix q