### PR TITLE
refactor: reuse authoring data in topology planning and encoding

### DIFF
--- a/lib/jido/agent/codec/data.ex
+++ b/lib/jido/agent/codec/data.ex
@@ -98,8 +98,9 @@ defmodule Jido.Agent.Codec.Data do
              _ ->
                Authoring.error("Invalid map entry")
            end),
-         true <- length(pairs) == map_size(Map.new(pairs)) do
-      {:ok, Map.new(pairs)}
+         decoded = Map.new(pairs),
+         true <- length(pairs) == map_size(decoded) do
+      {:ok, decoded}
     else
       false -> Authoring.error("Duplicate decoded map key")
       error -> error

--- a/lib/jido/topology.ex
+++ b/lib/jido/topology.ex
@@ -9,7 +9,7 @@ defmodule Jido.Topology do
   """
 
   alias Jido.Agent.Authoring
-  alias Jido.Topology.{Instance, Validation}
+  alias Jido.Topology.{Composition, Instance, Plan, Validation}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -58,13 +58,15 @@ defmodule Jido.Topology do
 
   @doc "Validates static authoring data."
   @spec new(map() | keyword() | t()) :: {:ok, t()} | {:error, Exception.t()}
-  def new(%__MODULE__{} = definition), do: definition |> Map.from_struct() |> new()
-
   def new(attrs) do
+    with {:ok, definition, _composed} <- new_with_composition(attrs), do: {:ok, definition}
+  end
+
+  defp new_with_composition(attrs) do
     with {:ok, attrs} <- Validation.definition(attrs),
-         :ok <- Jido.Topology.Composition.validate(attrs),
+         {:ok, composed} <- Composition.flatten(attrs),
          {:ok, definition} <- Zoi.parse(@schema, attrs),
-         do: {:ok, definition}
+         do: {:ok, definition, composed}
   end
 
   @doc "Validates a definition or raises its error."
@@ -73,12 +75,12 @@ defmodule Jido.Topology do
   @doc "Validates instance input and builds a stable local execution plan."
   @spec instantiate(t(), map() | keyword()) :: {:ok, Instance.t()} | {:error, Exception.t()}
   def instantiate(definition, opts) do
-    with {:ok, definition} <- new(definition),
+    with {:ok, definition, composed} <- new_with_composition(definition),
          {:ok, opts} <- Authoring.attrs(opts),
          :ok <- Authoring.keys(opts, [:id, :input]),
          {:ok, id} <- Validation.key(Map.get(opts, :id)),
          {:ok, input} <- Validation.parse_input(definition.schema, Map.get(opts, :input, %{})),
-         {:ok, plan} <- Jido.Topology.Plan.build(definition, id, input) do
+         {:ok, plan} <- Plan.build_composed(definition, id, input, composed) do
       {:ok, %Instance{id: id, definition: definition, input: input, plan: plan}}
     end
   end

--- a/lib/jido/topology/codec.ex
+++ b/lib/jido/topology/codec.ex
@@ -39,7 +39,7 @@ defmodule Jido.Topology.Codec do
   def encode(definition) do
     with {:ok, definition} <- Topology.new(definition),
          {:ok, registry} <- Value.registry(definition),
-         {:ok, document} <- encode(definition, registry),
+         {:ok, document} <- encode_validated(definition, registry),
          do: {:ok, document, registry}
   end
 
@@ -47,7 +47,11 @@ defmodule Jido.Topology.Codec do
   def encode(definition, registry) do
     with {:ok, definition} <- Topology.new(definition),
          {:ok, registry} <- Registry.new(registry),
-         {:ok, schema} <- Registry.identifier(registry, :schema, definition.schema),
+         do: encode_validated(definition, registry)
+  end
+
+  defp encode_validated(definition, registry) do
+    with {:ok, schema} <- Registry.identifier(registry, :schema, definition.schema),
          {:ok, metadata} <- Value.encode(definition.metadata, registry),
          {:ok, collections} <-
            Authoring.traverse(@collections, fn kind ->

--- a/lib/jido/topology/plan.ex
+++ b/lib/jido/topology/plan.ex
@@ -22,7 +22,17 @@ defmodule Jido.Topology.Plan do
   def build(definition, id, input) do
     with :ok <- root_imports(definition),
          {:ok, composed} <- Composition.flatten(definition),
-         {:ok, inputs} <- Composition.inputs(definition, input),
+         do: expand_plan(definition, id, input, composed)
+  end
+
+  # The caller must supply the composition from this definition's validation.
+  @doc false
+  def build_composed(definition, id, input, composed) do
+    with :ok <- root_imports(definition), do: expand_plan(definition, id, input, composed)
+  end
+
+  defp expand_plan(definition, id, input, composed) do
+    with {:ok, inputs} <- Composition.inputs(definition, input),
          {:ok, expanded} <- expand(composed.nodes, inputs, definition.startup.max_agents),
          {:ok, agents} <-
            Authoring.traverse(expanded, &agent(&1, id, Map.fetch!(inputs, &1.scope))),

--- a/test/jido/agent/authoring_test.exs
+++ b/test/jido/agent/authoring_test.exs
@@ -502,6 +502,31 @@ defmodule JidoTest.Agent.AuthoringTest do
     assert {:error, _} = Codec.decode(document, registry, state: %{count: "bad"})
   end
 
+  test "decoded map aliases reject duplicates after all entries decode" do
+    alias Jido.Agent.Codec.Data
+
+    registry = Registry.new!(%{"key" => {:atom, :key}, "alias" => {:alias, "key"}})
+    key = %{"$type" => "atom", "id" => "key"}
+    same_key = %{"$type" => "atom", "id" => "alias"}
+    entries = [[key, 1], [same_key, 2]]
+
+    assert {:ok, %{"other" => 2, key: 1}} =
+             Data.decode(%{"$type" => "map", "entries" => [[key, 1], ["other", 2]]}, registry)
+
+    assert {:error, error} = Data.decode(%{"$type" => "map", "entries" => entries}, registry)
+    assert Exception.message(error) =~ "Duplicate decoded map key"
+
+    for {tail, message} <- [
+          {["invalid"], "Invalid map entry"},
+          {["later", %{"$type" => "unknown"}], "Invalid tagged authoring value"}
+        ] do
+      assert {:error, error} =
+               Data.decode(%{"$type" => "map", "entries" => entries ++ [tail]}, registry)
+
+      assert Exception.message(error) =~ message
+    end
+  end
+
   test "Codec bounds documents and rejects runtime data on encode" do
     {:ok, document, registry} = Codec.encode(Counter.agent())
     deep = Enum.reduce(1..102, nil, fn _, acc -> [acc] end)

--- a/test/jido/topology/authoring_test.exs
+++ b/test/jido/topology/authoring_test.exs
@@ -179,6 +179,35 @@ defmodule Jido.Topology.AuthoringTest do
     assert {:error, _} = Codec.decode(%{document | "groups" => nil}, Formats.registry())
   end
 
+  test "both Codec entry points validate definitions before encoding" do
+    definition = Swarm.topology()
+    invalid = %{definition | metadata: %{pid: self()}}
+    assert {:error, error} = Topology.new(invalid)
+    assert {:error, ^error} = Codec.encode(invalid)
+    assert {:error, ^error} = Codec.encode(invalid, :invalid_registry)
+
+    assert {:error, _} = Codec.encode(definition, :invalid_registry)
+    assert {:error, _} = Codec.encode(definition, %{})
+    assert {:ok, document, registry} = Codec.encode(definition)
+    assert document["version"] == 2
+    assert {:ok, ^document} = Codec.encode(definition, registry)
+
+    v1 = document |> Map.drop(~w(includes imports exports)) |> Map.put("version", 1)
+    assert {:ok, ^definition} = Codec.decode(v1, registry)
+  end
+
+  test "both Codec entry points retain data and output document bounds" do
+    definition = Swarm.topology()
+    {:ok, _, registry} = Codec.encode(definition)
+    deep = Enum.reduce(1..102, nil, fn _, acc -> [acc] end)
+
+    for value <- [deep, List.duplicate(0, 10_001), String.duplicate("a", 1_048_577)] do
+      oversized = %{definition | metadata: %{"value" => value}}
+      assert {:error, _} = Codec.encode(oversized)
+      assert {:error, _} = Codec.encode(oversized, registry)
+    end
+  end
+
   test "Codec excludes instance and runtime data" do
     assert {:ok, instance} = Swarm.new(id: "private", input: %{worker_count: 2})
     assert {:error, _} = Codec.encode(instance)

--- a/test/jido/topology/authoring_test.exs
+++ b/test/jido/topology/authoring_test.exs
@@ -183,8 +183,10 @@ defmodule Jido.Topology.AuthoringTest do
     definition = Swarm.topology()
     invalid = %{definition | metadata: %{pid: self()}}
     assert {:error, error} = Topology.new(invalid)
-    assert {:error, ^error} = Codec.encode(invalid)
-    assert {:error, ^error} = Codec.encode(invalid, :invalid_registry)
+    assert {:error, derived_error} = Codec.encode(invalid)
+    assert {:error, supplied_error} = Codec.encode(invalid, :invalid_registry)
+    assert Map.drop(derived_error, [:stacktrace]) == Map.drop(error, [:stacktrace])
+    assert Map.drop(supplied_error, [:stacktrace]) == Map.drop(error, [:stacktrace])
 
     assert {:error, _} = Codec.encode(definition, :invalid_registry)
     assert {:error, _} = Codec.encode(definition, %{})

--- a/test/jido/topology/composition_test.exs
+++ b/test/jido/topology/composition_test.exs
@@ -47,7 +47,10 @@ defmodule Jido.Topology.CompositionTest do
 
     assert {:error, opts_error} = Topology.instantiate(definition, unexpected: true)
     assert Exception.message(opts_error) =~ "Unknown"
-    assert {:error, input_error} = Topology.instantiate(definition, id: "root", input: %{worker_count: -1})
+
+    assert {:error, input_error} =
+             Topology.instantiate(definition, id: "root", input: %{worker_count: -1})
+
     assert Exception.message(input_error) =~ "input"
 
     assert {:error, root_error} = Topology.instantiate(definition, id: "root")
@@ -56,7 +59,9 @@ defmodule Jido.Topology.CompositionTest do
   end
 
   test "direct Plan construction still checks the declaration graph" do
-    definition = Builder.new(name: "cycle") |> Builder.group(:workers, Cell, count: 0) |> Builder.build!()
+    definition =
+      Builder.new(name: "cycle") |> Builder.group(:workers, Cell, count: 0) |> Builder.build!()
+
     [group] = definition.groups
     invalid = %{definition | groups: [%{group | depends_on: ["workers"]}]}
 

--- a/test/jido/topology/composition_test.exs
+++ b/test/jido/topology/composition_test.exs
@@ -31,6 +31,40 @@ defmodule Jido.Topology.CompositionTest do
     assert instance.definition.startup.concurrency == 4
   end
 
+  test "direct Plan construction equals instance planning with normalized input" do
+    for input <- [%{east_workers: 0, west_workers: 2}, %{east_workers: 3, west_workers: 1}] do
+      instance = ComposedSystem.new!(id: "direct/plan", input: input)
+      assert {:ok, plan} = Plan.build(instance.definition, instance.id, instance.input)
+      assert plan == instance.plan
+    end
+  end
+
+  test "instance validation keeps graph, options, input, and root import error order" do
+    definition = WorkerTeam.topology()
+    invalid = %{definition | exports: [%{key: "missing", kind: :agent, from: "missing"}]}
+    assert {:error, graph_error} = Topology.new(invalid)
+    assert {:error, ^graph_error} = Topology.instantiate(invalid, unexpected: true)
+
+    assert {:error, opts_error} = Topology.instantiate(definition, unexpected: true)
+    assert Exception.message(opts_error) =~ "Unknown"
+    assert {:error, input_error} = Topology.instantiate(definition, id: "root", input: %{worker_count: -1})
+    assert Exception.message(input_error) =~ "input"
+
+    assert {:error, root_error} = Topology.instantiate(definition, id: "root")
+    assert Exception.message(root_error) =~ "unbound imports"
+    assert {:error, ^root_error} = Plan.build(invalid, "root", %{})
+  end
+
+  test "direct Plan construction still checks the declaration graph" do
+    definition = Builder.new(name: "cycle") |> Builder.group(:workers, Cell, count: 0) |> Builder.build!()
+    [group] = definition.groups
+    invalid = %{definition | groups: [%{group | depends_on: ["workers"]}]}
+
+    assert {:error, error} = Plan.build(invalid, "cycle", %{})
+    assert Exception.message(error) =~ "cycle"
+    assert {:error, ^error} = Topology.instantiate(invalid, id: "cycle")
+  end
+
   test "inputs and identities are isolated while Bus bindings share one owner" do
     instance = ComposedSystem.new!(id: "system", input: %{east_workers: 1, west_workers: 2})
     east = instance.plan.agents["component/east/group/workers/1"]

--- a/test/jido/topology/composition_test.exs
+++ b/test/jido/topology/composition_test.exs
@@ -43,7 +43,8 @@ defmodule Jido.Topology.CompositionTest do
     definition = WorkerTeam.topology()
     invalid = %{definition | exports: [%{key: "missing", kind: :agent, from: "missing"}]}
     assert {:error, graph_error} = Topology.new(invalid)
-    assert {:error, ^graph_error} = Topology.instantiate(invalid, unexpected: true)
+    assert {:error, instance_error} = Topology.instantiate(invalid, unexpected: true)
+    assert Map.drop(instance_error, [:stacktrace]) == Map.drop(graph_error, [:stacktrace])
 
     assert {:error, opts_error} = Topology.instantiate(definition, unexpected: true)
     assert Exception.message(opts_error) =~ "Unknown"
@@ -55,7 +56,8 @@ defmodule Jido.Topology.CompositionTest do
 
     assert {:error, root_error} = Topology.instantiate(definition, id: "root")
     assert Exception.message(root_error) =~ "unbound imports"
-    assert {:error, ^root_error} = Plan.build(invalid, "root", %{})
+    assert {:error, plan_error} = Plan.build(invalid, "root", %{})
+    assert Map.drop(plan_error, [:stacktrace]) == Map.drop(root_error, [:stacktrace])
   end
 
   test "direct Plan construction still checks the declaration graph" do
@@ -67,7 +69,8 @@ defmodule Jido.Topology.CompositionTest do
 
     assert {:error, error} = Plan.build(invalid, "cycle", %{})
     assert Exception.message(error) =~ "cycle"
-    assert {:error, ^error} = Topology.instantiate(invalid, id: "cycle")
+    assert {:error, instance_error} = Topology.instantiate(invalid, id: "cycle")
+    assert Map.drop(instance_error, [:stacktrace]) == Map.drop(error, [:stacktrace])
   end
 
   test "inputs and identities are isolated while Bus bindings share one owner" do


### PR DESCRIPTION
Authoring repeated map construction, composition flattening, and definition validation within one call. Build each decoded map once, retain the current composition result for instance planning, and share a private encoding worker between the two Topology codec entry points.

Keep error order, direct `Plan.build/3` validation, declaration and expanded graph checks, Registry checks, document limits, nested encoding, v2 output, and v1 decoding. No cross-call cache or public cache fields are added. Production changes are limited to the four files in #339 (S01-03, S05-03, S05-04).

The undocumented `Plan.build_composed/4` entry receives only the fresh composition from the current validation. Tests cover decoded alias keys, error order, direct Plan equality, codec boundaries, and version compatibility. Public APIs are unchanged.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `8437a9f83ffde988d52823855de7ff0936486d9f`.

- 72 focused tests passed.
- 1,048 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.3%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all seven changed files returned exit 16 for one existing `Module.concat/2` warning in the authoring test helper. Exact baseline files produced the same warning; no new lint warning was found.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer verified the final issue base, head, and check evidence. No actionable finding was found.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `3ae92da874e2767dded61069ba6f5614a8266f26`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991751928).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #339. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
