### PR TITLE
fix(agent-server): serialize sync call drain races

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -1239,34 +1239,38 @@ defmodule Jido.AgentServer do
 
   @impl true
   def handle_info(:drain, state) do
-    case State.dequeue(state) do
-      {:empty, s} ->
-        s = %{s | processing: false}
-        s = State.set_status(s, :idle)
-        {:noreply, s}
+    if signal_call_inflight?(state) do
+      {:noreply, %{state | processing: false}}
+    else
+      case State.dequeue(state) do
+        {:empty, s} ->
+          s = %{s | processing: false}
+          s = State.set_status(s, :idle)
+          {:noreply, s}
 
-      {{:value, item}, s1} ->
-        {signal, runtime_context, directive} = normalize_directive_queue_item(item)
-        TraceContext.set_from_signal(signal)
+        {{:value, item}, s1} ->
+          {signal, runtime_context, directive} = normalize_directive_queue_item(item)
+          TraceContext.set_from_signal(signal)
 
-        result =
-          try do
-            exec_directive_with_telemetry(directive, signal, runtime_context, s1)
-          after
-            TraceContext.clear()
+          result =
+            try do
+              exec_directive_with_telemetry(directive, signal, runtime_context, s1)
+            after
+              TraceContext.clear()
+            end
+
+          case result do
+            {:ok, s2} ->
+              continue_draining(s2)
+
+            {:async, _ref, s2} ->
+              continue_draining(s2)
+
+            {:stop, reason, s2} ->
+              warn_if_normal_stop(reason, directive, s2)
+              {:stop, reason, State.set_status(s2, :stopping)}
           end
-
-        case result do
-          {:ok, s2} ->
-            continue_draining(s2)
-
-          {:async, _ref, s2} ->
-            continue_draining(s2)
-
-          {:stop, reason, s2} ->
-            warn_if_normal_stop(reason, directive, s2)
-            {:stop, reason, State.set_status(s2, :stopping)}
-        end
+      end
     end
   end
 
@@ -1382,6 +1386,7 @@ defmodule Jido.AgentServer do
         state = %{state | signal_call_inflight: nil}
         state = apply_signal_call_result(result, inflight, state)
         state = maybe_start_next_signal_call(state)
+        state = maybe_resume_drain(state)
         state = maybe_process_deferred_async_signal(state)
         {:noreply, state}
 
@@ -1391,20 +1396,24 @@ defmodule Jido.AgentServer do
   end
 
   def handle_info(:process_deferred_signal, %State{} = state) do
-    case :queue.out(state.deferred_async_signals) do
-      {{:value, signal}, q} ->
-        state = %{state | deferred_async_signals: q}
+    if signal_call_inflight?(state) do
+      {:noreply, state}
+    else
+      case :queue.out(state.deferred_async_signals) do
+        {{:value, signal}, q} ->
+          state = %{state | deferred_async_signals: q}
 
-        case process_signal(signal, state) do
-          {:ok, new_state, _resolved_action} ->
-            {:noreply, maybe_process_deferred_async_signal(new_state)}
+          case process_signal(signal, state) do
+            {:ok, new_state, _resolved_action} ->
+              {:noreply, maybe_process_deferred_async_signal(new_state)}
 
-          {:error, _reason, new_state} ->
-            {:noreply, maybe_process_deferred_async_signal(new_state)}
-        end
+            {:error, _reason, new_state} ->
+              {:noreply, maybe_process_deferred_async_signal(new_state)}
+          end
 
-      {:empty, _} ->
-        {:noreply, state}
+        {:empty, _} ->
+          {:noreply, state}
+      end
     end
   end
 
@@ -1689,6 +1698,16 @@ defmodule Jido.AgentServer do
 
   defp maybe_process_deferred_async_signal(%State{} = state), do: state
 
