### PR TITLE
refactor: simplify persistence and runtime store access

### DIFF
--- a/lib/jido/persistence.ex
+++ b/lib/jido/persistence.ex
@@ -156,24 +156,18 @@ defmodule Jido.Persistence do
 
   defp resolve_instance_config(_jido), do: {:ok, nil}
 
-  defp resolve_source(source, opts) when is_atom(source) and not is_nil(source) do
-    if function_exported?(source, :__jido_persistence__, 0) do
-      with {:ok, config} <- resolve_instance_config(source),
-           {:ok, config} <- require_adapter(config) do
-        {:ok, config, Keyword.get(opts, :instance, source)}
-      end
-    else
-      with {:ok, config} <- resolve_config(source, nil),
-           {:ok, config} <- require_adapter(config) do
-        {:ok, config, Keyword.get(opts, :instance)}
-      end
-    end
-  end
-
   defp resolve_source(source, opts) do
-    with {:ok, config} <- resolve_config(source, nil),
+    {config_result, default_instance} =
+      if is_atom(source) and not is_nil(source) and
+           function_exported?(source, :__jido_persistence__, 0) do
+        {resolve_instance_config(source), source}
+      else
+        {resolve_config(source, nil), nil}
+      end
+
+    with {:ok, config} <- config_result,
          {:ok, config} <- require_adapter(config) do
-      {:ok, config, Keyword.get(opts, :instance)}
+      {:ok, config, Keyword.get(opts, :instance, default_instance)}
     end
   end
 
@@ -259,8 +253,7 @@ defmodule Jido.Persistence do
     }
 
     with true <- is_integer(revision) and revision >= 0,
