### PR TITLE
fix(pod): resolve strategy module alias in Pod.__using__/1

### DIFF
--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -717,7 +717,8 @@ defmodule Jido.Error do
   defp sanitize_transport(value, _depth) when is_binary(value), do: truncate_string(value)
 
   defp sanitize_transport(value, _depth)
-       when is_boolean(value) or is_number(value) or is_atom(value), do: value
+       when is_boolean(value) or is_number(value) or is_atom(value),
+       do: value
 
   defp sanitize_transport(%_{} = value, _depth) when is_exception(value) do
     %{

--- a/lib/jido/pod.ex
+++ b/lib/jido/pod.ex
@@ -70,10 +70,20 @@ defmodule Jido.Pod do
     user_plugins =
       Definition.expand_and_eval_literal_option(Keyword.get(opts, :plugins, []), __CALLER__)
 
+    strategy =
+      Definition.expand_and_eval_literal_option(Keyword.get(opts, :strategy), __CALLER__)
+
     agent_opts =
       opts
       |> Keyword.delete(:topology)
       |> Keyword.put(:plugins, pod_plugins ++ (user_plugins || []))
+      |> then(fn resolved_opts ->
+        if is_nil(strategy) do
+          resolved_opts
+        else
+          Keyword.put(resolved_opts, :strategy, strategy)
+        end
+      end)
       |> then(fn resolved_opts ->
         if is_nil(remaining_default_plugins) do
           Keyword.delete(resolved_opts, :default_plugins)

--- a/lib/jido/pod.ex
+++ b/lib/jido/pod.ex
@@ -76,6 +76,7 @@ defmodule Jido.Pod do
     agent_opts =
       opts
       |> Keyword.delete(:topology)
+      |> Keyword.delete(:strategy)
       |> Keyword.put(:plugins, pod_plugins ++ (user_plugins || []))
       |> then(fn resolved_opts ->
         if is_nil(strategy) do

--- a/test/jido/pod_test.exs
+++ b/test/jido/pod_test.exs
@@ -84,6 +84,14 @@ defmodule JidoTest.PodTest do
       strategy: {TestStrategy, max_depth: 3}
   end
 
+  defmodule PodWithNilStrategy do
+    @moduledoc false
+    use Jido.Pod,
+      name: "pod_with_nil_strategy",
+      topology: %{},
+      strategy: nil
+  end
+
   defmodule EmptyPod do
     @moduledoc false
     use Jido.Pod,
@@ -333,10 +341,62 @@ defmodule JidoTest.PodTest do
     assert agent.agent_module == PodWithStrategy
   end
 
+  test "strategy option resolves caller aliases before pod opts are escaped" do
+    suffix = System.unique_integer([:positive])
+    pod_mod = Module.concat(__MODULE__, :"AliasedStrategyPod#{suffix}")
+    pod_name = "aliased_strategy_pod_#{suffix}"
+
+    Code.compile_string("""
+    defmodule #{inspect(pod_mod)} do
+      @moduledoc false
+      alias #{inspect(TestStrategy)}, as: Strategy
+
+      use Jido.Pod,
+        name: #{inspect(pod_name)},
+        topology: %{},
+        strategy: Strategy
+    end
+    """)
+
+    assert pod_mod.strategy() == TestStrategy
+    agent = pod_mod.new()
+    assert agent.agent_module == pod_mod
+  end
+
   test "use Jido.Pod resolves strategy {module, opts} tuple" do
     assert PodWithStrategyOpts.strategy() == TestStrategy
     assert PodWithStrategyOpts.strategy_opts() == [max_depth: 3]
     agent = PodWithStrategyOpts.new()
     assert agent.agent_module == PodWithStrategyOpts
+  end
+
+  test "strategy tuple option resolves caller aliases before pod opts are escaped" do
+    suffix = System.unique_integer([:positive])
+    pod_mod = Module.concat(__MODULE__, :"AliasedStrategyTuplePod#{suffix}")
+    pod_name = "aliased_strategy_tuple_pod_#{suffix}"
+
+    Code.compile_string("""
+    defmodule #{inspect(pod_mod)} do
+      @moduledoc false
+      alias #{inspect(TestStrategy)}, as: Strategy
+
+      use Jido.Pod,
+        name: #{inspect(pod_name)},
+        topology: %{},
+        strategy: {Strategy, max_depth: 3}
+    end
+    """)
+
+    assert pod_mod.strategy() == TestStrategy
+    assert pod_mod.strategy_opts() == [max_depth: 3]
+    agent = pod_mod.new()
+    assert agent.agent_module == pod_mod
+  end
+
+  test "nil strategy option falls back to default strategy" do
+    assert PodWithNilStrategy.strategy() == Jido.Agent.Strategy.Direct
+    assert PodWithNilStrategy.strategy_opts() == []
+    agent = PodWithNilStrategy.new()
+    assert agent.agent_module == PodWithNilStrategy
   end
 end

--- a/test/jido/pod_test.exs
+++ b/test/jido/pod_test.exs
@@ -44,6 +44,20 @@ defmodule JidoTest.PodTest do
       capabilities: []
   end
 
+  defmodule TestStrategy do
+    @moduledoc false
+    @behaviour Jido.Agent.Strategy
+
+    @impl true
+    def init(agent, _ctx), do: {agent, []}
+
+    @impl true
+    def tick(agent, _ctx), do: {agent, []}
+
+    @impl true
+    def cmd(agent, _instructions, _ctx), do: {agent, []}
+  end
+
   defmodule ExamplePod do
     @moduledoc false
     use Jido.Pod,
@@ -52,6 +66,22 @@ defmodule JidoTest.PodTest do
         planner: %{agent: WorkerAgent, manager: :planner_nodes, activation: :eager},
         reviewer: %{agent: WorkerAgent, manager: :reviewer_nodes}
       }
+  end
+
+  defmodule PodWithStrategy do
+    @moduledoc false
+    use Jido.Pod,
+      name: "pod_with_strategy",
+      topology: %{},
+      strategy: TestStrategy
+  end
+
+  defmodule PodWithStrategyOpts do
+    @moduledoc false
+    use Jido.Pod,
+      name: "pod_with_strategy_opts",
+      topology: %{},
+      strategy: {TestStrategy, max_depth: 3}
   end
 
   defmodule EmptyPod do
@@ -295,5 +325,18 @@ defmodule JidoTest.PodTest do
     assert {:ok, %{topology_version: 3}} = Pod.fetch_state(expanded_agent)
     assert {:ok, %Topology{version: 3} = topology} = Pod.fetch_topology(expanded_agent)
     assert Map.has_key?(topology.nodes, "reviewer")
+  end
+
+  test "use Jido.Pod resolves strategy module alias" do
+    assert PodWithStrategy.strategy() == TestStrategy
+    agent = PodWithStrategy.new()
+    assert agent.agent_module == PodWithStrategy
+  end
+
+  test "use Jido.Pod resolves strategy {module, opts} tuple" do
+    assert PodWithStrategyOpts.strategy() == TestStrategy
+    assert PodWithStrategyOpts.strategy_opts() == [max_depth: 3]
+    agent = PodWithStrategyOpts.new()
+    assert agent.agent_module == PodWithStrategyOpts
   end
 end


### PR DESCRIPTION
The strategy option passed to `use Jido.Pod` was not expanded via `Definition.expand_and_eval_literal_option`, causing module aliases to pass through `Macro.escape` as raw AST tuples. This crashed `Agent.new/1` when calling `strategy().init/2`.

## Description

Brief description of changes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