+  defp maybe_resume_drain(%State{signal_call_inflight: nil} = state) do
+    if State.queue_empty?(state) do
+      state
+    else
+      start_drain_if_idle(%{state | processing: false})
+    end
+  end
+
+  defp maybe_resume_drain(%State{} = state), do: state
+
   defp maybe_set_idle_status(%State{} = state) do
     if is_nil(state.signal_call_inflight) and :queue.is_empty(state.signal_call_queue) and
          :queue.is_empty(state.deferred_async_signals) and state.processing == false do
@@ -1787,6 +1806,17 @@ defmodule Jido.AgentServer do
   end
 
   defp maybe_track_child_started(state, _signal), do: state
+
+  defp process_or_defer_internal_signal(%Signal{} = signal, %State{} = state) do
+    if signal_call_inflight?(state) do
+      {:noreply, enqueue_deferred_async_signal(state, signal)}
+    else
+      case process_signal(signal, state) do
+        {:ok, new_state, _resolved_action} -> {:noreply, new_state}
+        {:error, _reason, new_state} -> {:noreply, new_state}
+      end
+    end
+  end
 
   defp track_child_started(state, pid, child_module, child_id, child_partition, tag, meta) do
     ref = Process.monitor(pid)
@@ -3146,10 +3176,7 @@ defmodule Jido.AgentServer do
         {:error, _} -> signal
       end
 
-    case process_signal(traced_signal, orphaned_state) do
-      {:ok, new_state, _resolved_action} -> {:noreply, new_state}
-      {:error, _reason, ns} -> {:noreply, ns}
-    end
+    process_or_defer_internal_signal(traced_signal, orphaned_state)
   end
 
   defp handle_child_down(%State{} = state, pid, reason) do
@@ -3179,10 +3206,7 @@ defmodule Jido.AgentServer do
             {:error, _} -> signal
           end
 
