### PR TITLE
test(storage): introduce reusable adapter conformance suites

### DIFF
--- a/guides/storage-conformance.md
+++ b/guides/storage-conformance.md
@@ -1,0 +1,57 @@
+# Storage adapter conformance
+
+`Jido.Storage` defines six callbacks for checkpoints and thread journals. The
+shared ExUnit suites make those callback semantics executable for built-in and
+third-party adapters.
+
+## Shared contract
+
+| Area | Required behavior |
+| --- | --- |
+| Checkpoint reads | Return `{:ok, value}` when present and `:not_found` when absent. |
+| Checkpoint writes | Preserve arbitrary terms and overwrite the same key. |
+| Checkpoint deletes | Remove the value and remain idempotent. |
+| Thread reads | Reconstruct ordered entries, metadata, revision, timestamps, and stats; return `:not_found` when there are no entries. |
+| Thread appends | Accept entry structs or maps, preserve existing entries, assign contiguous zero-based sequences, increment revision by appended count, and preserve creation metadata. |
+| Optimistic writes | Accept a matching `:expected_rev`; reject a stale value with `{:error, :conflict}` without changing the journal. Revision `0` is valid for a new thread. |
+| Thread deletes | Remove entries and metadata and remain idempotent. |
+
+Use `JidoTest.StorageCheckpointConformance` and
+`JidoTest.StorageThreadConformance` from `test/support`. Each adapter supplies
+an option expression that creates isolated storage for every generated test.
+For example:
+
+```elixir
+use JidoTest.StorageThreadConformance,
+  adapter: MyStorage,
+  setup: quote(do: [namespace: unique_namespace()])
+```
+
+The Jido test suite runs both contracts against ETS and File. External adapters
+should import the helpers from an exact Jido commit and run them against every
+supported backend.
+
+## Adapter-specific coverage
+
+The shared suites intentionally do not prescribe implementation details.
+Adapters retain their own tests for concerns such as:
+
+- process and table lifecycle;
+- filesystem safety and corrupt persisted state;
+- repository configuration and transaction failures;
+- backend-specific locking, retry, and concurrency behavior.
+
+Concurrent adapters should additionally prove that parallel appends are
+lossless with unique contiguous sequences, and that two writers using the same
+`expected_rev` produce one success and one conflict.
+
+## Validation
+
+Run the built-in adapters with:
+
+```sh
+mix test test/jido/storage
+```
+
+An adapter is conformant only when its shared suite and applicable
+adapter-specific tests pass.

--- a/lib/jido/storage.ex
+++ b/lib/jido/storage.ex
@@ -92,7 +92,9 @@ defmodule Jido.Storage do
 
   Returns `{:ok, updated_thread}` on success.
   """
-  @callback append_thread(thread_id :: String.t(), entries :: [Entry.t()], opts :: keyword()) ::
+  @type entry_input :: Entry.t() | map()
+
+  @callback append_thread(thread_id :: String.t(), entries :: [entry_input()], opts :: keyword()) ::
               {:ok, Thread.t()} | {:error, term()}
 
   @doc """

--- a/lib/jido/storage/ets.ex
+++ b/lib/jido/storage/ets.ex
@@ -29,7 +29,6 @@ defmodule Jido.Storage.ETS do
   @behaviour Jido.Storage
 
   alias Jido.Thread
-  alias Jido.Thread.Entry
   alias Jido.Thread.EntryNormalizer
 
   @default_table :jido_storage
@@ -124,7 +123,7 @@ defmodule Jido.Storage.ETS do
     if the current thread revision doesn't match.
   - `:metadata` - Thread metadata to merge (only used when creating new thread).
   """
-  @spec append_thread(String.t(), [Entry.t()], opts()) ::
+  @spec append_thread(String.t(), [Jido.Storage.entry_input()], opts()) ::
           {:ok, Thread.t()} | {:error, term()}
   def append_thread(thread_id, entries, opts) do
     threads_table = threads_table(opts)

--- a/lib/jido/storage/file.ex
+++ b/lib/jido/storage/file.ex
@@ -150,15 +150,16 @@ defmodule Jido.Storage.File do
   Uses a global lock to ensure safe concurrent access.
   """
   @impl true
-  @spec append_thread(String.t(), [Entry.t()], opts()) ::
+  @spec append_thread(String.t(), [Jido.Storage.entry_input()], opts()) ::
           {:ok, Thread.t()} | {:error, term()}
   def append_thread(thread_id, entries, opts) do
     path = Keyword.fetch!(opts, :path)
     expected_rev = Keyword.get(opts, :expected_rev)
