### PR TITLE
refactor(observe): share configuration precedence lookup

### DIFF
--- a/lib/jido/observe/config.ex
+++ b/lib/jido/observe/config.ex
@@ -34,86 +34,60 @@ defmodule Jido.Observe.Config do
 
   @doc "Returns the telemetry log level for the given instance."
   @spec telemetry_log_level(instance()) :: :trace | :debug | :info | :warning | :error
-  def telemetry_log_level(instance \\ nil)
-
-  def telemetry_log_level(nil) do
-    global_telemetry(:log_level, Defaults.telemetry_log_level())
-    |> normalize_telemetry_log_level()
-  end
-
-  def telemetry_log_level(instance) do
-    with nil <- Jido.Debug.override(instance, :telemetry_log_level),
-         nil <- instance_telemetry(instance, :log_level) do
-      global_telemetry(:log_level, Defaults.telemetry_log_level())
-    end
+  def telemetry_log_level(instance \\ nil) do
+    resolve(
+      instance,
+      :telemetry,
+      :log_level,
+      :telemetry_log_level,
+      Defaults.telemetry_log_level()
+    )
     |> normalize_telemetry_log_level()
   end
 
   @doc "Returns the argument logging mode for the given instance."
   @spec telemetry_log_args(instance()) :: :keys_only | :full | :none
-  def telemetry_log_args(instance \\ nil)
-
-  def telemetry_log_args(nil) do
-    global_telemetry(:log_args, Defaults.telemetry_log_args())
-    |> normalize_telemetry_log_args()
-  end
-
-  def telemetry_log_args(instance) do
-    with nil <- Jido.Debug.override(instance, :telemetry_log_args),
-         nil <- instance_telemetry(instance, :log_args) do
-      global_telemetry(:log_args, Defaults.telemetry_log_args())
-    end
+  def telemetry_log_args(instance \\ nil) do
+    resolve(instance, :telemetry, :log_args, :telemetry_log_args, Defaults.telemetry_log_args())
     |> normalize_telemetry_log_args()
   end
 
   @doc "Returns the slow signal threshold in milliseconds."
   @spec slow_signal_threshold_ms(instance()) :: non_neg_integer()
-  def slow_signal_threshold_ms(instance \\ nil)
-
-  def slow_signal_threshold_ms(nil),
-    do:
-      global_telemetry(:slow_signal_threshold_ms, Defaults.slow_signal_threshold_ms())
-      |> normalize_non_neg_integer(Defaults.slow_signal_threshold_ms())
-
-  def slow_signal_threshold_ms(instance) do
-    with nil <- Jido.Debug.override(instance, :slow_signal_threshold_ms),
-         nil <- instance_telemetry(instance, :slow_signal_threshold_ms) do
-      global_telemetry(:slow_signal_threshold_ms, Defaults.slow_signal_threshold_ms())
-    end
+  def slow_signal_threshold_ms(instance \\ nil) do
+    resolve(
+      instance,
+      :telemetry,
+      :slow_signal_threshold_ms,
+      :slow_signal_threshold_ms,
+      Defaults.slow_signal_threshold_ms()
+    )
     |> normalize_non_neg_integer(Defaults.slow_signal_threshold_ms())
   end
 
   @doc "Returns the slow directive threshold in milliseconds."
   @spec slow_directive_threshold_ms(instance()) :: non_neg_integer()
-  def slow_directive_threshold_ms(instance \\ nil)
-
-  def slow_directive_threshold_ms(nil),
-    do:
-      global_telemetry(:slow_directive_threshold_ms, Defaults.slow_directive_threshold_ms())
-      |> normalize_non_neg_integer(Defaults.slow_directive_threshold_ms())
-
-  def slow_directive_threshold_ms(instance) do
-    with nil <- Jido.Debug.override(instance, :slow_directive_threshold_ms),
-         nil <- instance_telemetry(instance, :slow_directive_threshold_ms) do
-      global_telemetry(:slow_directive_threshold_ms, Defaults.slow_directive_threshold_ms())
-    end
+  def slow_directive_threshold_ms(instance \\ nil) do
+    resolve(
+      instance,
+      :telemetry,
+      :slow_directive_threshold_ms,
+      :slow_directive_threshold_ms,
+      Defaults.slow_directive_threshold_ms()
+    )
     |> normalize_non_neg_integer(Defaults.slow_directive_threshold_ms())
   end
 
   @doc "Returns the list of signal types considered interesting."
   @spec interesting_signal_types(instance()) :: [String.t()]
