### PR TITLE
fix: harden storage and signal target handling

### DIFF
--- a/lib/jido/actions/control.ex
+++ b/lib/jido/actions/control.ex
@@ -106,7 +106,8 @@ defmodule Jido.Actions.Control do
         source: [type: :string, default: nil, doc: "New source (optional)"]
       ]
 
-    def run(%{target_pid: pid, signal_type: type, payload: payload, source: source}, context) do
+    def run(%{target_pid: pid, signal_type: type, payload: payload, source: source}, context)
+        when is_pid(pid) do
       original = context[:signal]
 
       final_type = resolve_type(type, original)
@@ -116,6 +117,10 @@ defmodule Jido.Actions.Control do
       signal = Signal.new!(final_type, final_payload, source: final_source)
       directive = Directive.emit_to_pid(signal, pid)
       {:ok, %{forwarded_to: pid}, [directive]}
+    end
+
+    def run(%{target_pid: pid}, _context) do
+      {:error, {:invalid_target_pid, pid}}
     end
 
     defp resolve_type(type, _original) when is_binary(type), do: type

--- a/lib/jido/actions/lifecycle.ex
+++ b/lib/jido/actions/lifecycle.ex
@@ -102,10 +102,15 @@ defmodule Jido.Actions.Lifecycle do
             delivery_mode: mode
           },
           _context
-        ) do
+        )
+        when is_pid(pid) do
       signal = Signal.new!(type, payload, source: source)
       directive = Directive.emit_to_pid(signal, pid, delivery_mode: mode)
       {:ok, %{sent_to: pid}, [directive]}
+    end
+
+    def run(%{target_pid: pid}, _context) do
+      {:error, {:invalid_target_pid, pid}}
     end
   end
 

--- a/lib/jido/storage/file.ex
+++ b/lib/jido/storage/file.ex
@@ -23,13 +23,13 @@ defmodule Jido.Storage.File do
       ├── checkpoints/
       │   └── {key_hash}.term       # Serialized checkpoint
       └── threads/
-          └── {thread_id}/
+          └── {thread_id}/          # thread_id must be a single path segment
               ├── meta.term          # {rev, created_at, updated_at, metadata}
               └── entries.log        # Length-prefixed binary frames
 
   ## Concurrency
 
-  Uses `:global.trans/3` for thread-level locking to ensure safe concurrent access.
+  Uses `:global.trans/2` for thread-level locking to ensure safe concurrent access.
   """
 
   @behaviour Jido.Storage
@@ -59,7 +59,7 @@ defmodule Jido.Storage.File do
 
     case File.read(file_path) do
       {:ok, binary} ->
-        {:ok, :erlang.binary_to_term(binary, [:safe])}
+        safe_binary_to_term(binary, :invalid_term)
 
       {:error, :enoent} ->
         :not_found
@@ -67,8 +67,6 @@ defmodule Jido.Storage.File do
       {:error, reason} ->
         {:error, reason}
     end
-  rescue
-    ArgumentError -> {:error, :invalid_term}
   end
 
   @doc """
@@ -127,32 +125,19 @@ defmodule Jido.Storage.File do
   @spec load_thread(String.t(), opts()) :: {:ok, Thread.t()} | :not_found | {:error, term()}
   def load_thread(thread_id, opts) do
     path = Keyword.fetch!(opts, :path)
-    thread_dir = thread_path(path, thread_id)
-    meta_file = Path.join(thread_dir, "meta.term")
-    entries_file = Path.join(thread_dir, "entries.log")
 
-    with {:ok, meta_binary} <- File.read(meta_file),
+    with {:ok, thread_dir} <- thread_path(path, thread_id),
+         meta_file = Path.join(thread_dir, "meta.term"),
+         entries_file = Path.join(thread_dir, "entries.log"),
+         {:ok, meta_binary} <- File.read(meta_file),
          {:ok, entries_binary} <- File.read(entries_file),
+         {:ok, {rev, created_at, updated_at, metadata}} <- decode_meta(meta_binary),
          {:ok, entries} <- decode_entries(entries_binary) do
-      {rev, created_at, updated_at, metadata} = :erlang.binary_to_term(meta_binary, [:safe])
-
-      thread = %Thread{
-        id: thread_id,
-        rev: rev,
-        entries: entries,
-        created_at: created_at,
-        updated_at: updated_at,
-        metadata: metadata,
-        stats: %{entry_count: length(entries)}
-      }
-
-      {:ok, thread}
+      reconstruct_thread(thread_id, rev, created_at, updated_at, metadata, entries)
     else
       {:error, :enoent} -> :not_found
       {:error, reason} -> {:error, reason}
     end
