### PR TITLE
ci: migrate Linux jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5
     secrets: inherit
     with:
+      runner: blacksmith-2vcpu-ubuntu-2404
       credo_command: mix credo --min-priority higher
       docs_command: mix docs -f html
       test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     name: Release
     uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5
     with:
+      runner: blacksmith-2vcpu-ubuntu-2404
       operation: ${{ inputs.operation || 'auto' }}
       tag_name: ${{ inputs.tag_name || '' }}
       dry_run: ${{ inputs.dry_run || false }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,3 +19,5 @@ jobs:
   review:
     name: Jido Review
     uses: agentjido/github-actions/.github/workflows/jido-review.yml@v5
+    with:
+      runner: blacksmith-2vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary

- route all shared CI jobs to `blacksmith-2vcpu-ubuntu-2404`
- route the review job to the same Blacksmith runner
- route the release job to the same Blacksmith runner
- preserve workflow triggers, matrices, permissions, secrets, gates, caches, and action versions

## Audit

- CI: all 17 underlying Linux job definitions migrate through the shared runner input
- Review: the Linux review job migrates; its pull request and issue permissions are unchanged
- Release: the Linux release job migrates; its write permissions, Hex secret, concurrency, and release gates are unchanged
- no macOS, Windows, ARM, self-hosted, service-container, or deployment-environment jobs exist

## Validation

- Ruby YAML parse for all workflow files
- `actionlint`
- `git diff --check`
- exact three-file scope check
- `mix deps.get` and `mix compile` completed to satisfy the repository commit hook

Refs: jido-s20

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790633067&installation_model_id=434874&pr_number=328&repository=agentjido%2Fjido&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido%2Fpull%2F328&signature=1ab6ba4619ef88ae4701400a2053fa41e2be90bcf0119391b7a4da15a4b4a42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->