### PR TITLE
fix(instance-manager): fail closed on thaw errors

### DIFF
--- a/lib/jido/agent/instance_manager.ex
+++ b/lib/jido/agent/instance_manager.ex
@@ -191,7 +191,8 @@ defmodule Jido.Agent.InstanceManager do
 
   If an agent for the given key is already running, returns its pid.
   If storage is configured and a hibernated state exists, thaws it.
-  Otherwise starts a fresh agent.
+  If no checkpoint exists, starts a fresh agent. Other thaw failures return
+  `{:error, {:thaw_failed, reason}}` without starting an agent.
 
   ## Options
 
@@ -315,9 +316,12 @@ defmodule Jido.Agent.InstanceManager do
     config = get_config(manager)
     partition = effective_partition(config, opts)
 
-    # Try to thaw from storage first
-    agent_or_nil = maybe_thaw(config, key, partition)
+    with {:ok, agent_or_nil} <- maybe_thaw(config, key, partition) do
+      start_child(manager, config, key, agent_or_nil, opts, partition)
+    end
+  end
 
+  defp start_child(manager, config, key, agent_or_nil, opts, partition) do
     child_spec = build_child_spec(config, key, agent_or_nil, opts, partition)
 
     case DynamicSupervisor.start_child(dynamic_supervisor_name(manager), child_spec) do
@@ -373,7 +377,9 @@ defmodule Jido.Agent.InstanceManager do
     Supervisor.child_spec({Jido.AgentServer, base_opts}, restart: :transient)
   end
 
-  defp maybe_thaw(%{storage: nil}, _key, _partition), do: nil
+  @spec maybe_thaw(map(), key(), term()) ::
+          {:ok, Jido.Agent.t() | nil} | {:error, {:thaw_failed, term()}}
+  defp maybe_thaw(%{storage: nil}, _key, _partition), do: {:ok, nil}
 
   defp maybe_thaw(%{name: manager_name, storage: storage, agent: agent_module}, key, partition) do
     persistence_key = manager_persistence_key(manager_name, key, partition)
@@ -381,17 +387,21 @@ defmodule Jido.Agent.InstanceManager do
     case Persist.thaw(storage, agent_module, persistence_key) do
       {:ok, agent} ->
         Logger.debug(fn -> "InstanceManager thawed agent for key #{inspect(key)}" end)
-        agent
+        {:ok, agent}
 
       {:error, :not_found} ->
-        nil
+        Logger.debug(fn ->
+          "InstanceManager found no checkpoint for key #{inspect(key)}; starting fresh"
+        end)
+
+        {:ok, nil}
 
       {:error, reason} ->
         Logger.warning(fn ->
-          "InstanceManager failed to thaw agent for key #{inspect(key)}: #{inspect(reason)}"
+          "InstanceManager failed to thaw agent for key #{inspect(key)}; refusing to start: #{inspect(reason)}"
         end)
 
-        nil
+        {:error, {:thaw_failed, reason}}
     end
   end
 

--- a/test/jido/agent/instance_manager_test.exs
+++ b/test/jido/agent/instance_manager_test.exs
@@ -9,10 +9,13 @@ defmodule JidoTest.Agent.InstanceManagerTest do
   alias Jido.Agent.InstanceManager
   alias Jido.Agent.Directive
   alias Jido.AgentServer
+  alias Jido.Persist
   alias Jido.Scheduler
   alias Jido.Signal
   alias Jido.Storage.ETS
+  alias Jido.Storage.File, as: FileStorage
   alias Jido.Storage.Redis
+  alias Jido.Thread
 
   # Use module attribute for manager naming to avoid atom leaks
   # Each test gets a unique integer suffix but we clean up persistent_term
@@ -75,6 +78,28 @@ defmodule JidoTest.Agent.InstanceManagerTest do
            command_fn: fn cmd -> JidoTest.Agent.InstanceManagerTest.RedisMock.command(cmd) end,
            prefix: "instance_manager_test"
          ]}
+  end
+
+  defmodule ControlledStorage do
+    @behaviour Jido.Storage
+
+    @impl true
+    def get_checkpoint(_key, opts), do: Keyword.fetch!(opts, :checkpoint_result)
+
+    @impl true
+    def put_checkpoint(_key, _data, _opts), do: :ok
+
+    @impl true
+    def delete_checkpoint(_key, _opts), do: :ok
+
+    @impl true
+    def load_thread(_thread_id, _opts), do: :not_found
+
+    @impl true
+    def append_thread(_thread_id, _entries, _opts), do: {:error, :unsupported}
+
+    @impl true
+    def delete_thread(_thread_id, _opts), do: :ok
   end
 
   # Simple test agent
@@ -580,6 +605,89 @@ defmodule JidoTest.Agent.InstanceManagerTest do
       assert beta_state.partition == :beta
       assert beta_state.agent.state.counter == 22
       assert beta_state.agent.state.__partition__ == :beta