-  rescue
-    ArgumentError -> {:error, :invalid_term}
   end
 
   @doc """
@@ -171,9 +156,11 @@ defmodule Jido.Storage.File do
     path = Keyword.fetch!(opts, :path)
     expected_rev = Keyword.get(opts, :expected_rev)
 
-    with_thread_lock(thread_id, fn ->
-      do_append_thread(path, thread_id, entries, expected_rev)
-    end)
+    with {:ok, thread_dir} <- thread_path(path, thread_id) do
+      with_thread_lock(path, thread_id, fn ->
+        do_append_thread(thread_id, thread_dir, entries, expected_rev)
+      end)
+    end
   end
 
   @doc """
@@ -185,11 +172,12 @@ defmodule Jido.Storage.File do
   @spec delete_thread(String.t(), opts()) :: :ok | {:error, term()}
   def delete_thread(thread_id, opts) do
     path = Keyword.fetch!(opts, :path)
-    thread_dir = thread_path(path, thread_id)
 
-    case File.rm_rf(thread_dir) do
-      {:ok, _} -> :ok
-      {:error, reason, _} -> {:error, reason}
+    with {:ok, thread_dir} <- thread_path(path, thread_id) do
+      case File.rm_rf(thread_dir) do
+        {:ok, _} -> :ok
+        {:error, reason, _} -> {:error, reason}
+      end
     end
   end
 
@@ -197,8 +185,7 @@ defmodule Jido.Storage.File do
   # Private Helpers
   # =============================================================================
 
-  defp do_append_thread(path, thread_id, entries, expected_rev) do
-    thread_dir = thread_path(path, thread_id)
+  defp do_append_thread(thread_id, thread_dir, entries, expected_rev) do
     meta_file = Path.join(thread_dir, "meta.term")
     entries_file = Path.join(thread_dir, "entries.log")
 
@@ -290,9 +277,11 @@ defmodule Jido.Storage.File do
   defp load_existing_thread(meta_file, entries_file) do
     with {:ok, meta_binary} <- File.read(meta_file),
          {:ok, entries_binary} <- File.read(entries_file),
+         {:ok, {rev, created_at, _updated_at, metadata}} <- decode_meta(meta_binary),
          {:ok, entries} <- decode_entries(entries_binary) do
-      {rev, created_at, _updated_at, metadata} = :erlang.binary_to_term(meta_binary, [:safe])
-      {:ok, rev, entries, created_at, metadata}
+      with :ok <- validate_thread_rev(rev, entries) do
+        {:ok, rev, entries, created_at, metadata}
+      end
     else
       {:error, :enoent} -> :not_found
       {:error, reason} -> {:error, reason}
@@ -339,10 +328,71 @@ defmodule Jido.Storage.File do
   defp decode_frame(_rest, _size), do: {:error, :invalid_entries_log}
 
   defp decode_entry(term_binary) do
-    {:ok, :erlang.binary_to_term(term_binary, [:safe])}
+    with {:ok, term} <- safe_binary_to_term(term_binary, :invalid_entries_log),
+         {:ok, entry} <- validate_entry(term) do
+      {:ok, entry}
+    end
+  end
+
+  defp decode_meta(binary) do
+    with {:ok, term} <- safe_binary_to_term(binary, :invalid_term),
+         {:ok, meta} <- validate_meta(term) do
+      {:ok, meta}
+    end
+  end
+
+  defp safe_binary_to_term(binary, error_reason) do
+    {:ok, :erlang.binary_to_term(binary, [:safe])}
   rescue
     ArgumentError ->
