### PR TITLE
refactor(scheduler): simplify reconciliation and validation

### DIFF
--- a/lib/jido/plugin/scheduler.ex
+++ b/lib/jido/plugin/scheduler.ex
@@ -85,8 +85,6 @@ defmodule Jido.Plugin.Scheduler do
 
   @doc "Creates one delayed Signal Directive."
   @spec schedule(non_neg_integer(), Signal.t()) :: Schedule.t()
-  def schedule(delay_ms, %Signal{} = signal), do: %Schedule{delay_ms: delay_ms, signal: signal}
-
   def schedule(delay_ms, signal), do: %Schedule{delay_ms: delay_ms, signal: signal}
 
   @doc "Creates one recurring Signal Directive."

--- a/lib/jido/plugin/scheduler.ex
+++ b/lib/jido/plugin/scheduler.ex
@@ -130,7 +130,7 @@ defmodule Jido.Plugin.Scheduler do
   def validate_cron_state(cron, _opts) do
     Enum.reduce_while(cron, :ok, fn {job_id, spec}, :ok ->
       with :ok <- validate_durable_id(job_id),
-           {:ok, _validated} <-
+           {:ok, _timezone} <-
              validate_cron_spec(spec.cron_expression, spec.message, spec.timezone),
            :ok <- validate_occurrence(spec.message, Map.get(spec, :generation)),
            :ok <- validate_durable_message(Map.get(spec, :pending)),
@@ -185,11 +185,11 @@ defmodule Jido.Plugin.Scheduler do
   def validate_directive(%Cron{} = directive, _opts) do
     with {:ok, directive} <- Zoi.parse(Cron.schema(), Map.from_struct(directive)),
          :ok <- validate_durable_id(directive.job_id),
-         {:ok, spec} <-
+         {:ok, timezone} <-
            validate_cron_spec(directive.cron, directive.signal, directive.timezone),
          :ok <- validate_occurrence(directive.signal, directive.generation),
          :ok <- validate_delivery(directive) do
-      {:ok, %{directive | timezone: spec.timezone}}
+      {:ok, %{directive | timezone: timezone}}
     end
   end
 
@@ -283,10 +283,12 @@ defmodule Jido.Plugin.Scheduler do
   defp validate_delivery(_directive), do: :ok
 
   defp validate_cron_spec(cron_expression, message, timezone) do
-    with {:ok, spec} <- validate_and_build_cron_spec(cron_expression, message, timezone),
-         :ok <- validate_cron_syntax(spec.cron_expression),
-         :ok <- validate_timezone_support(spec.timezone) do
-      {:ok, spec}
+    with :ok <- validate_cron_expression_type(cron_expression),
+         {:ok, timezone} <- validate_timezone_option(timezone),
+         :ok <- validate_durable_message(message),
+         :ok <- validate_cron_syntax(cron_expression),
+         :ok <- validate_timezone_support(timezone) do
+      {:ok, timezone}
     end
   end
 
@@ -306,27 +308,14 @@ defmodule Jido.Plugin.Scheduler do
     end
   end
 
-  defp validate_and_build_cron_spec(cron_expression, message, timezone) do
-    with :ok <- validate_cron_expression_type(cron_expression),
-         {:ok, normalized_timezone} <- validate_timezone_option(timezone),
-         :ok <- validate_durable_message(message) do
-      {:ok,
-       %{
-         cron_expression: cron_expression,
-         message: message,
-         timezone: normalized_timezone
-       }}
-    end
-  end
-
   defp validate_cron_expression_type(cron_expression) when is_binary(cron_expression), do: :ok
 
   defp validate_cron_expression_type(_cron_expression),
     do: {:error, {:invalid_cron, :invalid_type}}
 
-  defp validate_timezone_option(nil), do: {:ok, @default_timezone}
-  defp validate_timezone_option(""), do: {:ok, @default_timezone}
-  defp validate_timezone_option(timezone) when is_binary(timezone), do: {:ok, timezone}
+  defp validate_timezone_option(timezone) when is_nil(timezone) or is_binary(timezone),
+    do: {:ok, normalize_timezone_value(timezone)}
+
   defp validate_timezone_option(_timezone), do: {:error, {:invalid_timezone, :invalid_type}}
 
   defp normalize_timezone_value(nil), do: @default_timezone

--- a/lib/jido/plugin/scheduler/runtime.ex
+++ b/lib/jido/plugin/scheduler/runtime.ex
@@ -211,35 +211,31 @@ defmodule Jido.Plugin.Scheduler.Runtime do
     runtime = runtime |> stop_changed_jobs(desired) |> Map.put(:desired_cron, desired)
 
     Enum.reduce_while(desired, {:ok, runtime}, fn {job_id, spec}, {:ok, runtime} ->
-      case Map.get(runtime.cron_jobs, job_id) do
-        {^spec, job, _ref} ->
-          if Process.alive?(job) do
-            {:cont, {:ok, runtime}}
-          else
-            runtime = drop_cron_job(runtime, job_id)
+      case ensure_cron_job(runtime, job_id, spec) do
+        {:ok, runtime} ->
+          {:cont, {:ok, runtime}}
 
-            case start_tracked_cron(runtime, job_id, spec) do
-              {:ok, runtime} ->
-                {:cont, {:ok, runtime}}
-
-              {:error, reason, runtime} ->
-                {:halt, {:error, {:cron_activation_failed, job_id, reason}, runtime}}
-            end
-          end
-
-        nil ->
-          case start_tracked_cron(runtime, job_id, spec) do
-            {:ok, runtime} ->
-              {:cont, {:ok, runtime}}
-
-            {:error, reason, runtime} ->
-              {:halt, {:error, {:cron_activation_failed, job_id, reason}, runtime}}
-          end
+        {:error, reason, runtime} ->
+          {:halt, {:error, {:cron_activation_failed, job_id, reason}, runtime}}
       end
     end)
     |> case do
       {:ok, runtime} -> {:ok, schedule_pending(runtime, 0)}
       error -> error
+    end
+  end
+
+  defp ensure_cron_job(runtime, job_id, spec) do
+    case Map.get(runtime.cron_jobs, job_id) do
+      {^spec, job, _ref} ->
+        if Process.alive?(job) do
+          {:ok, runtime}
+        else
+          runtime |> drop_cron_job(job_id) |> start_tracked_cron(job_id, spec)
+        end
+
+      nil ->
+        start_tracked_cron(runtime, job_id, spec)
     end
   end
 

--- a/lib/jido/plugin/sensor_manager/runtime.ex
+++ b/lib/jido/plugin/sensor_manager/runtime.ex
@@ -29,16 +29,11 @@ defmodule Jido.Plugin.SensorManager.Runtime do
   end
 
   defp controller(runtime) do
-    case Supervisor.which_children(runtime) do
-      [{Controller, pid, :worker, _modules} | _rest] when is_pid(pid) ->
-        pid
-
-      children ->
-        children
-        |> Enum.find_value(fn
-          {Controller, pid, :worker, _modules} when is_pid(pid) -> pid
-          _child -> nil
-        end)
-    end
+    runtime
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {Controller, pid, :worker, _modules} when is_pid(pid) -> pid
+      _child -> nil
+    end)
   end
 end

