### PR TITLE
refactor(agent): share common definition validation

### DIFF
--- a/lib/jido/agent/validation.ex
+++ b/lib/jido/agent/validation.ex
@@ -130,32 +130,19 @@ defmodule Jido.Agent.Validation do
   end
 
   defp build_definition(attrs) do
-    schema = Map.get(attrs, :schema, Zoi.object(%{}))
-    module = Map.get(attrs, :module, Agent)
-
-    with {:ok, name} <- validate_name(Map.get(attrs, :name)),
-         {:ok, description} <- validate_description(Map.get(attrs, :description)),
-         :ok <- validate_module(module),
-         :ok <- Jido.Agent.StateBudget.validate_limit(Map.get(attrs, :max_state_size)),
-         {:ok, plugins} <- Plugin.canonical_declarations(Map.get(attrs, :plugins, [])),
-         :ok <- State.validate_schema(schema),
-         {:ok, _complete_schema} <- Plugin.compose_schema(schema, plugins),
-         {:ok, routes} <- validate_routes(Map.get(attrs, :routes, [])),
-         {:ok, metadata} <- validate_metadata(Map.get(attrs, :metadata, %{})) do
-      {:ok,
-       %Agent{
-         id: nil,
-         module: module,
-         name: name,
-         description: description,
-         max_state_size: Map.get(attrs, :max_state_size),
-         schema: schema,
-         plugins: plugins,
-         state: nil,
-         routes: routes,
-         metadata: metadata
-       }}
-    end
+    %Agent{
+      id: nil,
+      module: Map.get(attrs, :module, Agent),
+      name: Map.get(attrs, :name),
+      description: Map.get(attrs, :description),
+      max_state_size: Map.get(attrs, :max_state_size),
+      schema: Map.get(attrs, :schema, Zoi.object(%{})),
+      plugins: Map.get(attrs, :plugins, []),
+      state: nil,
+      routes: Map.get(attrs, :routes, []),
+      metadata: Map.get(attrs, :metadata, %{})
+    }
+    |> validate_common()
   end
 
   defp validate_common(%Agent{} = agent) do

--- a/test/jido/agent/validation_test.exs
+++ b/test/jido/agent/validation_test.exs
@@ -1,0 +1,142 @@
+defmodule Jido.Agent.ValidationTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Agent
+  alias Jido.Error.ValidationError
+
+  defmodule CallbackPlugin do
+    use Jido.Plugin
+
+    @impl true
+    def state_spec(opts) do
+      send(self(), {:callback, :state_spec, opts})
+      :none
+    end
+
+    @impl true
+    def directives(opts) do
+      send(self(), {:callback, :directives, opts})
+      []
+    end
+  end
+
+  defmodule StatePlugin do
+    use Jido.Plugin
+
+    @impl true
+    def state_spec(_opts), do: {:owned, Zoi.integer()}
+  end
+
+  test "checks Plugin schema composition before routes and metadata" do
+    assert {:error,
+            %ValidationError{
+              message: "Agent Plugin state key conflicts with the Agent domain schema"
+            }} =
+             Agent.new(
+               name: "conflict",
+               schema: Zoi.object(%{owned: Zoi.integer()}),
+               plugins: [StatePlugin],
+               routes: nil,
+               metadata: nil
+             )
+  end
+
+  test "keeps defaults and explicit nil values at the definition boundary" do
+    expected = %Agent{
+      id: nil,
+      module: Agent,
+      name: "defaults",
+      description: nil,
+      max_state_size: nil,
+      schema: Zoi.object(%{}),
+      plugins: [],
+      state: nil,
+      routes: [],
+      metadata: %{}
+    }
+
+    assert {:ok, ^expected} = Agent.new(name: "defaults")
+
+    assert {:ok, ^expected} =
+             Agent.new(%{
+               name: "defaults",
+               id: nil,
+               state: nil,
+               description: nil,
+               max_state_size: nil
+             })
+
+    for field <- [:name, :module, :schema, :plugins, :routes, :metadata] do
+      assert {:error, %ValidationError{}} = Agent.new(Map.put(%{name: "defaults"}, field, nil))
+    end
+  end
+
+  test "rejects unknown keys and instance data before common fields or callbacks" do
+    attrs = %{name: nil, id: "instance", state: %{}, plugins: [CallbackPlugin]}
+
+    assert {:error,
+            %ValidationError{message: "Unknown Agent definition key", details: %{key: :extra}}} =
+             Agent.new(Map.put(attrs, :extra, true))
+
+    assert {:error,
+            %ValidationError{
+              message: "Agent.new/1 accepts definition data only",
+              details: %{keys: [:id, :state]}
+            }} = Agent.new(attrs)
+
+    refute_received {:callback, _, _}
+  end
+
+  test "reports the first common field error when later fields also fail" do
+    failures = [
+      {:name, nil},
+      {:description, 123},
+      {:module, nil},
+      {:max_state_size, -1},
+      {:plugins, nil},
+      {:schema, nil},
+      {:routes, nil},
+      {:metadata, nil}
+    ]
+
+    for index <- 0..(length(failures) - 1) do
+      {field, value} = Enum.at(failures, index)
+
+      assert {:error, %ValidationError{} = expected} =
+               Agent.new(Map.put(%{name: "order"}, field, value))
+
+      attrs = Map.merge(%{name: "order"}, Map.new(Enum.drop(failures, index)))
+      assert {:error, %ValidationError{} = actual} = Agent.new(attrs)
+      assert {actual.message, actual.details} == {expected.message, expected.details}
+    end
+  end
+
+  test "calls Plugin schema callbacks twice in order before route and metadata checks" do
+    opts = [label: :first]
+
+    for extra <- [%{}, %{routes: nil}, %{metadata: nil}] do
+      result =
+        Agent.new(Map.merge(%{name: "callbacks", plugins: [{CallbackPlugin, opts}]}, extra))
+
+      if extra == %{} do
+        assert {:ok, %Agent{plugins: [{CallbackPlugin, ^opts}]}} = result
+      else
+        assert {:error, %ValidationError{}} = result
+      end
+
+      for callback <- [:state_spec, :directives, :state_spec, :directives] do
+        assert_received {:callback, actual, ^opts}
+        assert actual == callback
+      end
+
+      refute_received {:callback, _, _}
+    end
+
+    assert {:error, %ValidationError{}} =
+             Agent.new(name: "callbacks", plugins: [CallbackPlugin], schema: nil)
+
+    assert_received {:callback, :state_spec, []}
+    assert_received {:callback, :directives, []}
+    refute_received {:callback, _, _}
+  end
+end


### PR DESCRIPTION
Agent construction repeated the nine common field checks used to validate existing Agent values. Build a neutral internal Agent with the current defaults, then use the common validation function. Keep error order, explicit nil handling, Plugin callback calls and route conversion.

Implements S01-01. S01-02 stays deferred: the public map keeps its explicit field list. Future schema fields do not enter it automatically.

Five added contract tests cover the changed validation boundaries. The public Agent API is unchanged.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `342037dfa0b2e1e3ffda605bb816281db1be674d`.

- 128 focused Agent, authoring, schema, state-budget, Plugin, and validation tests passed.
- 1,047 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.3%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on both changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer found no actionable code defect at the exact historical base and head. No source fix was required.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `6eefe0ec0cd829543201a8f3f0e75018256b6dc2`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991748618).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #338. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
