### PR TITLE
refactor(topology): narrow startup task inputs

### DIFF
--- a/lib/jido/topology/controller/activation.ex
+++ b/lib/jido/topology/controller/activation.ex
@@ -5,14 +5,14 @@ defmodule Jido.Topology.Controller.Activation do
   alias Jido.AgentServer, as: Server
   alias Jido.Topology.BusInputs
 
-  def start(spec, state) do
-    with {:ok, persistence} <- Jido.Persistence.resolve_config(:inherit, state.jido),
-         {:ok, agent_state, version, restore} <- saved_state(spec, state, persistence),
-         {:ok, definition} <- definition(spec, state),
+  def start(spec, context) do
+    with {:ok, persistence} <- Jido.Persistence.resolve_config(:inherit, context.jido),
+         {:ok, agent_state, version, restore} <- saved_state(spec, context, persistence),
+         {:ok, definition} <- definition(spec, context),
          {:ok, agent} <- Agent.instantiate(definition, id: spec.id, state: agent_state) do
       options = [
         agent: agent,
-        jido: state.jido,
+        jido: context.jido,
         register: true,
         on_parent_death: spec.on_parent_exit,
         persistence: persistence,
@@ -21,7 +21,7 @@ defmodule Jido.Topology.Controller.Activation do
       ]
 
       child = Supervisor.child_spec({Server, options}, restart: :temporary)
-      pool = Jido.agent_supervisor_name(state.jido)
+      pool = Jido.agent_supervisor_name(context.jido)
 
       with {:ok, pid} <- DynamicSupervisor.start_child(pool, child) do
         case Server.await_ready(pid) do
@@ -38,9 +38,9 @@ defmodule Jido.Topology.Controller.Activation do
 
   defp saved_state(spec, _state, nil), do: {:ok, spec.initial_state, 0, :if_found}
 
-  defp saved_state(spec, state, persistence) do
+  defp saved_state(spec, context, persistence) do
     case Jido.Persistence.load_agent_with_revision(persistence, spec.module, spec.id,
-           instance: state.jido
+           instance: context.jido
          ) do
       {:ok, agent, version} when agent.id == spec.id and agent.module == spec.module ->
         {:ok, agent.state, version, false}
@@ -56,12 +56,12 @@ defmodule Jido.Topology.Controller.Activation do
     end
   end
 
-  defp definition(spec, state) do
+  defp definition(spec, context) do
     config = Map.put(spec.module.__agent_config__(), :module, spec.module)
 
     metadata =
       Map.put(Map.get(config, :metadata, %{}), "jido.topology", %{
-        id: state.instance.id,
+        id: context.instance_id,
         key: spec.key
       })
 
@@ -74,9 +74,9 @@ defmodule Jido.Topology.Controller.Activation do
         subscriptions =
           Enum.map(spec.subscriptions, fn sub ->
             [
-              bus: Map.fetch!(state.instance.plan.resources, sub.bus).id,
+              bus: Map.fetch!(context.bus_ids, sub.bus),
               path: sub.path,
-              retry_delay_ms: state.instance.definition.startup.retry_interval
+              retry_delay_ms: context.retry_interval
             ]
           end)
 

--- a/lib/jido/topology/controller/runtime.ex
+++ b/lib/jido/topology/controller/runtime.ex
@@ -155,7 +155,7 @@ defmodule Jido.Topology.Controller.Runtime do
           safely(fn ->
             case Jido.whereis_agent(state.jido, spec.id) do
               nil -> :ok
-              pid -> if owned?(pid, spec, state), do: Jido.stop_agent(state.jido, pid)
+              pid -> if owned?(pid, spec, state.instance.id), do: Jido.stop_agent(state.jido, pid)
             end
           end)
       end
@@ -213,8 +213,11 @@ defmodule Jido.Topology.Controller.Runtime do
   defp dispatch(key, state) do
     supervisor = Controller.name(state.jido, state.instance.id, :tasks)
 
+    member = spec(key, state)
+    context = task_context(key, member, state)
+
     task =