--- a/test/jido/plugin/scheduler_occurrence_test.exs
+++ b/test/jido/plugin/scheduler_occurrence_test.exs
@@ -108,6 +108,14 @@ defmodule JidoTest.Plugin.SchedulerOccurrenceTest do
     assert :ok = Scheduler.validate_cron_state(%{plain: spec}, [])
   end
 
+  test "delayed schedule construction keeps invalid values for later validation" do
+    signal = tick()
+    assert Scheduler.schedule(10, signal) == %Scheduler.Schedule{delay_ms: 10, signal: signal}
+    invalid = Scheduler.schedule(-1, :not_a_signal)
+    assert invalid == %Scheduler.Schedule{delay_ms: -1, signal: :not_a_signal}
+    assert {:error, _} = Scheduler.validate_directive(invalid, [])
+  end
+
   test "timezone defaults are shared by validation and stored definitions" do
     for timezone <- [nil, "", "Etc/UTC"] do
       assert {:ok, directive} =

--- a/test/jido/plugin/scheduler_occurrence_test.exs
+++ b/test/jido/plugin/scheduler_occurrence_test.exs
@@ -108,6 +108,51 @@ defmodule JidoTest.Plugin.SchedulerOccurrenceTest do
     assert :ok = Scheduler.validate_cron_state(%{plain: spec}, [])
   end
 