-  def interesting_signal_types(instance \\ nil)
-
-  def interesting_signal_types(nil),
-    do:
-      global_telemetry(:interesting_signal_types, Defaults.interesting_signal_types())
-      |> normalize_interesting_signal_types()
-
-  def interesting_signal_types(instance) do
-    with nil <- Jido.Debug.override(instance, :interesting_signal_types),
-         nil <- instance_telemetry(instance, :interesting_signal_types) do
-      global_telemetry(:interesting_signal_types, Defaults.interesting_signal_types())
-    end
+  def interesting_signal_types(instance \\ nil) do
+    resolve(
+      instance,
+      :telemetry,
+      :interesting_signal_types,
+      :interesting_signal_types,
+      Defaults.interesting_signal_types()
+    )
     |> normalize_interesting_signal_types()
   end
 
@@ -194,35 +168,27 @@ defmodule Jido.Observe.Config do
 
   @doc "Returns the observability log level for the given instance."
   @spec observe_log_level(instance()) :: Logger.level()
-  def observe_log_level(instance \\ nil)
-
-  def observe_log_level(nil) do
-    global_observability(:log_level, Defaults.observe_log_level())
-    |> normalize_observe_log_level()
-  end
-
-  def observe_log_level(instance) do
-    with nil <- Jido.Debug.override(instance, :observe_log_level),
-         nil <- instance_observability(instance, :log_level) do
-      global_observability(:log_level, Defaults.observe_log_level())
-    end
+  def observe_log_level(instance \\ nil) do
+    resolve(
+      instance,
+      :observability,
+      :log_level,
+      :observe_log_level,
+      Defaults.observe_log_level()
+    )
     |> normalize_observe_log_level()
   end
 
   @doc "Returns the debug events mode for the given instance."
   @spec debug_events(instance()) :: :off | :minimal | :all
-  def debug_events(instance \\ nil)
-
-  def debug_events(nil) do
-    global_observability(:debug_events, Defaults.observe_debug_events())
-    |> normalize_debug_events()
-  end
-
-  def debug_events(instance) do
-    with nil <- Jido.Debug.override(instance, :observe_debug_events),
-         nil <- instance_observability(instance, :debug_events) do
-      global_observability(:debug_events, Defaults.observe_debug_events())
-    end
+  def debug_events(instance \\ nil) do
+    resolve(
+      instance,
+      :observability,
+      :debug_events,
+      :observe_debug_events,
+      Defaults.observe_debug_events()
+    )
     |> normalize_debug_events()
   end
 
@@ -234,52 +200,34 @@ defmodule Jido.Observe.Config do
 
   @doc "Returns true if sensitive data should be redacted."
   @spec redact_sensitive?(instance()) :: boolean()
-  def redact_sensitive?(instance \\ nil)
-
-  def redact_sensitive?(nil),
-    do:
-      global_observability(:redact_sensitive, Defaults.redact_sensitive())
-      |> normalize_boolean()
-
-  def redact_sensitive?(instance) do
-    with nil <- Jido.Debug.override(instance, :redact_sensitive),
-         nil <- instance_observability(instance, :redact_sensitive) do
-      global_observability(:redact_sensitive, Defaults.redact_sensitive())
-    end
+  def redact_sensitive?(instance \\ nil) do
+    resolve(
+      instance,
+      :observability,
+      :redact_sensitive,
+      :redact_sensitive,
+      Defaults.redact_sensitive()
+    )
     |> normalize_boolean()
   end
 
   @doc "Returns the tracer module for the given instance."
   @spec tracer(instance()) :: module()
-  def tracer(instance \\ nil)
-
-  def tracer(nil) do
-    global_observability(:tracer, Defaults.tracer())
-    |> normalize_tracer()
-  end
-
-  def tracer(instance) do
-    with nil <- Jido.Debug.override(instance, :tracer),
-         nil <- instance_observability(instance, :tracer) do
-      global_observability(:tracer, Defaults.tracer())
-    end
+  def tracer(instance \\ nil) do
+    resolve(instance, :observability, :tracer, :tracer, Defaults.tracer())
     |> normalize_tracer()
   end
 
   @doc "Returns tracer callback failure handling mode."
   @spec tracer_failure_mode(instance()) :: :warn | :strict