+    metadata = Keyword.get(opts, :metadata, %{})
 
     with {:ok, thread_dir} <- thread_path(path, thread_id) do
       with_thread_lock(path, thread_id, fn ->
-        do_append_thread(thread_id, thread_dir, entries, expected_rev)
+        do_append_thread(thread_id, thread_dir, entries, expected_rev, metadata)
       end)
     end
   end
@@ -185,12 +186,12 @@ defmodule Jido.Storage.File do
   # Private Helpers
   # =============================================================================
 
-  defp do_append_thread(thread_id, thread_dir, entries, expected_rev) do
+  defp do_append_thread(thread_id, thread_dir, entries, expected_rev, creation_metadata) do
     meta_file = Path.join(thread_dir, "meta.term")
     entries_file = Path.join(thread_dir, "entries.log")
 
     with {:ok, current_rev, current_entries, created_at, metadata} <-
-           load_thread_or_new(meta_file, entries_file),
+           load_thread_or_new(meta_file, entries_file, creation_metadata),
          :ok <- validate_expected_rev(expected_rev, current_rev),
          :ok <- ensure_thread_dir(thread_dir),
          {:ok, prepared_entries, now} <- build_prepared_entries(entries, current_entries),
@@ -210,14 +211,14 @@ defmodule Jido.Storage.File do
     end
   end
 
-  defp load_thread_or_new(meta_file, entries_file) do
+  defp load_thread_or_new(meta_file, entries_file, creation_metadata) do
     case load_existing_thread(meta_file, entries_file) do
       {:ok, rev, existing_entries, created, meta} ->
         {:ok, rev, existing_entries, created, meta}
 
       :not_found ->
         now = System.system_time(:millisecond)
-        {:ok, 0, [], now, %{}}
+        {:ok, 0, [], now, creation_metadata}
 
       {:error, reason} ->
         {:error, reason}
@@ -379,6 +380,9 @@ defmodule Jido.Storage.File do
   defp validate_thread_rev(rev, entries) do
     if rev == length(entries), do: :ok, else: {:error, :invalid_term}
   end
+
+  defp reconstruct_thread(_thread_id, _rev, _created_at, _updated_at, _metadata, []),
+    do: :not_found
 
   defp reconstruct_thread(thread_id, rev, created_at, updated_at, metadata, entries) do
     with :ok <- validate_thread_rev(rev, entries) do

--- a/lib/jido/storage/redis.ex
+++ b/lib/jido/storage/redis.ex
@@ -135,7 +135,8 @@ defmodule Jido.Storage.Redis do
   end
 
   @impl true
-  @spec append_thread(String.t(), [term()], opts()) :: {:ok, Thread.t()} | {:error, term()}
+  @spec append_thread(String.t(), [Jido.Storage.entry_input()], opts()) ::
+          {:ok, Thread.t()} | {:error, term()}
   def append_thread(thread_id, entries, opts) do
     expected_rev = Keyword.get(opts, :expected_rev)
     now = System.system_time(:millisecond)