+  test "timezone defaults are shared by validation and stored definitions" do
+    for timezone <- [nil, "", "Etc/UTC"] do
+      assert {:ok, directive} =
+               Scheduler.validate_directive(
+                 Scheduler.cron(:plain, "* * * * *", tick(), timezone: timezone),
+                 []
+               )
+
+      assert directive.timezone == "Etc/UTC"
+      assert Scheduler.build_cron_spec("* * * * *", tick(), timezone).timezone == "Etc/UTC"
+    end
+  end
+
+  test "cron state validation preserves the first error when several fields are invalid" do
+    invalid_message = %{tick() | data: %{pid: self()}}
+
+    for {cron, message, timezone, reason} <- [
+          {nil, invalid_message, 123, {:invalid_cron, :invalid_type}},
+          {"bad cron", invalid_message, 123, {:invalid_timezone, :invalid_type}},
+          {"bad cron", invalid_message, "Not/AZone", {:invalid_message, :non_durable_term}}
+        ] do
+      assert {:error, error} =
+               Scheduler.validate_cron_state(
+                 %{job: %{cron_expression: cron, message: message, timezone: timezone}},
+                 []
+               )
+
+      assert error == "invalid cron state for :job: #{inspect(reason)}"
+    end
+
+    assert {:error, syntax_error} =
+             Scheduler.validate_directive(
+               Scheduler.cron(:job, "bad cron", tick(), timezone: "Not/AZone"),
+               []
+             )
+
+    assert {:invalid_cron, _} = syntax_error
+
+    assert {:error, {:invalid_timezone, _}} =
+             Scheduler.validate_directive(
+               Scheduler.cron(:job, "* * * * *", tick(), timezone: "Not/AZone"),
+               []
+             )
+  end
+
   test "tracked schedules reject reserved template metadata" do
     {:ok, tagged} = Occurrence.attach(tick(), @scope, "job-1", 1, @instant)
 

