### PR TITLE
refactor(agent_server): use one attachment monitor map

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -448,8 +448,7 @@ defmodule Jido.AgentServer do
         pool_key: opts.pool_key,
         idle_timeout: opts.idle_timeout,
         persistence: opts.persistence,
-        attachments: MapSet.new(),
-        attachment_monitors: %{},
+        attachments: %{},
         idle_timer: nil,
         spawn_fun: opts.spawn_fun,
         debug: opts.debug,
@@ -1623,7 +1622,7 @@ defmodule Jido.AgentServer do
         error_count: data.error_count,
         lifecycle: %{
           pool: data.pool,
-          attached: MapSet.size(data.attachments),
+          attached: map_size(data.attachments),
           idle_timeout: data.idle_timeout,
           idle_timer?: not is_nil(data.idle_timer)
         }
@@ -1858,11 +1857,11 @@ defmodule Jido.AgentServer do
   defp maybe_log_cast_failure(_from, _signal, _reason, _agent_id), do: :ok
 
   defp handle_process_down(ref, pid, reason, phase, %State{} = data) do
-    case Map.fetch(data.attachment_monitors, ref) do
-      {:ok, ^pid} ->
+    case Map.fetch(data.attachments, pid) do
+      {:ok, ^ref} ->
         next_data =
           data
-          |> remove_attachment(ref, pid)
+          |> remove_attachment(pid)
           |> maybe_start_idle_timer(phase)
 
         {:keep_state, next_data}
@@ -2454,7 +2453,7 @@ defmodule Jido.AgentServer do
       not Process.alive?(owner_pid) ->
         {:error, :owner_not_alive}
 
-      MapSet.member?(data.attachments, owner_pid) ->
+      Map.has_key?(data.attachments, owner_pid) ->
         {:ok, cancel_idle_timer(data)}
 
       true ->
@@ -2463,29 +2462,24 @@ defmodule Jido.AgentServer do
         {:ok,
          %{
            cancel_idle_timer(data)
-           | attachments: MapSet.put(data.attachments, owner_pid),
-             attachment_monitors: Map.put(data.attachment_monitors, ref, owner_pid)
+           | attachments: Map.put(data.attachments, owner_pid, ref)
          }}
     end
   end
 
   defp detach_owner(%State{} = data, owner_pid) do
-    case Enum.find(data.attachment_monitors, fn {_ref, pid} -> pid == owner_pid end) do
-      {ref, ^owner_pid} ->
+    case Map.fetch(data.attachments, owner_pid) do
+      {:ok, ref} ->
         Process.demonitor(ref, [:flush])
-        remove_attachment(data, ref, owner_pid)
+        remove_attachment(data, owner_pid)
 
-      nil ->
+      :error ->
         data
     end
   end
 
-  defp remove_attachment(%State{} = data, ref, owner_pid) do
-    %{
-      data
-      | attachments: MapSet.delete(data.attachments, owner_pid),
-        attachment_monitors: Map.delete(data.attachment_monitors, ref)
-    }
+  defp remove_attachment(%State{} = data, owner_pid) do
+    %{data | attachments: Map.delete(data.attachments, owner_pid)}
   end
 
   defp maybe_start_idle_timer(%State{} = data, phase) when phase != :idle, do: data
@@ -2497,7 +2491,7 @@ defmodule Jido.AgentServer do
        do: data
 
   defp maybe_start_idle_timer(%State{} = data, :idle) do
-    if MapSet.size(data.attachments) == 0 do
+    if map_size(data.attachments) == 0 do
       timer = :erlang.start_timer(data.idle_timeout, self(), :agent_idle_timeout)
       %{data | idle_timer: timer}
     else

--- a/lib/jido/agent_server/state.ex
+++ b/lib/jido/agent_server/state.ex
@@ -41,9 +41,8 @@ defmodule Jido.AgentServer.State do
               persistence:
                 Zoi.any(description: "Optional Agent persistence adapter") |> Zoi.optional(),
               attachments:
-                Zoi.any(description: "Attached owner process set") |> Zoi.default(MapSet.new()),
-              attachment_monitors:
-                Zoi.map(description: "Attachment monitor references") |> Zoi.default(%{}),
+                Zoi.map(description: "Attached owner PIDs and monitor references")
+                |> Zoi.default(%{}),
               idle_timer: Zoi.any(description: "Current idle timer") |> Zoi.optional(),
               spawn_fun:
                 Zoi.any(description: "Optional process spawn function") |> Zoi.optional(),

--- a/test/jido/agent/idle_lifecycle_test.exs
+++ b/test/jido/agent/idle_lifecycle_test.exs
@@ -45,6 +45,27 @@ defmodule Jido.Agent.IdleLifecycleTest do
     assert %{attached: 0, idle_timer?: true} = Server.status(server).runtime.lifecycle
   end
 
+  test "DOWN requires the current owner and monitor reference", %{jido: jido} do
+    owner = start_supervised!({Elixir.Agent, fn -> nil end})
+    {:ok, server} = Jido.start_agent(jido, IdleAgent, idle_timeout: 10_000)
+    assert :ok = Server.attach(server, owner)
+    {:idle, state} = :sys.get_state(server)
+    old_ref = Map.fetch!(state.attachments, owner)
+    assert :ok = Server.detach(server, owner)
+    assert :ok = Server.attach(server, owner)
+    {:idle, state} = :sys.get_state(server)
+    current_ref = Map.fetch!(state.attachments, owner)
+    refute current_ref == old_ref
+
+    send(server, {:DOWN, old_ref, :process, owner, :normal})
+    send(server, {:DOWN, current_ref, :process, self(), :normal})
+    assert %{attached: 1, idle_timer?: false} = Server.status(server).runtime.lifecycle
+
+    Elixir.Agent.stop(owner)
+    eventually(fn -> Server.status(server).runtime.lifecycle.attached == 0 end)
+    assert %{attached: 0, idle_timer?: true} = Server.status(server).runtime.lifecycle
+  end
+
   test "owner death releases the attachment and a timer stops the server", %{jido: jido} do
     owner = start_supervised!({Elixir.Agent, fn -> nil end})
     {:ok, server} = Jido.start_agent(jido, IdleAgent, idle_timeout: 10_000)


### PR DESCRIPTION
Use one owner PID-to-monitor map for AgentServer attachments. Detach no longer scans a second map. A DOWN event removes an owner only if both PID and monitor reference match. Attach/detach replies, attachment counts and idle timer behavior stay the same.

Scope: S02-01, production changes only in `lib/jido/agent_server.ex` and `lib/jido/agent_server/state.ex`.

The added test rejects a stale reference after detach/reattach and a correct reference with the wrong PID. It also checks that actual owner death starts the idle timer. Public APIs, persistence, encoding, and telemetry stay the same.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `991b5d08e28723b7965f6bdc2ed59bb123346766`.

- 91 focused tests passed for this attachment patch.
- The combined G03 head, including child PR #357, passed 1,049 full-suite tests with one approved DIST-03 exclusion. Its coverage repeat passed the same selection: 83.5% total, AgentServer 84.3%, and State 100%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on the five combined changed files returned exit 16 for four Logger metadata warnings. Exact baseline files produced the same warnings. The foundation now adds those Logger keys.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer checked this parent at `20d2f39bb5e7b81c3f0454188ac2b49a99f55c74` and child #357 at `991b5d08e28723b7965f6bdc2ed59bb123346766` against their exact bases. No actionable finding or required source fix was found.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `c4c91f46afa892424deff65e22602819c53e0e3c`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991757157).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #340. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