--- a/mix.exs
+++ b/mix.exs
@@ -84,6 +84,7 @@ defmodule Jido.MixProject do
           "guides/observability-intro.md"
         ],
         Fundamentals: [
+          "guides/storage-conformance.md",
           "guides/agents.md",
           "guides/actions.md",
           "guides/signals.md",

--- a/test/jido/storage/ets_test.exs
+++ b/test/jido/storage/ets_test.exs
@@ -1,6 +1,14 @@
 defmodule JidoTest.Storage.ETSTest do
   use ExUnit.Case, async: true
 
+  use JidoTest.StorageCheckpointConformance,
+    adapter: Jido.Storage.ETS,
+    setup: quote(do: [table: unique_table(:checkpoint_conformance)])
+
+  use JidoTest.StorageThreadConformance,
+    adapter: Jido.Storage.ETS,
+    setup: quote(do: [table: unique_table(:thread_conformance)])
+
   alias Jido.Storage
   alias Jido.Storage.ETS
   alias Jido.Thread

--- a/test/jido/storage/file_test.exs
+++ b/test/jido/storage/file_test.exs
@@ -1,11 +1,31 @@
 defmodule JidoTest.Storage.FileTest do
   use ExUnit.Case, async: false
 
+  use JidoTest.StorageCheckpointConformance,
+    adapter: Jido.Storage.File,
+    setup: quote(do: conformance_opts(:checkpoint))
+
+  use JidoTest.StorageThreadConformance,
+    adapter: Jido.Storage.File,
+    setup: quote(do: conformance_opts(:thread))
+
   alias Jido.Storage.File, as: FileStorage
   alias Jido.Thread
   alias Jido.Thread.Entry
 
   @moduletag :storage
+
+  defp conformance_opts(scope) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "jido_file_conformance_#{scope}_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf!(path) end)
+    [path: path]
+  end
 
   setup do
     base_dir =

--- a/test/support/storage_checkpoint_conformance.ex
+++ b/test/support/storage_checkpoint_conformance.ex
@@ -1,0 +1,116 @@
+defmodule JidoTest.StorageCheckpointConformance do
+  @moduledoc """
+  Reusable ExUnit cases for the checkpoint half of `Jido.Storage`.
+
+  The caller supplies the adapter module and an option expression. The
+  expression is evaluated separately for every generated test, so adapters
+  can create isolated tables, directories, or other test resources without
+  becoming part of the shared contract.
+
+  ## Example
+
+      use JidoTest.StorageCheckpointConformance,
+        adapter: Jido.Storage.ETS,
+        setup: quote do: [table: unique_table(:checkpoint_contract)]
+
+  The helper intentionally covers only checkpoint semantics. Thread behavior,
+  adapter lifecycle, and backend-specific error handling remain in the
+  adapter's own test module.
+  """
+
+  defmacro __using__(options) do
+    adapter = Keyword.fetch!(options, :adapter)
+
+    setup =
+      case Keyword.get(options, :setup, quote(do: [])) do
+        {:quote, _, [[do: expression]]} -> expression
+        expression -> expression
+      end
+
+    quote do
+      alias unquote(adapter), as: CheckpointStorageAdapter
+
+      describe "checkpoint storage conformance" do
+        test "returns :not_found for a missing checkpoint" do
+          opts = unquote(setup)
+
+          assert :not_found =
+                   CheckpointStorageAdapter.get_checkpoint(
+                     {:missing, make_ref()},
+                     opts
+                   ),
+                 "checkpoint contract: missing get must return :not_found"
+        end
+
+        test "stores and retrieves a checkpoint" do
+          opts = unquote(setup)
+          key = {:roundtrip, make_ref()}
+          value = %{state: :saved, nested: [1, %{two: 2}]}
+
+          assert :ok = CheckpointStorageAdapter.put_checkpoint(key, value, opts),
+                 "checkpoint contract: put must return :ok"
+
+          assert {:ok, ^value} = CheckpointStorageAdapter.get_checkpoint(key, opts),
+                 "checkpoint contract: get must return the stored value"
+        end
+
+        test "overwrites a checkpoint for the same key" do
+          opts = unquote(setup)
+          key = {:overwrite, make_ref()}
+
+          assert :ok = CheckpointStorageAdapter.put_checkpoint(key, :first, opts),
+                 "checkpoint contract: initial put must return :ok"
+
+          assert :ok = CheckpointStorageAdapter.put_checkpoint(key, :second, opts),
+                 "checkpoint contract: overwrite put must return :ok"
+
+          assert {:ok, :second} = CheckpointStorageAdapter.get_checkpoint(key, opts),
+                 "checkpoint contract: latest value must replace the previous value"
+        end
+
+        test "preserves arbitrary term keys and values" do
+          opts = unquote(setup)
+
+          values = [
+            {"string", {:tuple, %{nested: [:term, 42]}}},
+            {{:tuple, 7, self()}, %MapSet{} |> MapSet.put(:value)},
+            {42, {:atom, [nil, false, %{binary: <<1, 2, 3>>}]}}
+          ]
+
+          Enum.each(values, fn {key, value} ->
+            assert :ok = CheckpointStorageAdapter.put_checkpoint(key, value, opts),
+                   "checkpoint contract: arbitrary term key #{inspect(key)} must be storable"
+
+            assert {:ok, ^value} = CheckpointStorageAdapter.get_checkpoint(key, opts),
+                   "checkpoint contract: arbitrary term key #{inspect(key)} must round-trip"
+          end)
+        end
+
+        test "deletes an existing checkpoint" do
+          opts = unquote(setup)
+          key = {:delete, make_ref()}
+
+          assert :ok = CheckpointStorageAdapter.put_checkpoint(key, :present, opts),
+                 "checkpoint contract: setup put must return :ok"
+
+          assert :ok = CheckpointStorageAdapter.delete_checkpoint(key, opts),
+                 "checkpoint contract: delete must return :ok"
+
+          assert :not_found = CheckpointStorageAdapter.get_checkpoint(key, opts),
+                 "checkpoint contract: deleted key must be missing"
+        end
+
+        test "deleting a missing checkpoint is idempotent" do
+          opts = unquote(setup)
+          key = {:delete_missing, make_ref()}
+
+          assert :ok = CheckpointStorageAdapter.delete_checkpoint(key, opts),
+                 "checkpoint contract: deleting a missing key must return :ok"
+
+          assert :ok = CheckpointStorageAdapter.delete_checkpoint(key, opts),
+                 "checkpoint contract: repeated delete must remain :ok"
+        end
+      end
+    end
+  end
+end

--- a/test/support/storage_thread_conformance.ex
+++ b/test/support/storage_thread_conformance.ex
@@ -1,0 +1,247 @@
+defmodule JidoTest.StorageThreadConformance do
+  @moduledoc """
+  Reusable ExUnit cases for the thread-journal half of `Jido.Storage`.
+
+  The caller supplies an adapter module and an option expression. The
+  expression is evaluated for every generated test, allowing adapters to
+  inject isolated tables, directories, or backend connections.
+
+  ## Example
+
+      use JidoTest.StorageThreadConformance,
+        adapter: Jido.Storage.ETS,
+        setup: quote do: [table: unique_table(:thread_conformance)]
+
+  The helper covers the shared journal contract. Adapter-specific lifecycle,
+  corruption, and backend failure tests belong in the adapter's own suite.
+  """
+
+  defmacro __using__(options) do
+    adapter = Keyword.fetch!(options, :adapter)
+
+    setup =
+      case Keyword.get(options, :setup, quote(do: [])) do
+        {:quote, _, [[do: expression]]} -> expression
+        expression -> expression
+      end
+
+    quote do
+      alias unquote(adapter), as: ThreadStorageAdapter
+
+      describe "thread journal storage conformance" do
+        test "returns :not_found when loading a missing thread" do
+          opts = unquote(setup)
+          thread_id = "missing_#{System.unique_integer([:positive])}"
+
+          assert :not_found = ThreadStorageAdapter.load_thread(thread_id, opts),
+                 "thread contract: missing load must return :not_found"
+        end
+
+        test "returns :not_found after an empty append" do
+          opts = unquote(setup)
+          thread_id = "empty_#{System.unique_integer([:positive])}"
+
+          assert {:ok, thread} = ThreadStorageAdapter.append_thread(thread_id, [], opts)
+          assert thread.entries == []
+          assert :not_found = ThreadStorageAdapter.load_thread(thread_id, opts)
+        end
+
+        test "creates a thread by appending entries" do
+          opts = unquote(setup)
+          thread_id = "create_#{System.unique_integer([:positive])}"
+          entries = [%{kind: :message, payload: %{content: "hello"}}]
+
+          assert {:ok, thread} = ThreadStorageAdapter.append_thread(thread_id, entries, opts),
+                 "thread contract: append must return the created thread"
+
+          assert thread.id == thread_id
+          assert thread.rev == 1
+          assert [%Jido.Thread.Entry{kind: :message}] = thread.entries
+        end
+
+        test "preserves append ordering and assigns contiguous sequences" do
+          opts = unquote(setup)
+          thread_id = "ordering_#{System.unique_integer([:positive])}"
+
+          first = [%{kind: :note, payload: %{n: 1}}, %{kind: :note, payload: %{n: 2}}]
+          second = [%{kind: :note, payload: %{n: 3}}]
+
+          assert {:ok, initial} = ThreadStorageAdapter.append_thread(thread_id, first, opts)
+          assert {:ok, _} = ThreadStorageAdapter.append_thread(thread_id, second, opts)
+          assert {:ok, thread} = ThreadStorageAdapter.load_thread(thread_id, opts)
+
+          assert Enum.map(thread.entries, & &1.payload.n) == [1, 2, 3]
+          assert Enum.map(thread.entries, & &1.seq) == [0, 1, 2]
+          assert Enum.take(thread.entries, 2) == initial.entries
+        end
+
+        test "preserves metadata from creation through later appends and load" do
+          opts = unquote(setup)
+          thread_id = "metadata_#{System.unique_integer([:positive])}"
+          metadata = %{account_id: "acct-1", source: :test}
+
+          assert {:ok, created} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}],
+                     Keyword.put(opts, :metadata, metadata)
+                   )
+
+          assert created.metadata == metadata
+
+          assert {:ok, appended} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          assert appended.metadata == metadata
+          assert {:ok, loaded} = ThreadStorageAdapter.load_thread(thread_id, opts)
+          assert loaded.metadata == metadata
+        end
+
+        test "increments revision by the number of appended entries" do
+          opts = unquote(setup)
+          thread_id = "revision_#{System.unique_integer([:positive])}"
+
+          assert {:ok, first} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}, %{kind: :note}],
+                     opts
+                   )
+
+          assert first.rev == 2
+
+          assert {:ok, second} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}, %{kind: :note}, %{kind: :note}],
+                     opts
+                   )
+
+          assert second.rev == 5
+          assert {:ok, loaded} = ThreadStorageAdapter.load_thread(thread_id, opts)
+          assert loaded.rev == 5
+        end
+
+        test "normalizes maps and preserves Entry structs" do
+          opts = unquote(setup)
+          thread_id = "normalization_#{System.unique_integer([:positive])}"
+          entry = Jido.Thread.Entry.new(kind: :tool_result, payload: %{ok: true})
+
+          assert {:ok, thread} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :message, payload: %{content: "map"}}, entry],
+                     opts
+                   )
+
+          assert Enum.all?(thread.entries, &match?(%Jido.Thread.Entry{}, &1))
+          assert Enum.map(thread.entries, & &1.seq) == [0, 1]
+          assert Enum.map(thread.entries, & &1.id) |> Enum.all?(&is_binary/1)
+        end
+
+        test "assigns entry and thread timestamps" do
+          opts = unquote(setup)
+          thread_id = "timestamps_#{System.unique_integer([:positive])}"
+          before = System.system_time(:millisecond)
+
+          assert {:ok, created} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          after_create = System.system_time(:millisecond)
+          entry = hd(created.entries)
+
+          assert is_integer(entry.at) and entry.at in before..after_create
+          assert is_integer(created.created_at) and created.created_at in before..after_create
+          assert is_integer(created.updated_at) and created.updated_at >= created.created_at
+
+          assert {:ok, updated} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          assert updated.created_at == created.created_at
+          assert updated.updated_at >= created.updated_at
+        end
+
+        test "reports entry count in stats" do
+          opts = unquote(setup)
+          thread_id = "stats_#{System.unique_integer([:positive])}"
+
+          assert {:ok, thread} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}, %{kind: :note}, %{kind: :note}],
+                     opts
+                   )
+
+          assert thread.stats.entry_count == 3
+          assert {:ok, loaded} = ThreadStorageAdapter.load_thread(thread_id, opts)
+          assert loaded.stats.entry_count == 3
+        end
+
+        test "accepts a matching expected revision" do
+          opts = unquote(setup)
+          thread_id = "expected_match_#{System.unique_integer([:positive])}"
+
+          assert {:ok, first} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          assert {:ok, second} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}],
+                     Keyword.put(opts, :expected_rev, first.rev)
+                   )
+
+          assert second.rev == 2
+        end
+
+        test "accepts expected revision zero when creating a thread" do
+          opts = unquote(setup)
+          thread_id = "expected_create_#{System.unique_integer([:positive])}"
+
+          assert {:ok, thread} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note}],
+                     Keyword.put(opts, :expected_rev, 0)
+                   )
+
+          assert thread.rev == 1
+        end
+
+        test "rejects a stale expected revision without changing the journal" do
+          opts = unquote(setup)
+          thread_id = "expected_stale_#{System.unique_integer([:positive])}"
+
+          assert {:ok, before} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          assert {:error, :conflict} =
+                   ThreadStorageAdapter.append_thread(
+                     thread_id,
+                     [%{kind: :note, payload: %{must_not: :persist}}],
+                     Keyword.put(opts, :expected_rev, 0)
+                   )
+
+          assert {:ok, after_conflict} = ThreadStorageAdapter.load_thread(thread_id, opts)
+          assert after_conflict.rev == before.rev
+          assert after_conflict.entries == before.entries
+        end
+
+        test "deleting a thread is idempotent" do
+          opts = unquote(setup)
+          thread_id = "delete_#{System.unique_integer([:positive])}"
+
+          assert {:ok, _} = ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+          assert :ok = ThreadStorageAdapter.delete_thread(thread_id, opts)
+          assert :not_found = ThreadStorageAdapter.load_thread(thread_id, opts)
+          assert :ok = ThreadStorageAdapter.delete_thread(thread_id, opts)
+
+          assert {:ok, recreated} =
+                   ThreadStorageAdapter.append_thread(thread_id, [%{kind: :note}], opts)
+
+          assert recreated.metadata == %{}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- add reusable checkpoint and thread-journal conformance suites
- exercise the shared contract against ETS and File
- define map and Entry inputs explicitly
- fix File creation metadata and empty-thread load semantics
- document adoption for third-party adapters

## Validation

- `mix test test/jido/storage` — 137 tests, 0 failures
- `mix quality` — passed, including Credo and Dialyzer

## Follow-up

A separate draft Jido Ecto PR will adopt these helpers at this exact commit SHA and add PostgreSQL concurrency coverage.

This PR is intentionally draft for author review. No maintainer review is requested yet.