### PR TITLE
docs: fix signal routing guide examples

### DIFF
--- a/guides/getting-started.livemd
+++ b/guides/getting-started.livemd
@@ -116,13 +116,42 @@ Key points:
 - Actions may be pure or effectful when they need a result back now
 - Directives describe runtime-owned effects and never modify state
 
-## Step 4: Handle Signals with AgentServer
+## Step 4: Route Signals with AgentServer
 
 For real applications, agents run inside AgentServer - a GenServer that handles signals and executes directives.
 
-First, let's add signal handling to our agent:
+AgentServer routes each signal type to an Action. We already have
+`IncrementAction`, so define the other counter actions and declare the complete
+signal routes on the agent:
 
 ```elixir
+defmodule DecrementAction do
+  use Jido.Action,
+    name: "decrement",
+    description: "Decrements the counter by a given amount",
+    schema: [
+      amount: [type: :integer, default: 1]
+    ]
+
+  @impl true
+  def run(params, context) do
+    current = context.state[:count] || 0
+    {:ok, %{count: current - params.amount}}
+  end
+end
+
+defmodule ResetAction do
+  use Jido.Action,
+    name: "reset",
+    description: "Resets the counter to zero",
+    schema: []
+
+  @impl true
+  def run(_params, _context) do
+    {:ok, %{count: 0}}
+  end
+end
+
 defmodule CounterAgentWithSignals do
   use Jido.Agent,
     name: "counter_with_signals",
@@ -130,31 +159,12 @@ defmodule CounterAgentWithSignals do
     schema: [
       count: [type: :integer, default: 0],
       status: [type: :atom, default: :idle]
+    ],
+    signal_routes: [
+      {"counter.increment", IncrementAction},
+      {"counter.decrement", DecrementAction},
+      {"counter.reset", ResetAction}
     ]
-
-  alias Jido.Signal
-
-  @impl true
-  def handle_signal(agent, %Signal{type: "counter.increment"} = signal) do
-    amount = signal.data[:amount] || 1
-    current = agent.state[:count]
-    {:ok, agent} = set(agent, count: current + amount)
-    {agent, []}
-  end
-
-  def handle_signal(agent, %Signal{type: "counter.decrement"} = signal) do
-    amount = signal.data[:amount] || 1
-    current = agent.state[:count]
-    {:ok, agent} = set(agent, count: current - amount)
-    {agent, []}
-  end
-
-  def handle_signal(agent, %Signal{type: "counter.reset"}) do
-    {:ok, agent} = set(agent, count: 0)
-    {agent, []}
-  end
-
-  def handle_signal(agent, _signal), do: {agent, []}
 end
 ```
 

--- a/guides/plugins.md
+++ b/guides/plugins.md
@@ -28,10 +28,9 @@ defmodule MyApp.ChatPlugin do
       messages: Zoi.list(Zoi.any()) |> Zoi.default([]),
       model: Zoi.string() |> Zoi.default("gpt-4")
     }),
-    signal_patterns: ["chat.*"],
     signal_routes: [
-      {"chat.send", MyApp.Actions.SendMessage},
-      {"chat.history", MyApp.Actions.ListHistory}
+      {"send", MyApp.Actions.SendMessage},
+      {"history", MyApp.Actions.ListHistory}
     ]
 end
 ```
@@ -51,8 +50,8 @@ end
 | `description` | Human-readable description |
 | `schema` | Zoi schema for plugin state defaults |
 | `config_schema` | Zoi schema for per-agent configuration |
-| `signal_patterns` | List of signal patterns for routing |
-| `signal_routes` | Static signal route tuples (`{"type", Action}`) |
+| `signal_patterns` | Patterns that select which signals run plugin signal hooks |
+| `signal_routes` | Static routes relative to the plugin's route prefix |
 | `category`, `vsn`, `tags` | Metadata for organization |
 
 ## Using Plugins
@@ -147,11 +146,14 @@ defmodule MyApp.ChatPlugin do
     state_key: :chat,
     actions: [MyApp.Actions.SendMessage, MyApp.Actions.ListHistory],
     signal_routes: [
-      {"chat.send", MyApp.Actions.SendMessage},
-      {"chat.history", MyApp.Actions.ListHistory}
+      {"send", MyApp.Actions.SendMessage},
+      {"history", MyApp.Actions.ListHistory}
     ]
 end
 ```
