### PR TITLE
fix(error): preserve validation paths in transport

### DIFF
--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -516,6 +516,13 @@ defmodule Jido.Error do
 
   The returned map is suitable for transport and reporting boundaries. It
   includes bounded, sanitized details and never includes stacktraces by default.
+
+  Details traverse at most #{@transport_max_depth} container levels, with up to
+  #{@transport_max_items} entries per map or list. Scalar leaves are kept at the
+  depth limit, so validation paths retain field names and list indexes. Strings
+  are limited to #{@transport_max_string} characters plus a truncation suffix.
+  Invalid UTF-8 binaries use bounded inspection.
+  Deeper containers and opaque terms are replaced with `#{@depth_limit}`.
   """
   @spec to_map(any()) :: map()
   def to_map(error) do
@@ -713,12 +720,16 @@ defmodule Jido.Error do
   end
 
   defp sanitize_transport(value, depth \\ @transport_max_depth)
-  defp sanitize_transport(_value, 0), do: @depth_limit
-  defp sanitize_transport(value, _depth) when is_binary(value), do: truncate_string(value)
+
+  defp sanitize_transport(value, _depth) when is_binary(value) do
+    if String.valid?(value), do: truncate_string(value), else: safe_inspect(value)
+  end
 
   defp sanitize_transport(value, _depth)
        when is_boolean(value) or is_number(value) or is_atom(value),
        do: value
+
+  defp sanitize_transport(_value, 0), do: @depth_limit
 
   defp sanitize_transport(%_{} = value, _depth) when is_exception(value) do
     %{

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -7,6 +7,18 @@ defmodule JidoTest.ErrorTest do
     defstruct [:token]
   end
 
+  defmodule ValidationAction do
+    use Jido.Action,
+      name: "error_transport_validation",
+      schema:
+        Zoi.object(%{
+          name: Zoi.string(),
+          users: Zoi.list(Zoi.object(%{name: Zoi.string()}))
+        })
+
+    def run(params, _context), do: {:ok, params}
+  end
+
   describe "validation_error/2" do
     test "creates a validation error with message" do
       error = Error.validation_error("Invalid input")
@@ -305,6 +317,101 @@ defmodule JidoTest.ErrorTest do
       refute inspect(result.details) =~ "keyword-secret"
       assert result.details.bad.token == "[REDACTED]"
       assert Jason.encode!(result)
+    end
+
+    test "preserves field names and indexes in validation paths" do
+      for path <- [[:name], ["name"], [:users, 0, :name], ["users", 19, "name"]] do
+        details = %{errors: [%{code: :required, message: "is required", path: path}]}
+
+        for error <- [
+              Error.validation_error("Invalid", details: details),
+              Jido.Action.Error.validation_error("Invalid", details)
+            ] do
+          assert Error.to_map(error).details.errors == details.errors
+        end
+      end
+    end
+
+    test "preserves real Zoi validation paths through execution and JSON transport" do
+      for {params, path} <- [
+            {%{users: []}, [:name]},
+            {%{name: "example", users: [%{name: 123}]}, [:users, 0, :name]}
+          ] do
+        assert {:error, %Jido.Action.Error.InvalidInputError{} = error} =
+                 Jido.Exec.run(ValidationAction, params)
+
+        assert [%{path: ^path}] = error.details.errors
+        result = Error.to_map(error)
+        assert result.details.errors == Jido.Action.Error.to_map(error).details.errors
+        assert Jido.Observe.exception_metadata(:error, error).error == result
+
+        encoded_path =
+          Enum.map(path, fn part -> if is_atom(part), do: to_string(part), else: part end)
+
+        decoded = result |> Jason.encode!() |> Jason.decode!()
+        assert [%{"path" => ^encoded_path}] = decoded["details"]["errors"]
+      end
+    end
+
+    test "preserves scalar leaves at the container depth limit" do
+      values = [nil, true, false, :field, 42, 1.5, "field"]
+      error = Error.execution_error("Failed", details: %{a: %{b: %{c: values}}})
+
+      assert Error.to_map(error).details.a.b.c == values
+    end
+
+    test "keeps invalid binary leaves safe for JSON transport" do
+      error = Error.execution_error("Failed", details: %{a: %{b: %{c: [<<255>>]}}})
+      result = Error.to_map(error)
+
+      assert result.details.a.b.c == ["<<255>>"]
+      assert Jason.encode!(result)
+
+      metadata = Jido.Observe.exception_metadata(:error, error)
+      assert metadata.error == result
+      assert Jason.encode!(metadata)
+    end
+
+    test "still stops containers and opaque terms at the depth limit" do
+      values = [%{value: "hidden"}, ["hidden"], %BadInspect{token: "hidden"}, {:value, "hidden"}]
+      error = Error.execution_error("Failed", details: %{a: %{b: %{c: values}}})
+
+      assert Error.to_map(error).details.a.b.c == List.duplicate("[DEPTH_LIMIT]", 4)
+    end
+
+    test "still redacts and truncates values at the depth limit" do
+      leaf = %{
+        password: "hidden-password",
+        accessToken: "hidden-token",
+        stackTrace: [{__MODULE__, :test, 0, []}],
+        text: String.duplicate("x", 700),
+        nested: %{value: "hidden"}
+      }
+
+      error = Error.execution_error("Failed", details: %{a: [%{b: leaf}]})
+      result = Error.to_map(error)
+
+      assert result.details.a == [
+               %{
+                 b: %{
+                   password: "[REDACTED]",
+                   accessToken: "[REDACTED]",
+                   stackTrace: "[OMITTED]",
+                   text: String.duplicate("x", 512) <> "...(truncated)",
+                   nested: "[DEPTH_LIMIT]"
+                 }
+               }
+             ]
+
+      refute Jason.encode!(result) =~ "hidden"
+    end
+
+    test "still bounds validation error counts and path lengths" do
+      errors = List.duplicate(%{path: Enum.to_list(0..24)}, 25)
+      error = Error.validation_error("Invalid", details: %{errors: errors})
+      result = Error.to_map(error)
+
+      assert result.details.errors == List.duplicate(%{path: Enum.to_list(0..19)}, 20)
     end
 
     test "handles foreign exceptions without leaking stacktraces" do

--- a/test/jido/error_test.exs
+++ b/test/jido/error_test.exs
@@ -372,6 +372,27 @@ defmodule JidoTest.ErrorTest do
       assert Jason.encode!(metadata)
     end
 
+    test "bounds long invalid binaries and redacts them under sensitive keys" do
+      for value <- [
+            :binary.copy(<<255>>, 2048),
+            String.duplicate("x", 700) <> <<255>>,
+            <<255>> <> String.duplicate("x", 700)
+          ] do
+        leaf = %{value: value, password: value}
+        error = Error.execution_error("Failed", details: %{a: %{b: %{c: leaf}}})
+        result = Error.to_map(error)
+
+        assert result.details.a.b.c.password == "[REDACTED]"
+        assert String.valid?(result.details.a.b.c.value)
+        assert String.length(result.details.a.b.c.value) <= 512 + String.length("...(truncated)")
+        assert Jason.encode!(result)
+
+        metadata = Jido.Observe.exception_metadata(:error, error)
+        assert metadata.error == result
+        assert Jason.encode!(metadata)
+      end
+    end
+
     test "still stops containers and opaque terms at the depth limit" do
       values = [%{value: "hidden"}, ["hidden"], %BadInspect{token: "hidden"}, {:value, "hidden"}]
       error = Error.execution_error("Failed", details: %{a: %{b: %{c: values}}})


### PR DESCRIPTION
## Description

This is the core error-reporting part of the validation-error work. The input-validation change is already merged in Jido Action.

Validation errors now keep field names and list indexes when core serializes them for callers and telemetry. A path such as `[:name]` no longer becomes `["[DEPTH_LIMIT]"]`. Container depth, item counts, string length, and sensitive-field redaction remain bounded. Invalid UTF-8 binary details use bounded inspection so they do not break JSON encoding.

No dependency update is needed.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None. This restores useful scalar values at the existing container depth limit.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Verified with Elixir 1.19.5 and Erlang/OTP 28.5:

- Focused error and telemetry tests: **140 tests, 0 failures**.
- `mix coveralls --include flaky`: **2,218 tests, 0 failures**, 187 excluded; **81.9% coverage**.
- `mix quality` and `mix docs --no-open`: passed.
- Real Zoi errors from `Jido.Exec.run/4` retain top-level and nested list paths through the public error map, JSON, and telemetry.
- Regression tests failed before each correction. Safety tests cover depth, item and string limits, redaction, stacktrace omission, and invalid binary details.
- Code review completed. Its one validated finding was fixed and tested.
- Supplemental strict Credo found one existing complexity warning in unchanged `extract_retry_hint/1`. The configured quality check passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #335

Related: agentjido/jido_action#222

## Post-Deploy Monitoring & Validation

- Owner and window: the release maintainer, during the first 24 hours after a consuming application upgrades.
- Check validation-error logs and telemetry at `error.details.errors[].path`. Expected: field names and list indexes remain visible; sensitive fields stay redacted.
- Search error logs for `Jason.EncodeError` and unexpected `[DEPTH_LIMIT]` path elements. Watch the application's error-serialization failure count.
- If ordinary paths are lost, sensitive values appear, or serialization failures increase, stop the rollout and restore the previous Jido version.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791116301&installation_model_id=434874&pr_number=336&repository=agentjido%2Fjido&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido%2Fpull%2F336&signature=bb48ce73c05b9880b51383458f935e215f025134286a4278f9d565a4ac16890d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->