+    end
+  end
+
+  describe "thaw failures" do
+    test "does not start or overwrite durable state after an unreadable checkpoint" do
+      manager = :"#{@manager_prefix}_thaw_failure_#{:erlang.unique_integer([:positive])}"
+      key = "corrupt-checkpoint"
+      thread_id = "durable-thread-#{:erlang.unique_integer([:positive])}"
+
+      base_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "jido_instance_manager_thaw_failure_#{:erlang.unique_integer([:positive])}"
+        )
+
+      storage = {FileStorage, path: base_dir}
+      storage_opts = [path: base_dir]
+
+      thread =
+        Thread.new(id: thread_id)
+        |> Thread.append(%{kind: :message, payload: %{content: "one"}})
+        |> Thread.append(%{kind: :message, payload: %{content: "two"}})
+
+      agent = TestAgent.new(id: key)
+      agent = %{agent | state: Map.put(agent.state, :__thread__, thread)}
+
+      assert :ok = Persist.hibernate(storage, TestAgent, {manager, key}, agent)
+
+      assert [checkpoint_file] = Path.wildcard(Path.join([base_dir, "checkpoints", "*.term"]))
+      corrupt_checkpoint = <<131, 255, 0, 1>>
+      File.write!(checkpoint_file, corrupt_checkpoint)
+
+      {:ok, _} =
+        start_supervised(
+          InstanceManager.child_spec(
+            name: manager,
+            agent: TestAgent,
+            storage: storage,
+            agent_opts: [jido: JidoTest.InstanceManagerTestJido]
+          )
+        )
+
+      on_exit(fn ->
+        :persistent_term.erase({InstanceManager, manager})
+        File.rm_rf!(base_dir)
+      end)
+
+      assert {:error, {:thaw_failed, :invalid_term}} = InstanceManager.get(manager, key)
+      assert :error = InstanceManager.lookup(manager, key)
+      assert %{count: 0, keys: []} = InstanceManager.stats(manager)
+
+      assert File.read!(checkpoint_file) == corrupt_checkpoint
+      assert {:ok, stored_thread} = FileStorage.load_thread(thread_id, storage_opts)
+      assert stored_thread.rev == 2
+      assert Enum.map(stored_thread.entries, & &1.payload.content) == ["one", "two"]
+    end
+
+    test "propagates non-not-found thaw errors without registering a child" do
+      reasons = [
+        :thread_mismatch,
+        {:restore_callback_failed, :migration_failed},
+        :storage_unavailable
+      ]
+
+      Enum.each(reasons, fn reason ->
+        manager = :"#{@manager_prefix}_thaw_reason_#{:erlang.unique_integer([:positive])}"
+
+        {:ok, _} =
+          start_supervised(
+            InstanceManager.child_spec(
+              name: manager,
+              agent: TestAgent,
+              storage: {ControlledStorage, checkpoint_result: {:error, reason}},
+              agent_opts: [jido: JidoTest.InstanceManagerTestJido]
+            )
+          )
+
+        on_exit(fn -> :persistent_term.erase({InstanceManager, manager}) end)
+
+        assert {:error, {:thaw_failed, ^reason}} = InstanceManager.get(manager, "failed-thaw")
+        assert :error = InstanceManager.lookup(manager, "failed-thaw")
+        assert InstanceManager.stats(manager).count == 0
+      end)
     end
   end
 

--- a/test/jido/integration/scheduler_durability_integration_test.exs
+++ b/test/jido/integration/scheduler_durability_integration_test.exs
@@ -433,8 +433,7 @@ defmodule JidoTest.Integration.SchedulerDurabilityIntegrationTest do
       :ok = AgentServer.detach(pid)
     end
 
-    test "write-through cron register and cancel do not rewrite corrupt checkpoint state",
-         context do
+    test "corrupt checkpoint prevents write-through cron registration", context do
       %{manager: manager, table: table} = start_manager(context, CronAgent)
       register_key = "corrupt-write-through-register"
       register_checkpoint_key = checkpoint_key(CronAgent, manager, register_key)
@@ -450,25 +449,17 @@ defmodule JidoTest.Integration.SchedulerDurabilityIntegrationTest do
 
       assert :ok = ETS.put_checkpoint(register_checkpoint_key, register_checkpoint, table: table)
 
-      {:ok, register_pid} = get_attached(manager, register_key)
+      assert {:error, {:thaw_failed, {:invalid_checkpoint, {:invalid_state, []}}}} =
+               InstanceManager.get(manager, register_key)
 
-      assert :ok =
-               register_cron(register_pid, "* * * * * * *", job_id: :write_through_register)
+      assert :error = InstanceManager.lookup(manager, register_key)
 
-      wait_for_job(register_pid, :write_through_register, timeout: 5_000)
+      assert {:ok, ^register_checkpoint} =
+               ETS.get_checkpoint(register_checkpoint_key, table: table)
+    end
 
-      eventually(
-        fn ->
-          case ETS.get_checkpoint(register_checkpoint_key, table: table) do
-            {:ok, checkpoint} ->
-              checkpoint.state == [] and checkpoint.marker == :register_marker
-
-            _ ->
-              false
-          end
-        end,
-        timeout: 3_000
-      )
+    test "write-through cron cancel does not rewrite corrupt checkpoint state", context do
+      %{manager: manager, table: table} = start_manager(context, CronAgent)
 
       cancel_key = "corrupt-write-through-cancel"
       cancel_checkpoint_key = checkpoint_key(CronAgent, manager, cancel_key)


### PR DESCRIPTION
## Summary

- preserve explicit fresh/restored outcomes across the InstanceManager thaw boundary
- return `{:error, {:thaw_failed, reason}}` for every non-`:not_found` restore failure
- refuse to build or register a child after a failed thaw
- distinguish missing checkpoints from failed restoration in logs

## Root cause

`maybe_thaw/3` collapsed both `{:error, :not_found}` and all other `Persist.thaw/3` errors to `nil`. `start_agent/3` interpreted `nil` as permission to create a fresh agent, allowing its state to diverge from an existing durable thread journal.

## Impact

InstanceManager now fails closed when durable state exists but cannot be restored. Missing checkpoints and storage-disabled managers continue to start fresh normally. Callers receive the underlying thaw reason in a structured error, and failed restoration leaves the registry, checkpoint, and thread journal untouched.

## Validation

- `mix test test/jido/agent/instance_manager_test.exs` — 33 passed
- `mix q`
- `mix test`

Closes #315