+
+Static plugin routes are relative to the plugin's route prefix. For this
+plugin, Jido expands `"send"` to `"chat.send"`.
 
 Use the `signal_routes/1` callback only when routes must be computed from runtime config.
 

--- a/guides/signals.md
+++ b/guides/signals.md
@@ -128,9 +128,10 @@ defmodule MyStrategy do
 end
 ```
 
-### Plugin Signal Patterns
+### Plugin Signal Patterns and Routes
 
-Plugins use `signal_patterns` to declare which signals they handle:
+Plugins use `signal_patterns` to select which inbound signals run their signal
+hooks. Compile-time `signal_routes` map relative paths to Actions:
 
 ```elixir
 defmodule MyApp.ChatPlugin do
@@ -140,11 +141,14 @@ defmodule MyApp.ChatPlugin do
     actions: [MyApp.Actions.SendMessage, MyApp.Actions.ClearHistory],
     signal_patterns: ["chat.*"],
     signal_routes: [
-      {"chat.send", MyApp.Actions.SendMessage},
-      {"chat.clear", MyApp.Actions.ClearHistory}
+      {"send", MyApp.Actions.SendMessage},
+      {"clear", MyApp.Actions.ClearHistory}
     ]
 end
 ```
+
+Jido prefixes each static plugin route with the plugin route prefix. Here,
+`"send"` becomes `"chat.send"` and `"clear"` becomes `"chat.clear"`.
 
 Pattern matching:
 - `"chat.*"` — matches `chat.message`, `chat.clear`, etc.

--- a/guides/your-first-plugin.md
+++ b/guides/your-first-plugin.md
@@ -16,8 +16,7 @@ defmodule MyApp.CounterPlugin do
       value: Zoi.integer() |> Zoi.default(0),
       last_updated: Zoi.any() |> Zoi.optional()
     }),
-    signal_patterns: ["counter.*"],
-    signal_routes: [{"counter.increment", MyApp.IncrementAction}]
+    signal_routes: [{"increment", MyApp.IncrementAction}]
 end
 ```
 
@@ -85,8 +84,7 @@ defmodule MyApp.CounterPlugin do
       value: Zoi.integer() |> Zoi.default(0),
       last_updated: Zoi.any() |> Zoi.optional()
     }),
-    signal_patterns: ["counter.*"],
-    signal_routes: [{"counter.increment", MyApp.IncrementAction}]
+    signal_routes: [{"increment", MyApp.IncrementAction}]
 end
 ```
 
@@ -103,8 +101,8 @@ end
 | Option | Description |
 |--------|-------------|
 | `schema` | Zoi schema for plugin state with defaults |
-| `signal_patterns` | Patterns this plugin handles (e.g., `"counter.*"`) |
-| `signal_routes` | Static signal route tuples (`{"type", Action}`) |
+| `signal_patterns` | Patterns that select which signals run the plugin's signal hooks |
+| `signal_routes` | Static routes relative to the plugin's route prefix |
 
 ### Step 3: Attach to an Agent
 
@@ -164,10 +162,14 @@ use Jido.Plugin,
   state_key: :counter,
   actions: [MyApp.IncrementAction, MyApp.ResetAction],
   signal_routes: [
-    {"counter.increment", MyApp.IncrementAction},
-    {"counter.reset", MyApp.ResetAction}
+    {"increment", MyApp.IncrementAction},
+    {"reset", MyApp.ResetAction}
   ]
 ```
+
+Static plugin routes are relative to the plugin's route prefix. A plugin named
+`"counter"` expands `"increment"` to `"counter.increment"`. Do not repeat the
+plugin name in a static route.
 
 Use `signal_routes/1` only for dynamic routes that depend on config.
 

--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -31,10 +31,9 @@ defmodule Jido.Plugin do
             messages: Zoi.list(Zoi.any()) |> Zoi.default([]),
             model: Zoi.string() |> Zoi.default("gpt-4")
           }),
-          signal_patterns: ["chat.*"],
           signal_routes: [
-            {"chat.send", MyApp.Actions.SendMessage},
-            {"chat.history", MyApp.Actions.ListHistory}
+            {"send", MyApp.Actions.SendMessage},
+            {"history", MyApp.Actions.ListHistory}
           ]
 
         @impl Jido.Plugin