-  def tracer_failure_mode(instance \\ nil)
-
-  def tracer_failure_mode(nil) do
-    global_observability(:tracer_failure_mode, Defaults.tracer_failure_mode())
-    |> normalize_tracer_failure_mode()
-  end
-
-  def tracer_failure_mode(instance) do
-    with nil <- Jido.Debug.override(instance, :tracer_failure_mode),
-         nil <- instance_observability(instance, :tracer_failure_mode) do
-      global_observability(:tracer_failure_mode, Defaults.tracer_failure_mode())
-    end
+  def tracer_failure_mode(instance \\ nil) do
+    resolve(
+      instance,
+      :observability,
+      :tracer_failure_mode,
+      :tracer_failure_mode,
+      Defaults.tracer_failure_mode()
+    )
     |> normalize_tracer_failure_mode()
   end
 
@@ -287,41 +235,37 @@ defmodule Jido.Observe.Config do
 
   @doc "Returns the maximum number of debug events to store."
   @spec debug_max_events(instance()) :: non_neg_integer()
-  def debug_max_events(instance \\ nil)
-
-  def debug_max_events(nil) do
-    global_telemetry(:debug_max_events, Defaults.debug_max_events())
-    |> normalize_non_neg_integer(Defaults.debug_max_events())
-  end
-
-  def debug_max_events(instance) do
-    with nil <- Jido.Debug.override(instance, :debug_max_events),
-         nil <- instance_telemetry(instance, :debug_max_events) do
-      global_telemetry(:debug_max_events, Defaults.debug_max_events())
-    end
+  def debug_max_events(instance \\ nil) do
+    resolve(
+      instance,
+      :telemetry,
+      :debug_max_events,
+      :debug_max_events,
+      Defaults.debug_max_events()
+    )
     |> normalize_non_neg_integer(Defaults.debug_max_events())
   end
 
   # --- Private helpers ---
 
-  defp instance_telemetry(instance, key) do
-    otp_app = instance_otp_app(instance)
+  defp resolve(nil, group, key, _override_key, default) do
+    global_config(group, key, default)
+  end
 
-    if otp_app do
-      otp_app
-      |> Application.get_env(instance, [])
-      |> Keyword.get(:telemetry, [])
-      |> Keyword.get(key)
+  defp resolve(instance, group, key, override_key, default) do
+    with nil <- Jido.Debug.override(instance, override_key),
+         nil <- instance_config(instance, group, key) do
+      global_config(group, key, default)
     end
   end
 
-  defp instance_observability(instance, key) do
+  defp instance_config(instance, group, key) do
     otp_app = instance_otp_app(instance)
 
     if otp_app do
       otp_app
       |> Application.get_env(instance, [])
-      |> Keyword.get(:observability, [])
+      |> Keyword.get(group, [])
       |> Keyword.get(key)
     end
   end
@@ -333,12 +277,8 @@ defmodule Jido.Observe.Config do
     end
   end
 
-  defp global_telemetry(key, default) do
-    :jido |> Application.get_env(:telemetry, []) |> Keyword.get(key, default)
-  end
-
-  defp global_observability(key, default) do
-    :jido |> Application.get_env(:observability, []) |> Keyword.get(key, default)
+  defp global_config(group, key, default) do
+    :jido |> Application.get_env(group, []) |> Keyword.get(key, default)
   end
 
   defp normalize_action_log_level(level, :full), do: logger_level_for_action(level)

--- a/test/jido/observe/config_test.exs
+++ b/test/jido/observe/config_test.exs
@@ -20,6 +20,102 @@ defmodule JidoTest.Observe.ConfigTest do
     def span_exception(_ctx, _kind, _reason, _stacktrace), do: :ok
   end
 