-      {:error, :invalid_entries_log}
+      {:error, error_reason}
+  end
+
+  defp validate_meta({rev, created_at, updated_at, metadata} = meta)
+       when is_integer(rev) and rev >= 0 and is_integer(created_at) and
+              is_integer(updated_at) and is_map(metadata) do
+    {:ok, meta}
+  end
+
+  defp validate_meta(_), do: {:error, :invalid_term}
+
+  defp validate_entry(%Entry{} = entry) do
+    case entry do
+      %Entry{id: id, seq: seq, at: at, kind: kind, payload: payload, refs: refs}
+      when is_binary(id) and is_integer(seq) and seq >= 0 and is_integer(at) and
+             is_atom(kind) and is_map(payload) and is_map(refs) ->
+        {:ok, entry}
+
+      _ ->
+        {:error, :invalid_entries_log}
+    end
+  end
+
+  defp validate_entry(%{id: id, seq: seq, at: at, kind: kind, payload: payload, refs: refs})
+       when is_binary(id) and is_integer(seq) and seq >= 0 and is_integer(at) and
+              is_atom(kind) and is_map(payload) and is_map(refs) do
+    {:ok, %Entry{id: id, seq: seq, at: at, kind: kind, payload: payload, refs: refs}}
+  end
+
+  defp validate_entry(_), do: {:error, :invalid_entries_log}
+
+  defp validate_thread_rev(rev, entries) do
+    if rev == length(entries), do: :ok, else: {:error, :invalid_term}
+  end
+
+  defp reconstruct_thread(thread_id, rev, created_at, updated_at, metadata, entries) do
+    with :ok <- validate_thread_rev(rev, entries) do
+      {:ok,
+       %Thread{
+         id: thread_id,
+         rev: rev,
+         entries: entries,
+         created_at: created_at,
+         updated_at: updated_at,
+         metadata: metadata,
+         stats: %{entry_count: length(entries)}
+       }}
+    end
   end
 
   defp checkpoint_path(base_path, key) do
@@ -350,8 +400,43 @@ defmodule Jido.Storage.File do
     Path.join([base_path, "checkpoints", "#{hash}.term"])
   end
 
-  defp thread_path(base_path, thread_id) do
-    Path.join([base_path, "threads", thread_id])
+  defp thread_path(base_path, thread_id) when is_binary(thread_id) and byte_size(thread_id) > 0 do
+    cond do
+      String.contains?(thread_id, <<0>>) ->
+        {:error, :invalid_thread_id}
+
+      Path.type(thread_id) == :absolute ->
+        {:error, :invalid_thread_id}
+
+      unsafe_thread_segment?(thread_id) ->
+        {:error, :invalid_thread_id}
+
+      true ->
+        threads_root = threads_root(base_path)
+        candidate = Path.expand(Path.join(threads_root, thread_id))
+
+        if inside_path?(candidate, threads_root) do
+          {:ok, candidate}
+        else
+          {:error, :invalid_thread_id}
+        end
+    end
+  end
+
+  defp thread_path(_base_path, _thread_id), do: {:error, :invalid_thread_id}
+
+  defp unsafe_thread_segment?(thread_id) do
+    thread_id in [".", ".."] or String.contains?(thread_id, ["/", "\\"])
+  end
+
+  defp threads_root(base_path), do: Path.expand(Path.join(base_path, "threads"))
+
+  defp inside_path?(candidate, root) do
+    root_parts = Path.split(root)
+    candidate_parts = Path.split(candidate)
+
+    length(candidate_parts) > length(root_parts) and
+      Enum.take(candidate_parts, length(root_parts)) == root_parts
   end
 
   defp ensure_checkpoints_dir(base_path) do
@@ -371,8 +456,9 @@ defmodule Jido.Storage.File do
     :ok
   end
 