@@ -65,11 +64,11 @@ defmodule Jido.Plugin do
   - `vsn` - Optional version string.
   - `schema` - Optional Zoi schema for plugin state.
   - `config_schema` - Optional Zoi schema for per-agent config.
-  - `signal_patterns` - List of signal pattern strings (default: []).
+  - `signal_patterns` - Patterns that select which inbound signals run plugin signal hooks (default: []).
   - `tags` - List of tag strings (default: []).
   - `capabilities` - List of atoms describing what the plugin provides (default: []).
   - `requires` - List of requirements like `{:config, :token}`, `{:app, :req}`, `{:plugin, :http}` (default: []).
-  - `signal_routes` - List of signal route tuples like `{"post", ActionModule}` (default: []).
+  - `signal_routes` - Static routes relative to the plugin route prefix, such as `{"post", ActionModule}` (default: []).
   - `subscriptions` - List of sensor subscription tuples like `{SensorModule, config}` or `{tag, SensorModule, config}` (default: []).
   - `schedules` - List of schedule tuples like `{"*/5 * * * *", ActionModule}` (default: []).
 
@@ -115,7 +114,9 @@ defmodule Jido.Plugin do
                               Zoi.any(description: "Zoi schema for per-agent configuration.")
                               |> Zoi.optional(),
                             signal_patterns:
-                              Zoi.list(Zoi.string(), description: "Signal patterns for routing.")
+                              Zoi.list(Zoi.string(),
+                                description: "Patterns that select inbound plugin signal hooks."
+                              )
                               |> Zoi.default([]),
                             tags:
                               Zoi.list(Zoi.string(), description: "Tags for categorization.")
@@ -133,7 +134,8 @@ defmodule Jido.Plugin do
                               |> Zoi.default([]),
                             signal_routes:
                               Zoi.list(Zoi.any(),
-                                description: "Signal route tuples like {\"post\", ActionModule}."
+                                description:
+                                  "Static routes relative to the plugin route prefix, such as {\"post\", ActionModule}."
                               )
                               |> Zoi.default([]),
                             subscriptions:

--- a/lib/jido/plugin/manifest.ex
+++ b/lib/jido/plugin/manifest.ex
@@ -21,9 +21,9 @@ defmodule Jido.Plugin.Manifest do
   - `schema` - Zoi schema for plugin state
   - `config_schema` - Zoi schema for per-agent config
   - `actions` - List of action modules
-  - `signal_routes` - List of signal route tuples like `{"post", ActionModule}`
+  - `signal_routes` - Static routes relative to the plugin route prefix, such as `{"post", ActionModule}`
   - `schedules` - List of schedule tuples like `{"*/5 * * * *", ActionModule}`
