### PR TITLE
refactor(util): reuse validation and registry setup

### DIFF
--- a/lib/jido/util.ex
+++ b/lib/jido/util.ex
@@ -78,24 +78,12 @@ defmodule Jido.Util do
     end
   end
 
-  def validate_name(name, _opts) when is_binary(name) do
-    if Regex.match?(@name_regex, name) do
-      :ok
-    else
-      {:error,
-       Jido.Error.validation_error(
-         "The name must start with a letter and contain only letters, numbers, and underscores.",
-         field: :name
-       )}
-    end
-  end
-
   def validate_name(_, []) do
     {:error, Jido.Error.validation_error("Invalid name format.", field: :name)}
   end
 
-  def validate_name(_, _opts) do
-    {:error, Jido.Error.validation_error("Invalid name format.", field: :name)}
+  def validate_name(name, _opts) do
+    with {:ok, _name} <- validate_name(name, []), do: :ok
   end
 
   @doc """
@@ -148,18 +136,6 @@ defmodule Jido.Util do
     end
   end
 
-  def validate_actions(actions, _opts) when is_list(actions) do
-    if Enum.all?(actions, &implements_action?/1) do
-      :ok
-    else
-      {:error,
-       Jido.Error.validation_error("All actions must implement the Jido.Action behavior",
-         kind: :action,
-         subject: actions
-       )}
-    end
-  end
-
   def validate_actions(action, []) when is_atom(action) do
     if implements_action?(action) do
       {:ok, action}
@@ -172,16 +148,8 @@ defmodule Jido.Util do
     end
   end
 
-  def validate_actions(action, _opts) when is_atom(action) do
-    if implements_action?(action) do
-      :ok
-    else
-      {:error,
-       Jido.Error.validation_error("All actions must implement the Jido.Action behavior",
-         kind: :action,
-         subject: action
-       )}
-    end
+  def validate_actions(actions, _opts) when is_list(actions) or is_atom(actions) do
+    with {:ok, _actions} <- validate_actions(actions, []), do: :ok
   end
 
   defp implements_action?(module) when is_atom(module) do

--- a/lib/jido/util.ex
+++ b/lib/jido/util.ex
@@ -320,21 +320,8 @@ defmodule Jido.Util do
 
   def whereis(pid, _opts) when is_pid(pid), do: {:ok, pid}
 
-  def whereis({name, registry}, _opts) when is_atom(registry) do
-    name = if is_atom(name), do: Atom.to_string(name), else: name
-
-    case Registry.lookup(registry, name) do
-      [{pid, _}] -> {:ok, pid}
-      [] -> {:error, :not_found}
-    end
-  end
-
   def whereis(name, opts) do
-    registry =
-      Keyword.get(opts, :registry) ||
-        raise ArgumentError, ":registry option is required"
-
-    name = if is_atom(name), do: Atom.to_string(name), else: name
+    {:via, Registry, {registry, name}} = via_tuple(name, opts)
 
     case Registry.lookup(registry, name) do
       [{pid, _}] -> {:ok, pid}

--- a/test/jido/util_test.exs
+++ b/test/jido/util_test.exs
@@ -83,27 +83,33 @@ defmodule JidoTest.UtilTest do
     test "preserves complete validation errors across option forms" do
       for opts <- [[], [validate: true], :ignored] do
         for name <- ["", "1invalid", "invalid-name"] do
-          assert Util.validate_name(name, opts) ==
-                   {:error,
-                    Jido.Error.validation_error(
-                      "The name must start with a letter and contain only letters, numbers, and underscores.",
-                      field: :name
-                    )}
+          assert_validation_error(
+            Util.validate_name(name, opts),
+            {:error,
+             Jido.Error.validation_error(
+               "The name must start with a letter and contain only letters, numbers, and underscores.",
+               field: :name
+             )}
+          )
         end
 
         for name <- [nil, :name, 42, [], %{}] do
-          assert Util.validate_name(name, opts) ==
-                   {:error, Jido.Error.validation_error("Invalid name format.", field: :name)}
+          assert_validation_error(
+            Util.validate_name(name, opts),
+            {:error, Jido.Error.validation_error("Invalid name format.", field: :name)}
+          )
         end
 
         for actions <- [Enum, NonExistentModule, [TestActions.BasicAction, Enum]] do
-          assert Util.validate_actions(actions, opts) ==
-                   {:error,
-                    Jido.Error.validation_error(
-                      "All actions must implement the Jido.Action behavior",
-                      kind: :action,
-                      subject: actions
-                    )}
+          assert_validation_error(
+            Util.validate_actions(actions, opts),
+            {:error,
+             Jido.Error.validation_error(
+               "All actions must implement the Jido.Action behavior",
+               kind: :action,
+               subject: actions
+             )}
+          )
         end
       end
     end
@@ -242,5 +248,9 @@ defmodule JidoTest.UtilTest do
       assert :ok = Util.cond_log(:info, :invalid, "invalid level")
       assert :ok = Util.cond_log(:debug, :info, "with opts", domain: [:test])
     end
+  end
+
+  defp assert_validation_error({:error, actual}, {:error, expected}) do
+    assert Map.delete(actual, :stacktrace) == Map.delete(expected, :stacktrace)
   end
 end

--- a/test/jido/util_test.exs
+++ b/test/jido/util_test.exs
@@ -66,6 +66,55 @@ defmodule JidoTest.UtilTest do
     end
   end
 
+  describe "validation result contracts" do
+    test "preserves values and ignores options other than the empty list" do
+      for value <- [TestActions.BasicAction, [TestActions.BasicAction], []] do
+        assert Util.validate_actions(value, []) == {:ok, value}
+
+        for opts <- [[validate: false], [unknown: true], :ignored, nil, %{}] do
+          assert Util.validate_actions(value, opts) == :ok
+          assert Util.validate_name("Valid_123", opts) == :ok
+        end
+      end
+
+      assert Util.validate_name("Valid_123", []) == {:ok, "Valid_123"}
+    end
+
+    test "preserves complete validation errors across option forms" do
+      for opts <- [[], [validate: true], :ignored] do
+        for name <- ["", "1invalid", "invalid-name"] do
+          assert Util.validate_name(name, opts) ==
+                   {:error,
+                    Jido.Error.validation_error(
+                      "The name must start with a letter and contain only letters, numbers, and underscores.",
+                      field: :name
+                    )}
+        end
+
+        for name <- [nil, :name, 42, [], %{}] do
+          assert Util.validate_name(name, opts) ==
+                   {:error, Jido.Error.validation_error("Invalid name format.", field: :name)}
+        end
+
+        for actions <- [Enum, NonExistentModule, [TestActions.BasicAction, Enum]] do
+          assert Util.validate_actions(actions, opts) ==
+                   {:error,
+                    Jido.Error.validation_error(
+                      "All actions must implement the Jido.Action behavior",
+                      kind: :action,
+                      subject: actions
+                    )}
+        end
+      end
+    end
+
+    test "keeps unsupported action inputs as function clause errors" do
+      for opts <- [[], [validate: true], :ignored], input <- [42, "action", %{}, [42]] do
+        assert_raise FunctionClauseError, fn -> Util.validate_actions(input, opts) end
+      end
+    end
+  end
+
   describe "validate_module/1" do
     test "validates existing module" do
       assert {:ok, Enum} = Util.validate_module(Enum)

--- a/test/jido/util_test.exs
+++ b/test/jido/util_test.exs
@@ -186,6 +186,32 @@ defmodule JidoTest.UtilTest do
       assert {:ok, ^pid} = Util.whereis(pid)
     end
 
+    test "returns a dead pid and ignores options" do
+      {pid, ref} = spawn_monitor(fn -> :ok end)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      assert Util.whereis(pid, :ignored) == {:ok, pid}
+    end
+
+    test "tuple registry takes precedence and atom keys become strings", %{jido: jido} do
+      registry = Jido.registry_name(jido)
+      pid = self()
+      {:ok, _} = Registry.register(registry, "util_contract", :value)
+
+      for name <- [:util_contract, "util_contract"] do
+        assert Util.whereis({name, registry}, registry: MissingRegistry) == {:ok, pid}
+        assert Util.whereis({name, registry}, :ignored) == {:ok, pid}
+        assert Util.whereis(name, registry: registry) == {:ok, pid}
+      end
+    end
+
+    test "preserves the exact error for absent or false registry options" do
+      for opts <- [[], [registry: nil], [registry: false]] do
+        assert_raise ArgumentError, ":registry option is required", fn ->
+          Util.whereis(:util_contract, opts)
+        end
+      end
+    end
+
     test "returns not_found for unregistered names", %{jido: jido} do
       registry = Jido.registry_name(jido)
 


### PR DESCRIPTION
Refs #346. Remove repeated validation and registry setup in `Jido.Util` (S08-01, S08-02).

The empty-option validators remain the source of validation results. Other options map success to `:ok`. Original atom/list values, input guards, exact error fields and compilation-aware Action checks stay intact. `whereis/2` uses `via_tuple/2` for registry setup and keeps its direct PID result.

Production changes are limited to `lib/jido/util.ex`. Tests cover option handling, stable error fields, unsupported Action inputs, registry precedence, atom keys, dead PIDs, and missing registries. The validation and registry changes use separate commits.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `37a1aa7692feab3c0d06b9353edab682f7244d5e`.

- 125 focused tests passed.
- 1,048 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.2%; Util coverage was 100%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on both changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The review found an error comparison that included captured stack traces. The corrected test compares all other error fields. The final focused and full runs passed, and no actionable finding remains.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `98501f1e90fbed77d21461f971565dcb8fabbeb7`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991776699).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #346. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
