### PR TITLE
deps: replace uniq with internal UUIDv7

### DIFF
--- a/lib/jido/id.ex
+++ b/lib/jido/id.ex
@@ -1,0 +1,31 @@
+defmodule Jido.ID do
+  @moduledoc false
+
+  @max_unix_ts_ms 0xFFFFFFFFFFFF
+
+  @doc false
+  @spec uuid7() :: String.t()
+  def uuid7 do
+    uuid7(System.system_time(:millisecond), :crypto.strong_rand_bytes(10))
+  end
+
+  @doc false
+  @spec uuid7(non_neg_integer(), <<_::80>>) :: String.t()
+  def uuid7(timestamp_ms, random_bytes)
+      when is_integer(timestamp_ms) and timestamp_ms in 0..@max_unix_ts_ms and
+             byte_size(random_bytes) == 10 do
+    # UUIDv7 has 74 random bits; 10 random bytes provide those bits plus 6 discarded bits.
+    <<rand_a::12, rand_b::62, _unused::6>> = random_bytes
+
+    <<timestamp_ms::48, 7::4, rand_a::12, 2::2, rand_b::62>>
+    |> Base.encode16(case: :lower)
+    |> format_uuid()
+  end
+
+  defp format_uuid(
+         <<a::binary-size(8), b::binary-size(4), c::binary-size(4), d::binary-size(4),
+           e::binary-size(12)>>
+       ) do
+    a <> "-" <> b <> "-" <> c <> "-" <> d <> "-" <> e
+  end
+end