-  - `signal_patterns` - Legacy signal patterns for routing
+  - `signal_patterns` - Patterns that gate inbound signal hooks and support legacy route fallback
   - `subscriptions` - Sensor subscriptions provided by this plugin
   """
 
@@ -53,7 +53,8 @@ defmodule Jido.Plugin.Manifest do
                 Zoi.list(Zoi.atom(), description: "List of action modules") |> Zoi.default([]),
               signal_routes:
                 Zoi.list(Zoi.any(),
-                  description: "Signal route tuples like {\"post\", ActionModule}"
+                  description:
+                    "Static routes relative to the plugin route prefix, such as {\"post\", ActionModule}"
                 )
                 |> Zoi.default([]),
               schedules:
@@ -62,7 +63,9 @@ defmodule Jido.Plugin.Manifest do
                 )
                 |> Zoi.default([]),
               signal_patterns:
-                Zoi.list(Zoi.string(), description: "Legacy signal patterns")
+                Zoi.list(Zoi.string(),
+                  description: "Inbound hook patterns and legacy route fallback patterns"
+                )
                 |> Zoi.default([]),
               singleton:
                 Zoi.boolean(description: "Whether plugin is singleton")

--- a/test/jido/docs_routing_guides_test.exs
+++ b/test/jido/docs_routing_guides_test.exs
@@ -1,0 +1,129 @@
+defmodule Jido.DocsRoutingGuidesTest do
+  use JidoTest.Case, async: true
+
+  alias Jido.AgentServer
+  alias Jido.Signal
+
+  defmodule IncrementAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "docs_increment",
+      schema: [amount: [type: :integer, default: 1]]
+
+    @impl true
+    def run(params, context) do
+      current = context.state[:count] || 0
+      {:ok, %{count: current + params.amount}}
+    end
+  end
+
+  defmodule DecrementAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "docs_decrement",
+      schema: [amount: [type: :integer, default: 1]]
+
+    @impl true
+    def run(params, context) do
+      current = context.state[:count] || 0
+      {:ok, %{count: current - params.amount}}
+    end
+  end
+
+  defmodule ResetAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "docs_reset",
+      schema: []
+
+    @impl true
+    def run(_params, _context), do: {:ok, %{count: 0}}
+  end
+
+  defmodule CounterAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "docs_counter_agent",
+      schema: [count: [type: :integer, default: 0]],
+      signal_routes: [
+        {"counter.increment", Jido.DocsRoutingGuidesTest.IncrementAction},
+        {"counter.decrement", Jido.DocsRoutingGuidesTest.DecrementAction},
+        {"counter.reset", Jido.DocsRoutingGuidesTest.ResetAction}
+      ]
+  end
+
+  defmodule PluginIncrementAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "docs_plugin_increment",
+      schema: Zoi.object(%{amount: Zoi.integer() |> Zoi.default(1)})
+
+    @impl true
+    def run(%{amount: amount}, %{state: state}) do
+      current = get_in(state, [:counter, :value]) || 0
+
+      {:ok, %{},
+       [
+         %Jido.Agent.StateOp.SetPath{path: [:counter, :value], value: current + amount}
+       ]}
+    end
+  end
+
+  defmodule CounterPlugin do
+    @moduledoc false
+    use Jido.Plugin,
+      name: "counter",
+      state_key: :counter,
+      actions: [Jido.DocsRoutingGuidesTest.PluginIncrementAction],
+      schema: Zoi.object(%{value: Zoi.integer() |> Zoi.default(0)}),
+      signal_routes: [
+        {"increment", Jido.DocsRoutingGuidesTest.PluginIncrementAction}
+      ]
+  end
+
+  defmodule PluginAgent do
+    @moduledoc false
+    use Jido.Agent,
+      name: "docs_plugin_agent",
+      plugins: [Jido.DocsRoutingGuidesTest.CounterPlugin]
+  end
+
+  test "Getting Started agent routes complete signal types to Actions", %{jido: jido} do
+    {:ok, pid} = Jido.start_agent(jido, CounterAgent, id: unique_id("docs-counter"))
+
+    {:ok, agent} =
+      AgentServer.call(
+        pid,
+        Signal.new!("counter.increment", %{amount: 10}, source: "/test")
+      )
+
+    assert agent.state.count == 10
+
+    {:ok, agent} =
+      AgentServer.call(
+        pid,
+        Signal.new!("counter.decrement", %{amount: 3}, source: "/test")
+      )
+
+    assert agent.state.count == 7
+
+    :ok = AgentServer.cast(pid, Signal.new!("counter.reset", %{}, source: "/test"))
+
+    state = eventually_state(pid, fn state -> state.agent.state.count == 0 end)
+    assert state.agent.state.count == 0
+  end
+
+  test "Your First Plugin expands relative static routes", %{jido: jido} do
+    assert {"counter.increment", PluginIncrementAction, -10} in PluginAgent.plugin_routes()
+
+    {:ok, pid} = Jido.start_agent(jido, PluginAgent, id: unique_id("docs-plugin"))
+
+    {:ok, agent} =
+      AgentServer.call(
+        pid,
+        Signal.new!("counter.increment", %{amount: 5}, source: "/test")
+      )
+
+    assert agent.state.counter.value == 5
+  end
+end


### PR DESCRIPTION
## Summary

- replace the obsolete Agent `handle_signal/2` Quick Start example with Action-based `signal_routes`
- correct compile-time plugin routes so paths are relative to the plugin route prefix
- clarify the separate purpose of `signal_patterns` in the plugin guides and module documentation
- add runtime regression tests for both reported guide flows

## Validation

- `mix test test/jido/docs_routing_guides_test.exs test/jido/plugin/routes_test.exs test/jido/docs_examples_test.exs` (23 passed)
- `mix test` (2,211 passed, 187 excluded)
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix docs`
- `mix q`

Closes #329
Closes #330

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685877&installation_model_id=434874&pr_number=333&repository=agentjido%2Fjido&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido%2Fpull%2F333&signature=c4bff12effb2aaecf9e287f4028b1fed43dec31bd7e14e4b6be80fa9d470c07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->