+  defmodule ConfigInstance do
+    def __otp_app__, do: :jido_observe_config_test
+  end
+
+  @settings [
+    {:telemetry_log_level, :telemetry, :log_level, :telemetry_log_level, :debug, :error, :info},
+    {:telemetry_log_args, :telemetry, :log_args, :telemetry_log_args, :full, :none, :keys_only},
+    {:slow_signal_threshold_ms, :telemetry, :slow_signal_threshold_ms, :slow_signal_threshold_ms,
+     0, 12, 24},
+    {:slow_directive_threshold_ms, :telemetry, :slow_directive_threshold_ms,
+     :slow_directive_threshold_ms, 0, 13, 25},
+    {:interesting_signal_types, :telemetry, :interesting_signal_types, :interesting_signal_types,
+     [], ["instance"], ["global"]},
+    {:observe_log_level, :observability, :log_level, :observe_log_level, :debug, :error, :info},
+    {:debug_events, :observability, :debug_events, :observe_debug_events, :all, :minimal, :off},
+    {:redact_sensitive?, :observability, :redact_sensitive, :redact_sensitive, false, true, true},
+    {:tracer, :observability, :tracer, :tracer, ValidTracer, Jido.Observe.NoopTracer,
+     ValidTracer},
+    {:tracer_failure_mode, :observability, :tracer_failure_mode, :tracer_failure_mode, :strict,
+     :warn, :strict},
+    {:debug_max_events, :telemetry, :debug_max_events, :debug_max_events, 0, 14, 26}
+  ]
+
+  for {getter, group, key, override_key, override_value, instance_value, global_value} <-
+        @settings do
+    test "#{getter} preserves lazy nil-only precedence and normalization" do
+      getter = unquote(getter)
+      group = unquote(group)
+      key = unquote(key)
+      override_key = unquote(override_key)
+      override_value = unquote(Macro.escape(override_value))
+      instance_value = unquote(Macro.escape(instance_value))
+      global_value = unquote(Macro.escape(global_value))
+      saved_global = Application.fetch_env(:jido, group)
+      saved_instance = Application.fetch_env(:jido_observe_config_test, ConfigInstance)
+
+      on_exit(fn ->
+        restore_env(:jido, group, saved_global)
+        restore_env(:jido_observe_config_test, ConfigInstance, saved_instance)
+        Debug.reset(ConfigInstance)
+      end)
+
+      Application.delete_env(:jido, group)
+      default = apply(Config, getter, [nil])
+      Application.put_env(:jido, group, [{key, global_value}])
+
+      Application.put_env(:jido_observe_config_test, ConfigInstance, [
+        {group, [{key, instance_value}]}
+      ])
+
+      put_override(override_key, override_value)
+      assert apply(Config, getter, [ConfigInstance]) == override_value
+      assert apply(Config, getter, [nil]) == global_value
+
+      put_override(override_key, nil)
+      assert apply(Config, getter, [ConfigInstance]) == instance_value
+      Application.put_env(:jido_observe_config_test, ConfigInstance, [{group, [{key, nil}]}])
+      assert apply(Config, getter, [ConfigInstance]) == global_value
+      Application.delete_env(:jido, group)
+      assert apply(Config, getter, [ConfigInstance]) == default
+
+      # Malformed lower-priority config must never be read after a selected value.
+      Application.put_env(:jido, group, :unreadable)
+      Application.put_env(:jido_observe_config_test, ConfigInstance, :unreadable)
+      put_override(override_key, override_value)
+      assert apply(Config, getter, [ConfigInstance]) == override_value
+      put_override(override_key, %{invalid: true})
+      assert apply(Config, getter, [ConfigInstance]) == default
+      put_override(override_key, false)
+      assert apply(Config, getter, [ConfigInstance]) == default
+
+      put_override(override_key, nil)
+
+      Application.put_env(:jido_observe_config_test, ConfigInstance, [
+        {group, [{key, instance_value}]}
+      ])
+
+      assert apply(Config, getter, [ConfigInstance]) == instance_value
+
+      Application.put_env(:jido_observe_config_test, ConfigInstance, [
+        {group, [{key, %{invalid: true}}]}
+      ])
+
+      assert apply(Config, getter, [ConfigInstance]) == default
+      Application.put_env(:jido_observe_config_test, ConfigInstance, [{group, [{key, false}]}])
+      assert apply(Config, getter, [ConfigInstance]) == default
+    end
+  end
+
+  defp put_override(key, value) do
+    :persistent_term.put({:jido_debug, ConfigInstance}, %{level: :on, overrides: %{key => value}})
+  end
+
+  defp restore_env(app, key, {:ok, value}), do: Application.put_env(app, key, value)
+  defp restore_env(app, key, :error), do: Application.delete_env(app, key)
+
   setup do
     Debug.reset(@test_instance)
 


### PR DESCRIPTION
All observation settings repeat the same configuration lookup. Use one private lookup for runtime override, instance configuration, and global configuration. Keep each named getter and its normalization. Only nil permits fallback; false and invalid values still take priority. Lower-priority configuration is read only when needed.

Implements S07-01. Tests cover all 11 settings, nil fallback, invalid-value priority, false values, and lazy reads. PR #360 has a separate span-completion patch; neither G08 PR depends on the other. The duration-unit issue remains outside scope.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `0f57601f0e34f192fd2b4b52a4a4716e95bc6520`.

- 216 focused observation, debug, telemetry, and error transport tests passed.
- 1,053 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.7%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on both changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The independent reviewer found no actionable finding on the historical head.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `0e3324ef2e39b84aea8baa53cac32e62139f55f1`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991772822).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #345. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