-  defp with_thread_lock(thread_id, fun) do
-    lock_id = {:jido_thread_lock, thread_id}
+  defp with_thread_lock(base_path, thread_id, fun) do
+    lock_key = {:jido_thread_lock, Path.expand(base_path), thread_id}
+    lock_id = {lock_key, self()}
 
     :global.trans(lock_id, fn ->
       fun.()

--- a/lib/jido/storage/redis.ex
+++ b/lib/jido/storage/redis.ex
@@ -41,7 +41,7 @@ defmodule Jido.Storage.Redis do
 
   ## Concurrency
 
-  Thread operations use `:global.trans/3` for distributed locking, matching
+  Thread operations use `:global.trans/2` for distributed locking, matching
   the pattern used by `Jido.Storage.ETS` and `Jido.Storage.File`.
   """
 
@@ -139,12 +139,13 @@ defmodule Jido.Storage.Redis do
   def append_thread(thread_id, entries, opts) do
     expected_rev = Keyword.get(opts, :expected_rev)
     now = System.system_time(:millisecond)
+    redis_key = thread_key(thread_id, opts)
 
-    lock_key = {:jido_storage_redis_append_thread, thread_id}
+    lock_key = {:jido_storage_redis_append_thread, redis_key}
     lock_id = {lock_key, self()}
 
     :global.trans(lock_id, fn ->
-      do_append_thread(thread_id, entries, expected_rev, now, opts)
+      do_append_thread(thread_id, redis_key, entries, expected_rev, now, opts)
     end)
   end
 
@@ -164,9 +165,8 @@ defmodule Jido.Storage.Redis do
   # Private Helpers
   # =============================================================================
 
-  defp do_append_thread(thread_id, entries, expected_rev, now, opts) do
+  defp do_append_thread(thread_id, redis_key, entries, expected_rev, now, opts) do
     command_fn = fetch_command_fn!(opts)
-    redis_key = thread_key(thread_id, opts)
 
     with {:ok, stored_thread} <- load_thread_or_new(command_fn, redis_key, now),
          :ok <- validate_expected_rev(expected_rev, stored_thread.rev) do

--- a/test/jido/actions/control_test.exs
+++ b/test/jido/actions/control_test.exs
@@ -53,6 +53,12 @@ defmodule JidoTest.Actions.ControlTest do
 
       assert directive.signal.data == %{key: "value"}
     end
+
+    test "returns an error for invalid target pid" do
+      params = %{target_pid: "not-a-pid", signal_type: nil, payload: nil, source: nil}
+
+      assert {:error, {:invalid_target_pid, "not-a-pid"}} = Control.Forward.run(params, %{})
+    end
   end
 
   describe "Broadcast" do

--- a/test/jido/actions/lifecycle_test.exs
+++ b/test/jido/actions/lifecycle_test.exs
@@ -77,6 +77,18 @@ defmodule JidoTest.Actions.LifecycleTest do
       assert Keyword.get(opts, :target) == target
       assert Keyword.get(opts, :delivery_mode) == :sync
     end
+
+    test "returns an error for invalid target pid" do
+      params = %{
+        target_pid: "not-a-pid",
+        signal_type: "result.ready",
+        payload: %{},
+        source: "/agent",
+        delivery_mode: :async
+      }
+
+      assert {:error, {:invalid_target_pid, "not-a-pid"}} = Lifecycle.NotifyPid.run(params, %{})
+    end
   end
 
   describe "SpawnChild" do

--- a/test/jido/storage/file_test.exs
+++ b/test/jido/storage/file_test.exs
@@ -252,6 +252,43 @@ defmodule JidoTest.Storage.FileTest do
       assert :not_found = FileStorage.load_thread(thread_id, opts)
     end
 
+    test "thread operations reject ids that escape the configured storage root", %{
+      path: path,
+      opts: opts
+    } do
+      outside_dir =
+        Path.join(
+          Path.dirname(path),
+          "jido_file_storage_outside_#{:erlang.unique_integer([:positive])}"
+        )
+
+      sentinel = Path.join(outside_dir, "sentinel.txt")
+      File.mkdir_p!(outside_dir)
+      File.write!(sentinel, "keep")
+      on_exit(fn -> File.rm_rf!(outside_dir) end)
+
+      escaping_thread_id = Path.join(["..", "..", Path.basename(outside_dir)])
+
+      assert {:error, :invalid_thread_id} =
+               FileStorage.append_thread(escaping_thread_id, [%{kind: :note}], opts)
+
+      assert {:error, :invalid_thread_id} = FileStorage.load_thread(escaping_thread_id, opts)
+      assert {:error, :invalid_thread_id} = FileStorage.delete_thread(escaping_thread_id, opts)
+
+      assert {:error, :invalid_thread_id} =
+               FileStorage.append_thread(outside_dir, [%{kind: :note}], opts)
+
+      for invalid_thread_id <- ["tenant/thread", "tenant\\thread", ".", ".."] do
+        assert {:error, :invalid_thread_id} =
+                 FileStorage.append_thread(invalid_thread_id, [%{kind: :note}], opts)
+
+        assert {:error, :invalid_thread_id} = FileStorage.load_thread(invalid_thread_id, opts)
+        assert {:error, :invalid_thread_id} = FileStorage.delete_thread(invalid_thread_id, opts)
+      end
+
+      assert File.exists?(sentinel)
+    end
+
     test "thread entries have correct seq numbers", %{opts: opts} do
       thread_id = "seq_test_#{:erlang.unique_integer([:positive])}"
 
@@ -324,6 +361,39 @@ defmodule JidoTest.Storage.FileTest do
       :ok = File.write(entries_file, <<0, 0, 1, 0, 1, 2, 3>>)
 
       assert {:error, :invalid_entries_log} = FileStorage.load_thread(thread_id, opts)
+    end
+
+    test "load_thread/2 returns {:error, :invalid_entries_log} for invalid entry term", %{
+      opts: opts
+    } do
+      thread_id = "invalid_entry_#{:erlang.unique_integer([:positive])}"
+      path = Keyword.fetch!(opts, :path)
+
+      entry = %Entry{id: "e1", seq: 0, at: 0, kind: :message, payload: %{ok: true}, refs: %{}}
+      {:ok, _thread} = FileStorage.append_thread(thread_id, [entry], opts)
+
+      invalid_entry = :erlang.term_to_binary(%{not: :an_entry})
+      entries_file = Path.join([path, "threads", thread_id, "entries.log"])
+
+      :ok =
+        File.write(entries_file, <<byte_size(invalid_entry)::unsigned-32, invalid_entry::binary>>)
+
+      assert {:error, :invalid_entries_log} = FileStorage.load_thread(thread_id, opts)
+    end
+
+    test "load_thread/2 returns {:error, :invalid_term} for invalid metadata term", %{
+      opts: opts
+    } do
+      thread_id = "invalid_meta_#{:erlang.unique_integer([:positive])}"
+      path = Keyword.fetch!(opts, :path)
+
+      entry = %Entry{id: "e1", seq: 0, at: 0, kind: :message, payload: %{ok: true}, refs: %{}}
+      {:ok, _thread} = FileStorage.append_thread(thread_id, [entry], opts)
+
+      meta_file = Path.join([path, "threads", thread_id, "meta.term"])
+      :ok = File.write(meta_file, :erlang.term_to_binary(%{rev: 1}))
+
+      assert {:error, :invalid_term} = FileStorage.load_thread(thread_id, opts)
     end
 
     test "append_thread/3 returns {:error, :invalid_entries_log} when existing entries are corrupt",

--- a/test/jido/storage/redis_test.exs
+++ b/test/jido/storage/redis_test.exs
@@ -325,6 +325,51 @@ defmodule JidoTest.Storage.RedisTest do
       assert Enum.map(thread.entries, & &1.payload.n) == [1]
     end
 
+    test "serializes concurrent appends for the same Redis thread key" do
+      pid = start_mock_redis()
+      test_pid = self()
+      release_ref = make_ref()
+
+      opts = [
+        command_fn:
+          mock_command_fn(pid, fn
+            ["GET", "jido:th:race-th"] = command ->
+              send(test_pid, {:race_get, self()})
+
+              receive do
+                {:release_get, ^release_ref} -> handle_mock_command(pid, command)
+              after
+                1_000 -> {:error, :test_timeout}
+              end
+
+            _ ->
+              :next
+          end)
+      ]
+
+      task_a =
+        Task.async(fn ->
+          Redis.append_thread("race-th", [%{kind: :note, payload: %{n: 1}}], opts)
+        end)
+
+      task_b =
+        Task.async(fn ->
+          Redis.append_thread("race-th", [%{kind: :note, payload: %{n: 2}}], opts)
+        end)
+
+      assert_receive {:race_get, first_getter}, 500
+      refute_receive {:race_get, _second_getter}, 100
+
+      send(first_getter, {:release_get, release_ref})
+      assert_receive {:race_get, second_getter}, 500
+      send(second_getter, {:release_get, release_ref})
+
+      assert [{:ok, %Thread{}}, {:ok, %Thread{}}] = Task.await_many([task_a, task_b], 2_000)
+      assert {:ok, thread} = Redis.load_thread("race-th", redis_opts(pid))
+      assert thread.rev == 2
+      assert Enum.sort(Enum.map(thread.entries, & &1.payload.n)) == [1, 2]
+    end
+
     test "returns {:error, :invalid_term} when stored thread data is corrupt" do
       pid = start_mock_redis()
       put_raw(pid, thread_key("bad-th"), <<0, 1, 2>>)


### PR DESCRIPTION
## Summary
- Constrain `Jido.Storage.File` thread IDs to a non-empty single path segment before load/append/delete operations.
- Validate decoded file-store thread metadata and entries before reconstructing threads, returning structured errors for corrupt persisted data.
- Correct file-store thread append locking to use a real `:global.trans/2` resource/requester tuple and scope Redis thread append locks by Redis key.
- Return structured errors from built-in PID-targeting actions when routed signal data contains a non-PID target.

## Security notes
- Prevents file storage path traversal via malicious thread IDs, including `..`, separators, and absolute-path inputs reaching `File.rm_rf/1`.
- Prevents prefix-style deletion of nested file-store thread directories by rejecting separator-bearing thread IDs.
- Prevents corrupt on-disk thread metadata/entry terms from crashing callers during load/append.
- Avoids malformed signal payloads crashing `NotifyPid`/`Forward` through `Directive.emit_to_pid/3` function-clause errors.

## Verification
- `mix hex.audit`
- `mix test`
- `mix q`