-        case process_signal(traced_signal, state) do
-          {:ok, new_state, _resolved_action} -> {:noreply, new_state}
-          {:error, _reason, ns} -> {:noreply, ns}
-        end
+        process_or_defer_internal_signal(traced_signal, state)
 
       tag ->
         Logger.debug(fn ->
@@ -3201,10 +3225,7 @@ defmodule Jido.AgentServer do
             {:error, _} -> signal
           end
 
-        case process_signal(traced_signal, state) do
-          {:ok, new_state, _resolved_action} -> {:noreply, new_state}
-          {:error, _reason, ns} -> {:noreply, ns}
-        end
+        process_or_defer_internal_signal(traced_signal, state)
 
       true ->
         {:noreply, state}

--- a/test/jido/agent_server/signal_call_drain_race_test.exs
+++ b/test/jido/agent_server/signal_call_drain_race_test.exs
@@ -1,0 +1,148 @@
+defmodule JidoTest.AgentServer.SignalCallDrainRaceTest do
+  use JidoTest.Case, async: true
+
+  @moduletag :capture_log
+
+  alias Jido.Agent.Directive
+  alias Jido.AgentServer
+  alias Jido.Signal
+
+  defmodule SlowCallAction do
+    @moduledoc false
+    use Jido.Action, name: "race_slow_call"
+
+    def run(_params, %{state: %{test_pid: test_pid}}) when is_pid(test_pid) do
+      send(test_pid, {:slow_call_started, self()})
+
+      receive do
+        :release_slow_call -> {:ok, %{call_done: true}}
+      after
+        1_000 -> {:error, :slow_call_not_released}
+      end
+    end
+  end
+
+  defmodule RuntimeMutationAction do
+    @moduledoc false
+    use Jido.Action, name: "race_runtime_mutation"
+
+    def run(_params, %{state: %{test_pid: test_pid}}) when is_pid(test_pid) do
+      send(test_pid, :runtime_instruction_ran)
+      {:ok, %{runtime_done: true}}
+    end
+  end
+
+  defmodule CaptureRuntimeResultAction do
+    @moduledoc false
+    use Jido.Action, name: "race_capture_runtime_result"
+
+    def run(%{status: :ok, result: result}, _context) do
+      {:ok, %{runtime_done: Map.get(result, :runtime_done), instruction_seen: true}}
+    end
+  end
+
+  defmodule QueueRuntimeInstructionAction do
+    @moduledoc false
+    use Jido.Action, name: "race_queue_runtime_instruction"
+
+    def run(_params, _context) do
+      instruction = Jido.Instruction.new!(%{action: RuntimeMutationAction})
+
+      directive =
+        Directive.run_instruction(instruction, result_action: CaptureRuntimeResultAction)
+
+      {:ok, %{}, [directive]}
+    end
+  end
+
+  defmodule RaceAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "signal_call_drain_race_agent",
+      schema: [
+        test_pid: [type: :any, default: nil],
+        call_done: [type: :boolean, default: false],
+        runtime_done: [type: :boolean, default: false],
+        instruction_seen: [type: :boolean, default: false]
+      ]
+
+    def signal_routes(_ctx) do
+      [
+        {"queue_runtime_instruction", QueueRuntimeInstructionAction},
+        {"slow_call", SlowCallAction}
+      ]
+    end
+  end
+
+  test "sync call result preserves state committed by the drain loop", %{jido: jido} do
+    {:ok, pid} =
+      AgentServer.start_link(
+        agent: RaceAgent,
+        id: unique_id("drain-race"),
+        initial_state: %{test_pid: self()},
+        jido: jido
+      )
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        try do
+          :sys.resume(pid)
+        catch
+          :exit, _ -> :ok
+        end
+
+        try do
+          GenServer.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok = :sys.suspend(pid)
+    :ok = AgentServer.cast(pid, signal("queue_runtime_instruction"))
+
+    call_task =
+      Task.async(fn ->
+        AgentServer.call(pid, signal("slow_call"), 2_000)
+      end)
+
+    eventually(fn -> queued_cast_and_call?(pid) end)
+
+    :ok = :sys.resume(pid)
+
+    assert_receive {:slow_call_started, call_runner}, 500
+
+    send(call_runner, :release_slow_call)
+
+    assert {:ok, returned_agent} = Task.await(call_task, 2_000)
+    assert returned_agent.state.call_done == true
+    assert_receive :runtime_instruction_ran, 500
+
+    eventually_state(pid, fn state ->
+      state.agent.state.call_done == true and state.agent.state.runtime_done == true and
+        state.agent.state.instruction_seen == true
+    end)
+  end
+
+  defp queued_cast_and_call?(pid) do
+    case Process.info(pid, :messages) do
+      {:messages, messages} ->
+        Enum.any?(messages, &queue_runtime_instruction_cast?/1) and
+          Enum.any?(messages, &slow_call?/1)
+
+      nil ->
+        false
+    end
+  end
+
+  defp queue_runtime_instruction_cast?(
+         {:"$gen_cast", {:signal, %Signal{type: "queue_runtime_instruction"}}}
+       ),
+       do: true
+
+  defp queue_runtime_instruction_cast?(_message), do: false
+
+  defp slow_call?({:"$gen_call", _from, {:signal, %Signal{type: "slow_call"}}}), do: true
+  defp slow_call?(_message), do: false
+end


### PR DESCRIPTION
## Summary

Fixes the F01 race by preventing synchronous `AgentServer.call/3` task results from overwriting agent-state updates committed by the directive drain loop or internally generated parent/child DOWN signals.

## Root Cause

Sync calls run `cmd/3` in an off-process task using a snapshot of `State`. While that task was in flight, the GenServer could still drain queued directives or process generated parent/child exit signals in-process. When the sync call task returned, `apply_signal_call_result/3` replaced the current agent with the stale snapshot-derived agent, silently losing those interim state updates.

## Changes

- Pause the directive drain loop while a sync call is in flight and explicitly resume it after sync calls are idle.
- Guard deferred async signal processing against being overtaken by a new sync call.
- Defer internally generated orphan/child/sensor exit signals while a sync call is in flight.
- Add a focused regression test that reproduces the stale snapshot overwrite with a queued `RunInstruction` and a blocked sync call.

## Validation

- Confirmed the new regression test failed before the fix with `returned_agent.state.runtime_done == false`.
- `mix test test/jido/agent_server/signal_call_drain_race_test.exs`
- `mix test`
- `mix q`