--- a/lib/jido/pod/mutation/planner.ex
+++ b/lib/jido/pod/mutation/planner.ex
@@ -3,6 +3,7 @@ defmodule Jido.Pod.Mutation.Planner do
   Pure planner for live pod mutations.
   """
 
+  alias Jido.ID
   alias Jido.Pod.Mutation
   alias Jido.Pod.Mutation.{AddNode, Plan, RemoveNode, Report}
   alias Jido.Pod.Topology
@@ -20,7 +21,7 @@ defmodule Jido.Pod.Mutation.Planner do
          {:ok, added, removed} <- diff_nodes(topology, validated_final_topology),
          {:ok, start_requested, start_waves} <- build_start_plan(validated_final_topology, added),
          {:ok, stop_waves} <- stop_waves(topology, removed) do
-      mutation_id = Uniq.UUID.uuid7()
+      mutation_id = ID.uuid7()
 
       normalized_final_topology =
         TopologyState.normalize_updated_topology(topology, validated_final_topology)

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Jido.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:crypto, :logger],
       mod: {Jido.Application, []}
     ]
   end
@@ -400,7 +400,6 @@ defmodule Jido.MixProject do
       {:telemetry_metrics, "~> 1.1"},
       {:crontab, "~> 1.2"},
       {:time_zone_info, "~> 0.7"},
-      {:uniq, "~> 0.6.1"},
 
       # Development & Test Dependencies
       {:git_ops, "~> 2.9", only: :dev, runtime: false},

--- a/test/jido/id_test.exs
+++ b/test/jido/id_test.exs
@@ -1,0 +1,118 @@
+defmodule JidoTest.IDTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias Jido.ID
+
+  @uuid7_regex ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/
+
+  describe "uuid7/0" do
+    test "generates lowercase RFC 9562 UUIDv7 strings" do
+      assert ID.uuid7() =~ @uuid7_regex
+    end
+
+    test "encodes current Unix millisecond timestamp, version, variant, and random fields" do
+      before_ms = System.system_time(:millisecond)
+      uuid = ID.uuid7()
+      after_ms = System.system_time(:millisecond)
+
+      decoded = decode_uuid7(uuid)
+
+      assert decoded.timestamp in before_ms..after_ms
+      assert decoded.version == 7
+      assert decoded.variant == 2
+      assert decoded.rand_a in 0..0xFFF
+      assert decoded.rand_b in 0..0x3FFFFFFFFFFFFFFF
+    end
+
+    test "generates unique IDs" do
+      ids = for _index <- 1..1000, do: ID.uuid7()
+
+      assert length(Enum.uniq(ids)) == 1000
+    end
+  end
+
+  describe "uuid7/2" do
+    test "matches RFC 9562 UUIDv7 example bit layout" do
+      timestamp = 0x017F22E279B0
+      rand_a = 0x0CC3
+      rand_b = 0b01 <<< 60 ||| 0x8C4DC0C0C07398F
+      random_bytes = <<rand_a::12, rand_b::62, 0::6>>
+
+      assert ID.uuid7(timestamp, random_bytes) ==
+               "017f22e2-79b0-7cc3-98c4-dc0c0c07398f"
+    end
+
+    test "supports minimum and maximum representable values" do
+      assert ID.uuid7(0, <<0::80>>) == "00000000-0000-7000-8000-000000000000"
+
+      assert ID.uuid7(0xFFFFFFFFFFFF, :binary.copy(<<0xFF>>, 10)) ==
+               "ffffffff-ffff-7fff-bfff-ffffffffffff"
+    end
+
+    test "preserves lexical timestamp ordering with fixed random bytes" do
+      random_bytes = <<0::80>>
+
+      assert ID.uuid7(1, random_bytes) < ID.uuid7(2, random_bytes)
+    end
+
+    test "uses the high 74 random bits and ignores only the low 6 padding bits" do
+      rand_a = 0x0ABC
+      rand_b = 0x123456789ABCDEF
+
+      uuid_with_zero_padding = ID.uuid7(42, <<rand_a::12, rand_b::62, 0::6>>)
+      uuid_with_one_padding = ID.uuid7(42, <<rand_a::12, rand_b::62, 0b111111::6>>)
+
+      assert uuid_with_zero_padding == uuid_with_one_padding
+
+      decoded = decode_uuid7(uuid_with_zero_padding)
+
+      assert decoded.rand_a == rand_a
+      assert decoded.rand_b == rand_b
+    end
+
+    test "rejects timestamps outside the 48-bit UUIDv7 range" do
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(0x1_0000_0000_0000, <<0::80>>)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(-1, <<0::80>>)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(1.0, <<0::80>>)
+      end
+    end
+
+    test "rejects random inputs that are not 80 bits" do
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(0, <<0::72>>)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(0, <<0::88>>)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        ID.uuid7(0, :not_binary)
+      end
+    end
+  end
+
+  defp decode_uuid7(uuid) do
+    {:ok, <<timestamp::48, version::4, rand_a::12, variant::2, rand_b::62>>} =
+      uuid
+      |> String.replace("-", "")
+      |> Base.decode16(case: :mixed)
+
+    %{
+      timestamp: timestamp,
+      version: version,
+      rand_a: rand_a,
+      variant: variant,
+      rand_b: rand_b
+    }
+  end
+end

--- a/test/jido/pod/mutation/planner_test.exs
+++ b/test/jido/pod/mutation/planner_test.exs
@@ -15,6 +15,8 @@ defmodule JidoTest.Pod.Mutation.PlannerTest do
     use Jido.Pod, name: "mutation_planner_nested_pod"
   end
 
+  @uuid7_regex ~r/\A[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/
+
   test "plans batched add mutations with mixed atom and string names" do
     topology = Topology.new!(name: "planner_mixed")
 
@@ -29,6 +31,7 @@ defmodule JidoTest.Pod.Mutation.PlannerTest do
     ]
 
     assert {:ok, plan} = Planner.plan(topology, ops)
+    assert plan.mutation_id =~ @uuid7_regex
     assert plan.added == [:planner, "reviewer"]
     assert plan.removed == []
     assert plan.start_requested == [:planner]
@@ -39,6 +42,21 @@ defmodule JidoTest.Pod.Mutation.PlannerTest do
     assert Topology.owner_of(plan.final_topology, "reviewer") == {:ok, :planner}
     assert Topology.dependencies_of(plan.final_topology, "reviewer") == [:planner]
     assert plan.final_topology.version == 2
+  end
+
+  test "generates unique UUIDv7 mutation IDs for each plan" do
+    topology = Topology.new!(name: "planner_mutation_ids")
+
+    ops = [
+      Mutation.add_node(:planner, %{agent: Worker, manager: :planner_manager, activation: :eager})
+    ]
+
+    assert {:ok, plan1} = Planner.plan(topology, ops)
+    assert {:ok, plan2} = Planner.plan(topology, ops)
+
+    assert plan1.mutation_id =~ @uuid7_regex
+    assert plan2.mutation_id =~ @uuid7_regex
+    assert plan1.mutation_id != plan2.mutation_id
   end
 
   test "plans batched add mutations for nested pod nodes" do


### PR DESCRIPTION
Closes #305

## Summary
- add an internal `Jido.ID` UUIDv7 generator using `:crypto.strong_rand_bytes/1`
- replace mutation planning's direct `Uniq.UUID.uuid7/0` call
- remove the direct `uniq` dependency from `mix.exs`
- add UUIDv7 bit-layout tests and mutation planner ID shape/uniqueness coverage

## Verification
- `mix test test/jido/id_test.exs test/jido/pod/mutation/planner_test.exs`
- `mix deps.unlock --check-unused`
- `mix test`
- `mix q`