-      Task.Supervisor.async_nolink(supervisor, fn -> safely(fn -> ensure(key, state) end) end)
+      Task.Supervisor.async_nolink(supervisor, fn -> safely(fn -> ensure(member, context) end) end)
 
     timer =
       Process.send_after(
@@ -251,55 +254,64 @@ defmodule Jido.Topology.Controller.Runtime do
     %{state | phase: phase, waiters: if(phase == :ready, do: %{}, else: state.waiters)}
   end
 
-  defp ensure(key, state) do
-    case Map.fetch(state.instance.plan.resources, key) do
-      {:ok, resource} -> ensure_bus(resource, state)
-      :error -> ensure_agent(Map.fetch!(state.instance.plan.agents, key), state)
+  defp task_context(key, member, state) do
+    if Map.has_key?(state.instance.plan.resources, key) do
+      %{jido: state.jido, pool: Controller.name(state.jido, state.instance.id, :resources)}
+    else
+      bus_ids =
+        Map.new(member.subscriptions, fn sub ->
+          {sub.bus, Map.fetch!(state.instance.plan.resources, sub.bus).id}
+        end)
+
+      %{
+        jido: state.jido,
+        instance_id: state.instance.id,
+        parent: if(member.parent, do: Map.fetch!(state.ready, member.parent)),
+        bus_ids: bus_ids,
+        retry_interval: state.instance.definition.startup.retry_interval
+      }
     end
   end
 
-  defp ensure_bus(spec, state) do
-    pool = Controller.name(state.jido, state.instance.id, :resources)
-
-    case Bus.whereis(spec.id, jido: state.jido) do
+  defp ensure(spec, %{pool: pool} = context) do
+    case Bus.whereis(spec.id, jido: context.jido) do
       {:ok, pid} ->
         if Enum.any?(DynamicSupervisor.which_children(pool), &(elem(&1, 1) == pid)),
           do: {:ok, pid},
           else: {:error, :bus_identity_in_use}
 
       _ ->
-        options = Keyword.merge(spec.config, name: spec.id, jido: state.jido)
+        options = Keyword.merge(spec.config, name: spec.id, jido: context.jido)
         DynamicSupervisor.start_child(pool, {Bus, options})
     end
   end
 
-  defp ensure_agent(spec, state) do
-    missing = Enum.reject(spec.depends_on, &Map.has_key?(state.ready, &1))
+  defp ensure(spec, context) do
+    with {:ok, pid} <- activate(spec, context),
+         :ok <- Server.await_ready(pid),
+         :ok <- subscriptions_ready(pid, spec),
+         :ok <- bind_parent(pid, spec, context),
+         do: {:ok, pid}
+  end
 
-    if missing != [] do
-      {:error, {:dependencies_unavailable, missing}}
-    else
-      with {:ok, pid} <- activate(spec, state),
-           :ok <- Server.await_ready(pid),
-           :ok <- subscriptions_ready(pid, spec),
-           :ok <- bind_parent(pid, spec, state),
-           do: {:ok, pid}
+  defp activate(spec, context) do
+    case Jido.whereis_agent(context.jido, spec.id) do
+      nil ->
+        start_agent(spec, context)
+
+      pid ->
+        if owned?(pid, spec, context.instance_id),
+          do: {:ok, pid},
+          else: {:error, :agent_identity_in_use}
     end
   end
 
-  defp activate(spec, state) do
-    case Jido.whereis_agent(state.jido, spec.id) do
-      nil -> start_agent(spec, state)
-      pid -> if owned?(pid, spec, state), do: {:ok, pid}, else: {:error, :agent_identity_in_use}
-    end
-  end
-
-  defp start_agent(spec, state) do
-    with {:ok, pid} <- Controller.Activation.start(spec, state) do
-      if owned?(pid, spec, state) do
+  defp start_agent(spec, context) do
+    with {:ok, pid} <- Controller.Activation.start(spec, context) do
+      if owned?(pid, spec, context.instance_id) do
         {:ok, pid}
       else
-        Jido.stop_agent(state.jido, pid)
+        Jido.stop_agent(context.jido, pid)
         {:error, :restored_agent_identity_in_use}
       end
     end
@@ -316,9 +328,7 @@ defmodule Jido.Topology.Controller.Runtime do
 
   defp bind_parent(_pid, %{parent: nil}, _state), do: :ok
 
-  defp bind_parent(pid, spec, state) do
-    parent = Map.fetch!(state.ready, spec.parent)
-
+  defp bind_parent(pid, spec, %{parent: parent}) do
     case Map.get(Server.children(parent), spec.key) do
       %{pid: ^pid} -> :ok
       nil -> Server.adopt_child(parent, pid, spec.key)
@@ -326,13 +336,13 @@ defmodule Jido.Topology.Controller.Runtime do
     end
   end
 
-  defp marker(spec, state), do: %{id: state.instance.id, key: spec.key}
+  defp marker(spec, instance_id), do: %{id: instance_id, key: spec.key}
 
-  defp owned?(pid, spec, state) do
+  defp owned?(pid, spec, instance_id) do
     agent = Server.agent(pid)
 
     agent.module == spec.module and
-      Map.get(agent.metadata, "jido.topology") == marker(spec, state)
+      Map.get(agent.metadata, "jido.topology") == marker(spec, instance_id)
   end
 
   defp safely(fun) do

--- a/test/jido/topology/composition_runtime_test.exs
+++ b/test/jido/topology/composition_runtime_test.exs
@@ -92,6 +92,57 @@ defmodule Jido.Topology.CompositionRuntimeTest do
     assert :ok = Controller.await_ready(controller)
   end
 
+  test "child activation keeps the parent PID from dispatch", %{jido: jido} do
+    :persistent_term.put({BlockReady, :observer}, self())
+    on_exit(fn -> :persistent_term.erase({BlockReady, :observer}) end)
+
+    instance =
+      Builder.new(name: "parent-snapshot")
+      |> Builder.agent(:parent, Cell)
+      |> Builder.agent(:child, SlowCell)
+      |> Builder.owns(:parent, :child)
+      |> Builder.startup(task_timeout: 5_000, retry_interval: 60_000)
+      |> Builder.build!(id: "parent-snapshot")
+
+    controller = start_supervised!({Controller, jido: jido, topology: instance})
+    assert_receive {:readiness_blocked, gate}, 1_000
+    parent = Controller.whereis_agent(controller, :parent)
+
+    {_, runtime, _, _} =
+      Enum.find(Supervisor.which_children(controller), &(elem(&1, 0) == Controller.Runtime))
+
+    # Remove the live ready entry after dispatch. The task must keep its snapshot.
+    :sys.replace_state(runtime, fn state -> %{state | ready: %{}} end)
+    send(gate, :release)
+    assert :ok = Controller.await_ready(controller)
+    child = Controller.whereis_agent(controller, :child)
+    assert Server.children(parent)["agent/child"].pid == child
+  end
+
+  test "a failed parent blocks child activation", %{jido: jido} do
+    {:ok, unrelated} = Jido.start_agent(jido, Cell, id: "blocked-parent/agent/parent")
+
+    instance =
+      Builder.new(name: "blocked-parent")
+      |> Builder.agent(:parent, Cell)
+      |> Builder.agent(:child, Cell)
+      |> Builder.owns(:parent, :child)
+      |> Builder.startup(retry_interval: 60_000)
+      |> Builder.build!(id: "blocked-parent")
+
+    controller = start_supervised!({Controller, jido: jido, topology: instance})
+
+    eventually(fn ->
+      Controller.status(controller).errors == %{
+        "agent/parent" => :agent_identity_in_use,
+        "agent/child" => {:dependencies_unavailable, ["agent/parent"]}
+      }
+    end)
+
+    assert Controller.whereis_agent(controller, :child) == nil
+    assert Process.alive?(unrelated)
+  end
+
   test "a team failure leaves the shared Bus and the other team running", %{jido: jido} do
     instance =
       Builder.new(ComposedSystem)


### PR DESCRIPTION
Startup tasks copied the full controller state. Select the member and its required activation inputs before task creation. Keep the dispatch parent PID and required Bus IDs. Remove the repeated dependency check. Activation faults remain inside the task fault handler.

Parent snapshot and blocked-dependency tests cover the narrowed inputs. Public APIs, ownership, restoration, Bus subscriptions, and asynchronous startup stay the same. Implements S05-01. No measured memory or speed gain is claimed.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `7fe5a135cdcbda6671e70337d2557369776a4a28`.

- 29 focused controller, job, composition, and topology example tests passed on the combined G06 patch.
- The combined G06 head, including child PR #358, passed 1,050 full-suite tests with one approved DIST-03 exclusion. The final coverage retry passed the same selection at 83.3%, using a private temporary directory.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all four combined changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer verified the final base and head IDs for both G06 PRs and found no actionable finding. No issue source change followed that review.

The first coverage run hit a scheduled-occurrence persistence conflict and measured 83.4%. An isolated unchanged baseline passed 1,042 tests, with one exclusion and 83.3% coverage; it did not reproduce the conflict. The final retry passed. Cross-VM temporary-path interference remains a possible cause, not a confirmed cause. The earlier failed run remains in the evidence.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `5e3a1f6dd089ad85670dd598360c667e698f1b9c`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991766499).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #343. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