-         {:ok, checkpoint} <- Agent.checkpoint(agent, context),
-         true <- is_map(checkpoint) do
+         {:ok, checkpoint} <- Agent.checkpoint(agent, context) do
       record = %{
         format: @format_version,
         kind: :agent,

--- a/lib/jido/runtime_store.ex
+++ b/lib/jido/runtime_store.ex
@@ -165,13 +165,7 @@ defmodule Jido.RuntimeStore do
     server = Jido.runtime_store_name(instance)
 
     try do
-      case GenServer.whereis(server) do
-        nil ->
-          fallback
-
-        _pid ->
-          GenServer.call(server, request)
-      end
+      GenServer.call(server, request)
     catch
       :exit, {:noproc, _} -> fallback
       :exit, {:normal, _} -> fallback

--- a/test/jido/persistence_test.exs
+++ b/test/jido/persistence_test.exs
@@ -8,6 +8,94 @@ defmodule JidoTest.PersistenceTest do
   alias Jido.Signal
   alias JidoTest.AgentRuntimeFixtures.RuntimeAgent
 
+  defmodule ConfiguredInstance do
+    def __jido_persistence__, do: {ETS, table: __MODULE__}
+  end
+
+  defmodule DisabledInstance do
+    def __jido_persistence__, do: nil
+  end
+
+  defmodule InvalidInstance do
+    def __jido_persistence__, do: {:invalid, :options}
+  end
+
+  defmodule RaisingInstance do
+    def __jido_persistence__, do: raise("invalid instance config")
+  end
+
+  defmodule CheckpointAgent do
+    use Jido.Agent, name: "checkpoint_contract", schema: Zoi.object(%{reply: Zoi.any()})
+
+    @impl true
+    def checkpoint(agent, _context), do: agent.state.reply
+  end
+
+  test "instance sources use their default namespace and honor explicit overrides" do
+    agent = RuntimeAgent.new!(id: unique_id("namespace"))
+    direct = ConfiguredInstance.__jido_persistence__()
+
+    for {opts, namespace} <- [
+          {[], ConfiguredInstance},
+          {[instance: nil], nil},
+          {[instance: :override], :override}
+        ] do
+      assert :ok = Persistence.save_agent(ConfiguredInstance, agent, opts)
+
+      assert {:ok, ^agent} =
+               Persistence.load_agent(direct, RuntimeAgent, agent.id, instance: namespace)
+
+      assert {:ok, ^agent} =
+               Persistence.load_agent(ConfiguredInstance, RuntimeAgent, agent.id, opts)
+
+      assert :ok = Persistence.delete_agent(ConfiguredInstance, RuntimeAgent, agent.id, opts)
+
+      assert {:error, :not_found} =
+               Persistence.load_agent(direct, RuntimeAgent, agent.id, instance: namespace)
+    end
+  end
+
+  test "source resolution preserves disabled and invalid configuration errors" do
+    agent = RuntimeAgent.new!(id: unique_id("config"))
+
+    for call <- [
+          &Persistence.save_agent(&1, agent),
+          &Persistence.load_agent(&1, RuntimeAgent, agent.id),
+          &Persistence.delete_agent(&1, RuntimeAgent, agent.id)
+        ] do
+      for source <- [nil, false, :inherit, DisabledInstance] do
+        assert {:error, :persistence_not_configured} = call.(source)
+      end
+
+      for source <- [InvalidInstance, RaisingInstance, {:invalid, :options}] do
+        assert {:error, {:invalid_persistence_config, _}} = call.(source)
+      end
+
+      assert {:error, {:invalid_persistence_adapter, String}} = call.(String)
+    end
+  end
+
+  test "checkpoint callback failures and invalid revisions cannot write a record" do
+    persistence = adapter(:callback)
+
+    for reply <- [{:ok, :invalid}, {:ok, %URI{}}, {:error, :checkpoint_failed}] do
+      agent = CheckpointAgent.new!(id: unique_id("callback"), state: %{reply: reply})
+      expected = Agent.checkpoint(agent)
+      assert {:error, _} = expected
+      assert ^expected = Persistence.save_agent(persistence, agent)
+      assert {:error, :not_found} = Persistence.load_agent(persistence, CheckpointAgent, agent.id)
+    end
+
+    agent = RuntimeAgent.new!(id: unique_id("revision"))
+
+    for revision <- [-1, nil, "0"] do
+      assert {:error, {:invalid_checkpoint, :shape}} =
+               Persistence.save_agent(persistence, agent, revision: revision)
+    end
+
+    assert {:error, :not_found} = Persistence.load_agent(persistence, RuntimeAgent, agent.id)
+  end
+
   defmodule RaisingAdapter do
     @behaviour Jido.Persistence.Adapter
 

--- a/test/jido/persistence_test.exs
+++ b/test/jido/persistence_test.exs
@@ -80,9 +80,16 @@ defmodule JidoTest.PersistenceTest do
 
     for reply <- [{:ok, :invalid}, {:ok, %URI{}}, {:error, :checkpoint_failed}] do
       agent = CheckpointAgent.new!(id: unique_id("callback"), state: %{reply: reply})
-      expected = Agent.checkpoint(agent)
-      assert {:error, _} = expected
-      assert ^expected = Persistence.save_agent(persistence, agent)
+
+      case reply do
+        {:ok, invalid} ->
+          assert {:error, %Jido.Error.ValidationError{details: %{checkpoint: ^invalid}}} =
+                   Persistence.save_agent(persistence, agent)
+
+        {:error, reason} ->
+          assert {:error, ^reason} = Persistence.save_agent(persistence, agent)
+      end
+
       assert {:error, :not_found} = Persistence.load_agent(persistence, CheckpointAgent, agent.id)
     end
 

--- a/test/jido/runtime_store_test.exs
+++ b/test/jido/runtime_store_test.exs
@@ -3,6 +3,89 @@ defmodule JidoTest.RuntimeStoreTest do
 
   alias Jido.RuntimeStore
 
+  test "a stopped worker returns the fallback for each operation", %{jido: jido} do
+    assert :ok = Supervisor.terminate_child(jido, Jido.runtime_store_name(jido))
+
+    for {call, fallback} <- calls(jido) do
+      assert call.() == fallback
+    end
+  end
+
+  test "a normal exit during a call returns each operation's fallback", %{jido: jido} do
+    assert :ok = Supervisor.terminate_child(jido, Jido.runtime_store_name(jido))
+
+    for {call, fallback} <- calls(jido) do
+      worker = start_call_worker(jido)
+      task = Task.async(call)
+      assert_receive {:request, ^worker, _request}, 1_000
+      ref = Process.monitor(worker)
+      send(worker, {:exit, :normal})
+      assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 1_000
+      assert Task.await(task) == fallback
+    end
+  end
+
+  test "an abnormal worker exit reaches the caller", %{jido: jido} do
+    assert :ok = Supervisor.terminate_child(jido, Jido.runtime_store_name(jido))
+    worker = start_call_worker(jido)
+    task = Task.async(fn -> catch_exit(RuntimeStore.fetch(jido, :hive, :key)) end)
+    assert_receive {:request, ^worker, _request}, 1_000
+    send(worker, {:exit, :shutdown})
+    assert {:shutdown, {GenServer, :call, _}} = Task.await(task)
+  end
+
+  test "a write timeout propagates even when the worker later completes it", %{jido: jido} do
+    assert :ok = Supervisor.terminate_child(jido, Jido.runtime_store_name(jido))
+    worker = start_call_worker(jido)
+    task = Task.async(fn -> catch_exit(RuntimeStore.put(jido, :hive, :key, :value)) end)
+    assert_receive {:request, ^worker, {:put, :hive, :key, :value}}, 1_000
+    assert {:timeout, {GenServer, :call, _}} = Task.await(task, 6_000)
+    send(worker, :complete)
+    assert_receive {:completed, ^worker}, 1_000
+    assert [{{:hive, :key}, :value}] = :ets.lookup(Jido.runtime_store_name(jido), {:hive, :key})
+  end
+
+  defp calls(jido) do
+    [
+      {fn -> RuntimeStore.fetch(jido, :hive, :key) end, :error},
+      {fn -> RuntimeStore.get(jido, :hive, :key, :default) end, :default},
+      {fn -> RuntimeStore.put(jido, :hive, :key, :value) end, {:error, :not_running}},
+      {fn -> RuntimeStore.delete(jido, :hive, :key) end, {:error, :not_running}},
+      {fn -> RuntimeStore.list(jido, :hive) end, []}
+    ]
+  end
+
+  defp start_call_worker(jido) do
+    observer = self()
+
+    worker =
+      spawn(fn ->
+        receive do
+          {:"$gen_call", from, request} ->
+            send(observer, {:request, self(), request})
+
+            receive do
+              {:exit, reason} ->
+                exit(reason)
+
+              :complete ->
+                {:put, hive, key, value} = request
+                :ets.insert(Jido.runtime_store_name(jido), {{hive, key}, value})
+                GenServer.reply(from, :ok)
+                send(observer, {:completed, self()})
+            after
+              10_000 -> exit(:barrier_timeout)
+            end
+        after
+          10_000 -> exit(:request_timeout)
+        end
+      end)
+
+    on_exit(fn -> Process.exit(worker, :kill) end)
+    Process.register(worker, Jido.runtime_store_name(jido))
+    worker
+  end
+
   describe "RuntimeStore" do
     test "supports put/get/fetch/delete within a hive", %{jido: jido} do
       assert :error == RuntimeStore.fetch(jido, :relationships, "child-1")


### PR DESCRIPTION
Persistence used duplicate paths to select an adapter and instance namespace. RuntimeStore checked for a process before it called that process. This refactor shares the persistence result path and calls RuntimeStore once with its existing exit handling.

Explicit `instance: nil` still overrides the instance default. Checkpoint output validation stays in `Agent.checkpoint/2`; revision, portability, stored record and restored identity checks stay in Persistence. RuntimeStore keeps each fallback and propagates timeouts and other exits.

Scope: S06-01, S06-02 and S06-03. Production changes are limited to `lib/jido/persistence.ex` and `lib/jido/runtime_store.ex`. No adapter, record, revision, ETS ownership or Thread changes.

New tests cover explicit nil and custom namespaces, configuration errors, invalid checkpoint results and revisions, stopped-worker fallbacks, normal and abnormal exits, and timeout propagation followed by a write.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `5fac0a2fa94021b415c8968829017702e7da81b6`.

- 99 focused tests passed.
- 1,049 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.4%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on four changed files returned exit 16 for one unchanged test-helper warning. Exact baseline files produced the same warning; no new lint warning was found.

Independent `gpt-6-astra` review with `xhigh` effort is complete. One P2 error-comparison test finding was corrected and verified. The reviewer checked the final issue diff and evidence. No actionable finding remains.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `5c13b38525a5904a9cc9efc8439b8810757815b6`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991769317).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #344. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
