### PR TITLE
fix: remove ok dependency

### DIFF
--- a/lib/jido/agent.ex
+++ b/lib/jido/agent.ex
@@ -209,8 +209,6 @@ defmodule Jido.Agent do
   defp ast_node?({_, meta, _}) when is_list(meta), do: true
   defp ast_node?(_other), do: false
 
-  require OK
-
   @schema Zoi.struct(
             __MODULE__,
             %{
@@ -463,8 +461,6 @@ defmodule Jido.Agent do
       alias Jido.Agent.Strategy, as: AgentStrategy
       alias Jido.Instruction
       alias Jido.Plugin.Requirements, as: PluginRequirements
-
-      require OK
     end
   end
 
@@ -999,7 +995,7 @@ defmodule Jido.Agent do
       @spec set(Agent.t(), map() | keyword()) :: Agent.agent_result()
       def set(%Agent{} = agent, attrs) do
         new_state = AgentState.merge(agent.state, Map.new(attrs))
-        OK.success(%{agent | state: new_state})
+        {:ok, %{agent | state: new_state}}
       end
 
       @doc """
@@ -1017,11 +1013,10 @@ defmodule Jido.Agent do
       def validate(%Agent{} = agent, opts \\ []) do
         case AgentState.validate(agent.state, agent.schema, opts) do
           {:ok, validated_state} ->
-            OK.success(%{agent | state: validated_state})
+            {:ok, %{agent | state: validated_state}}
 
           {:error, reason} ->
-            Jido.Error.validation_error("State validation failed", %{reason: reason})
-            |> OK.failure()
+            {:error, Jido.Error.validation_error("State validation failed", %{reason: reason})}
         end
       end
     end
@@ -1478,7 +1473,7 @@ defmodule Jido.Agent do
   @spec set(t(), map() | keyword()) :: agent_result()
   def set(%Agent{} = agent, attrs) do
     new_state = StateHelper.merge(agent.state, Map.new(attrs))
-    OK.success(%{agent | state: new_state})
+    {:ok, %{agent | state: new_state}}
   end
 
   @doc """
@@ -1488,11 +1483,10 @@ defmodule Jido.Agent do
   def validate(%Agent{} = agent, opts \\ []) do
     case StateHelper.validate(agent.state, agent.schema, opts) do
       {:ok, validated_state} ->
-        OK.success(%{agent | state: validated_state})
+        {:ok, %{agent | state: validated_state}}
 
       {:error, reason} ->
-        Error.validation_error("State validation failed", %{reason: reason})
-        |> OK.failure()
+        {:error, Error.validation_error("State validation failed", %{reason: reason})}
     end
   end
 

--- a/lib/jido/pod/runtime.ex
+++ b/lib/jido/pod/runtime.ex
@@ -288,7 +288,18 @@ defmodule Jido.Pod.Runtime do
         Task.async_stream(
           wave,
           fn name ->
-            ensure_planned_node(server_pid, state, topology, requested_names, name, report, opts)
+            case ensure_planned_node(
+                   server_pid,
+                   state,
+                   topology,
+                   requested_names,
+                   name,
+                   report,
+                   opts
+                 ) do
+              {:ok, result} -> {:node_ensured, result}
+              {:error, reason} -> {:node_failed, reason}
+            end
           end,
           ordered: true,
           max_concurrency: max_concurrency,
@@ -297,8 +308,8 @@ defmodule Jido.Pod.Runtime do
         )
         |> Enum.zip(wave)
         |> Enum.map(fn
-          {{:ok, {:ok, result}}, name} -> {:ok, name, result}
-          {{:ok, {:error, reason}}, name} -> {:error, name, reason}
+          {{:ok, {:node_ensured, result}}, name} -> {:ok, name, result}
+          {{:ok, {:node_failed, reason}}, name} -> {:error, name, reason}
           {{:exit, reason}, name} -> {:error, name, {:task_exit, reason}}
         end)
 

--- a/lib/jido/util.ex
+++ b/lib/jido/util.ex
@@ -20,7 +20,6 @@ defmodule Jido.Util do
 
   alias Jido.Signal.ID, as: SignalID
 
-  require OK
   require Logger
 
   @name_regex ~r/^[a-zA-Z][a-zA-Z0-9_]*$/
@@ -68,7 +67,7 @@ defmodule Jido.Util do
 
   def validate_name(name, []) when is_binary(name) do
     if Regex.match?(@name_regex, name) do
-      OK.success(name)
+      {:ok, name}
     else
       {:error,
        Jido.Error.validation_error(

--- a/mix.exs
+++ b/mix.exs
@@ -393,7 +393,6 @@ defmodule Jido.MixProject do
       # Jido Deps
       {:deep_merge, "~> 1.0"},
       {:nimble_options, "~> 1.1"},
-      {:ok, "~> 2.3"},
       {:splode, "~> 0.3.0"},
       {:telemetry, "~> 1.3"},
       {:poolboy, "~> 1.5"},

--- a/mix.lock
+++ b/mix.lock
@@ -37,7 +37,6 @@
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "nimble_pool": {:hex, :nimble_pool, "1.1.0", "bf9c29fbdcba3564a8b800d1eeb5a3c58f36e1e11d7b7fb2e084a643f645f06b", [:mix], [], "hexpm", "af2e4e6b34197db81f7aad230c1118eac993acc0dae6bc83bac0126d4ae0813a"},
-  "ok": {:hex, :ok, "2.3.0", "0a3d513ec9038504dc5359d44e14fc14ef59179e625563a1a144199cdc3a6d30", [:mix], [], "hexpm", "f0347b3f8f115bf347c704184b33cf084f2943771273f2b98a3707a5fa43c4d5"},
   "owl": {:hex, :owl, "0.13.0", "26010e066d5992774268f3163506972ddac0a7e77bfe57fa42a250f24d6b876e", [:mix], [{:ucwidth, "~> 0.2", [hex: :ucwidth, repo: "hexpm", optional: true]}], "hexpm", "59bf9d11ce37a4db98f57cb68fbfd61593bf419ec4ed302852b6683d3d2f7475"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "2.2.0", "ff3a5616e1bed6804de7773b92cbccfc0b0f473faf1f63d7daf1206c7aeaaa6f", [:mix], [], "hexpm", "adc313a5bf7136039f63cfd9668fde73bba0765e0614cba80c06ac9460ff3e96"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},

--- a/test/jido/agent/agent_test.exs
+++ b/test/jido/agent/agent_test.exs
@@ -212,6 +212,14 @@ defmodule JidoTest.AgentTest do
       {:ok, validated} = TestAgents.Basic.validate(agent, strict: true)
       refute Map.has_key?(validated.state, :extra_field)
     end
+
+    test "returns a single error tuple for invalid Zoi state" do
+      agent = TestAgents.ZoiSchema.new(state: %{status: :idle, count: "not_an_integer"})
+      result = TestAgents.ZoiSchema.validate(agent)
+
+      refute match?({:error, {:error, _reason}}, result)
+      assert {:error, %Jido.Error.ValidationError{message: "State validation failed"}} = result
+    end
   end
 
   describe "cmd/2" do

--- a/test/jido/storage/ets_test.exs
+++ b/test/jido/storage/ets_test.exs
@@ -327,7 +327,10 @@ defmodule JidoTest.Storage.ETSTest do
         1..total_appends
         |> Task.async_stream(
           fn i ->
-            ETS.append_thread(thread_id, [%{kind: :note, payload: %{n: i}}], opts)
+            case ETS.append_thread(thread_id, [%{kind: :note, payload: %{n: i}}], opts) do
+              {:ok, _thread} -> :appended
+              {:error, reason} -> {:append_failed, reason}
+            end
           end,
           max_concurrency: 20,
           ordered: false,
@@ -335,10 +338,7 @@ defmodule JidoTest.Storage.ETSTest do
         )
         |> Enum.to_list()
 
-      assert Enum.all?(results, fn
-               {:ok, {:ok, _thread}} -> true
-               _ -> false
-             end)
+      assert Enum.frequencies(results) == %{{:ok, :appended} => total_appends}
 
       assert {:ok, thread} = ETS.load_thread(thread_id, opts)
       assert thread.rev == total_appends + 1


### PR DESCRIPTION
## Summary

- Remove the `:ok` package from `mix.exs` and `mix.lock`.
- Replace `OK.success/1` and `OK.failure/1` usage with explicit tagged tuples.
- Remove `require OK` from `Jido.Agent`, generated agent modules, and `Jido.Util`.
- Clean up existing generic nested task result patterns by returning domain-tagged async results instead of matching `{:ok, {:ok, ...}}`.

## Nested tuple review

Searched for remaining `OK` references and generic nested result patterns:

```sh
rg -n "require OK|OK\.|\{:ok,\s*\{:ok|\{:error,\s*\{:error|\{\:ok, \{\:ok|\{\:error, \{\:error" lib test mix.exs mix.lock
```

No matches remain.

The two existing nested patterns were from `Task.async_stream/3` wrapping tagged function returns. This PR fixes those at the task boundary:

- `Jido.Pod.Runtime` now maps node ensure results to `{:node_ensured, result}` / `{:node_failed, reason}` inside the task, then converts them back to wave results after the task wrapper.
- The concurrent ETS storage test now returns `:appended` / `{:append_failed, reason}` from each task instead of asserting on `{:ok, {:ok, thread}}`.

## Verification

- `mix deps.unlock --check-unused`
- Targeted tests:
  - `mix test test/jido/util_test.exs test/jido/agent/agent_test.exs test/jido/agent/state_test.exs test/jido/pod/runtime_test.exs test/jido/pod/mutation_runtime_test.exs test/jido/storage/ets_test.exs`
- `mix test`
- `mix quality`

Closes #304.
