### PR TITLE
refactor(error): remove redundant redaction predicates

### DIFF
--- a/lib/jido/error.ex
+++ b/lib/jido/error.ex
@@ -492,17 +492,6 @@ defmodule Jido.Error do
   @redacted "[REDACTED]"
   @omitted "[OMITTED]"
   @depth_limit "[DEPTH_LIMIT]"
-  @sensitive_key_parts MapSet.new(~w[
-    api_key
-    apikey
-    authorization
-    credential
-    credentials
-    password
-    private_key
-    secret
-    token
-  ])
   @sensitive_key_fragments ~w[
     apikey
     authorization
@@ -751,28 +740,17 @@ defmodule Jido.Error do
   end
 
   defp sensitive_key?(key) do
-    normalized_key = normalized_key(key)
-    key_parts = key_parts(normalized_key)
-    compact_key = compact_key(normalized_key)
-
-    MapSet.member?(@sensitive_key_parts, normalized_key) ||
-      Enum.any?(key_parts, &MapSet.member?(@sensitive_key_parts, &1)) ||
-      Enum.any?(@sensitive_key_fragments, &String.contains?(compact_key, &1))
+    compact_key = key |> normalized_key() |> compact_key()
+    Enum.any?(@sensitive_key_fragments, &String.contains?(compact_key, &1))
   end
 
   defp stacktrace_key?(key) do
-    normalized_key = normalized_key(key)
-    compact_key = compact_key(normalized_key)
-
-    normalized_key in ["stacktrace", "stack_trace"] ||
-      "stacktrace" in key_parts(normalized_key) ||
-      String.contains?(compact_key, "stacktrace")
+    key |> normalized_key() |> compact_key() |> String.contains?("stacktrace")
   end
 
   defp normalized_key(key) when is_atom(key), do: key |> Atom.to_string() |> String.downcase()
   defp normalized_key(key) when is_binary(key), do: String.downcase(key)
 
-  defp key_parts(key), do: String.split(key, ~r/[^a-z0-9]+/, trim: true)
   defp compact_key(key), do: String.replace(key, ~r/[^a-z0-9]+/, "")
 
   defp transport_string(value) when is_binary(value), do: truncate_string(value)

--- a/test/jido/error_transport_test.exs
+++ b/test/jido/error_transport_test.exs
@@ -18,6 +18,84 @@ defmodule JidoTest.ErrorTransportTest do
     def run(params, _context), do: {:ok, params}
   end
 
+  describe "transport key policy" do
+    test "redacts sensitive keys in maps and key-value lists without changing key names" do
+      keys = [
+        :api_key,
+        "API.KEY",
+        "prefixApiKeySuffix",
+        :authorization,
+        "AUTHORIZATION-header",
+        :credential,
+        "userCredentials",
+        :password,
+        "pass / word",
+        :private_key,
+        "PRIVATE-KEY",
+        :secret,
+        "clientSecretValue",
+        :token,
+        "accessToken",
+        "to\tken",
+        "seécret"
+      ]
+
+      for key <- keys, entries <- [%{key => "hidden"}, [{key, "hidden"}]] do
+        error = Error.execution_error("Failed", details: %{nested: entries})
+        result = Error.to_map(error)
+
+        assert result.details.nested == %{key => "[REDACTED]"}
+        assert Jido.Observe.exception_metadata(:error, error).error == result
+        refute Jason.encode!(result) =~ "hidden"
+      end
+    end
+
+    test "redaction takes priority over stacktrace omission" do
+      for key <- [:token_stacktrace, "STACK.TRACE-password", "secretStackTrace"],
+          entries <- [%{key => <<255>>}, [{key, <<255>>}]] do
+        error = Error.execution_error("Failed", details: %{nested: entries})
+        assert Error.to_map(error).details.nested == %{key => "[REDACTED]"}
+      end
+    end
+
+    test "keeps key handling for invalid binaries and non-string map keys" do
+      details = %{
+        <<255>> => "visible",
+        (<<255>> <> "TOKEN") => "hidden",
+        {:password, 1} => "hidden",
+        123 => "visible"
+      }
+
+      error = Error.execution_error("Failed", details: %{nested: details})
+
+      assert Error.to_map(error).details.nested == %{
+               <<255>> => "visible",
+               (<<255>> <> "TOKEN") => "[REDACTED]",
+               "{:password, 1}" => "[REDACTED]",
+               "123" => "visible"
+             }
+    end
+
+    test "omits stacktrace variants and keeps ordinary keys visible" do
+      for key <- [
+            :stacktrace,
+            :stack_trace,
+            "StackTrace",
+            "call-stack.trace-value",
+            "sta ck/trace"
+          ] do
+        for entries <- [%{key => "hidden"}, [{key, "hidden"}]] do
+          error = Error.execution_error("Failed", details: %{nested: entries})
+          assert Error.to_map(error).details.nested == %{key => "[OMITTED]"}
+        end
+      end
+
+      details = %{"api" => 1, "key" => 2, "stack" => 3, "trace" => 4, name: "visible"}
+      error = Error.execution_error("Failed", details: %{nested: details})
+      assert Error.to_map(error).details.nested == details
+    end
+  end
+
   describe "transport boundaries from current main" do
     test "preserves field names and indexes in validation paths" do
       for path <- [[:name], ["name"], [:users, 0, :name], ["users", 19, "name"]] do


### PR DESCRIPTION
Remove duplicate sensitive-key and stacktrace checks from error transport. The compact substring check already covers these cases. Keep the exact sensitive fragments, key normalization, redaction priority and output bounds.

Add four public-output tests for atom and string keys, case and separators, embedded fragments, invalid binary keys, other map keys, maps and key-value lists. Check that sensitive keys take priority over stacktrace omission and ordinary keys remain visible.

Production changes are limited to `lib/jido/error.ex`. Error constructors, retry hints, and serialization limits stay the same. S07 error projection and the duration issue remain outside scope. Implements S08-03.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `b2cdf313b417ccdb742a4de9d359daaa5392fbd3`.

- 124 focused error and observation tests passed.
- 1,046 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.2%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on both changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer found no source defect. The lint evidence finding was resolved by running the active warning checks. No source fix was required.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `c530d6fd2ac8269edeeefe6f6c86c6e476ad8c9f`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991779315).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #347. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