--- a/test/jido/plugin/scheduler_runtime_test.exs
+++ b/test/jido/plugin/scheduler_runtime_test.exs
@@ -1,0 +1,118 @@
+defmodule JidoTest.Plugin.SchedulerRuntimeTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Plugin.{DirectiveContext, Init}
+  alias Jido.Plugin.Scheduler
+  alias Jido.Plugin.Scheduler.Runtime
+  alias Jido.Signal
+
+  test "reconciliation retains live jobs and replaces dead jobs before their DOWN is handled" do
+    runtime = runtime()
+    spec = spec()
+    assert {:reply, :ok, runtime} = reconcile(runtime, %{live: spec, dead: spec}, 1)
+    {^spec, dead, old_ref} = runtime.cron_jobs.dead
+    live = runtime.cron_jobs.live
+    barrier = Process.monitor(dead)
+    Process.exit(dead, :kill)
+    assert_receive {:DOWN, ^barrier, :process, ^dead, :killed}, 1_000
+
+    assert {:reply, :ok, runtime} = reconcile(runtime, %{live: spec, dead: spec}, 2)
+
+    try do
+      assert runtime.cron_jobs.live == live
+      assert {^spec, replacement, new_ref} = runtime.cron_jobs.dead
+      assert replacement != dead
+      assert new_ref != old_ref
+      assert Process.alive?(replacement)
+      refute_received {:DOWN, ^old_ref, :process, ^dead, _}
+
+      assert {:noreply, ^runtime} =
+               Runtime.handle_info({:DOWN, old_ref, :process, dead, :killed}, runtime)
+    after
+      Runtime.terminate(:normal, runtime)
+    end
+  end
+
+  test "activation stops at the first error and retains completed jobs and desired state" do
+    runtime = %{runtime() | partition: self()}
+    plain = spec()
+    tracked = Map.put(plain, :generation, 1)
+    # Use the map's enumeration order to select the successful and failing jobs.
+    desired = %{first: plain, second: plain, third: plain}
+    [success, failure, later] = Enum.map(desired, &elem(&1, 0))
+    desired = desired |> Map.put(failure, tracked) |> Map.put(later, tracked)
+
+    assert {:reply, {:error, {:cron_activation_failed, ^failure, :non_durable_occurrence_scope}},
+            runtime} =
+             reconcile(runtime, desired, 1)
+
+    try do
+      assert Map.keys(runtime.cron_jobs) == [success]
+      assert runtime.desired_cron == desired
+      assert runtime.last_reconciled_version == nil
+      assert is_reference(runtime.retry_timer)
+      {^plain, job, _ref} = runtime.cron_jobs[success]
+      assert Process.alive?(job)
+    after
+      Runtime.terminate(:normal, runtime)
+    end
+  end
+
+  test "a dead matching job is removed when its replacement cannot start" do
+    runtime = runtime()
+    spec = Map.put(spec(), :generation, 1)
+    assert {:reply, :ok, runtime} = reconcile(runtime, %{job: spec}, 1)
+    {^spec, job, ref} = runtime.cron_jobs.job
+    barrier = Process.monitor(job)
+    Process.exit(job, :kill)
+    assert_receive {:DOWN, ^barrier, :process, ^job, :killed}, 1_000
+
+    assert {:reply, {:error, {:cron_activation_failed, :job, :non_durable_occurrence_scope}},
+            runtime} =
+             reconcile(%{runtime | partition: self()}, %{job: spec}, 2)
+
+    try do
+      assert runtime.cron_jobs == %{}
+      assert runtime.desired_cron == %{job: spec}
+      assert runtime.last_reconciled_version == 1
+      refute_received {:DOWN, ^ref, :process, ^job, _}
+    after
+      Runtime.terminate(:normal, runtime)
+    end
+  end
+
+  defp runtime do
+    {:ok, runtime, {:continue, :reconcile_agent}} =
+      Runtime.init(%Init{
+        agent_server: self(),
+        agent_id: "scheduler-contract",
+        module: Scheduler,
+        options: [retry_delay_ms: 60_000]
+      })
+
+    runtime
+  end
+
+  defp spec do
+    Scheduler.build_cron_spec("0 0 1 1 *", Signal.new!("test.tick", %{}, source: "/test"))
+  end
+
+  defp reconcile(runtime, desired, version) do
+    signal = spec().message
+
+    context = %DirectiveContext{
+      turn_id: "turn",
+      agent_id: runtime.agent_id,
+      source_signal: signal,
+      effective_signal: signal,
+      state_version: version,
+      plugin_state: %{cron: desired}
+    }
+
+    Runtime.handle_call(
+      {:directive, Scheduler.cancel(:unused), context},
+      {self(), make_ref()},
+      runtime
+    )
+  end
+end


### PR DESCRIPTION
Cron reconciliation repeats activation result handling, and cron validation builds a temporary map. Handle each activation result once and return the validated timezone. Remove the equivalent Schedule constructor clause and Controller lookup branch.

Keep partial activation state, the first error, monitor cleanup order, timezone defaults, validation order, and plain cron map shape. Six added tests cover these boundaries. Existing tests cover durable delivery and sensor recovery.

Implements S04-01, S04-02, and S04-03 in the three files from issue #342. Cancellation and desired-versus-running state stay the same. Runtime, validation, and equivalent-branch changes use separate commits.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `c9d6e4bc2f1a405ddae15051e4768fa1daeffa27`.

- 86 focused tests passed, including the new Scheduler runtime tests.
- The final plain full suite and coverage suite each passed 1,048 tests, with one approved DIST-03 exclusion. Coverage was 83.6%; Scheduler 95.7%, Scheduler runtime 88.5%, and SensorManager runtime 88.8%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all five changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The independent final review and supplemental review found no actionable G05 finding.

An earlier full run failed in tracing test cleanup when it stopped an already stopped Agent. An unchanged baseline passed 101 targeted executions; the cause was not proven to be a baseline fault. The final full and coverage runs passed. A separate G06 coverage run without G05 changes hit a scheduled-occurrence persistence conflict. Its baseline did not reproduce the conflict; its later retry passed. Both earlier failures remain in the saved evidence, without an assigned cause.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `fd14b28cc4d81323d29c1c9c160124c4db9b9ca3`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991764179).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #342. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
