### PR TITLE
refactor(agent_server): share task completion cleanup

### DIFF
--- a/lib/jido/agent_server.ex
+++ b/lib/jido/agent_server.ex
@@ -843,8 +843,7 @@ defmodule Jido.AgentServer do
         :admitting,
         %State{admission_task: %{task: %Task{ref: ref}} = pending} = data
       ) do
-    Process.demonitor(ref, [:flush])
-    cancel_task_timer(pending.timer)
+    release_task_result(pending)
     data = %{data | admission_task: nil}
 
     case result do
@@ -877,7 +876,7 @@ defmodule Jido.AgentServer do
         :admitting,
         %State{admission_task: %{task: %Task{ref: task_ref} = task, timer: timer}} = data
       ) do
-    _result = Task.shutdown(task, :brutal_kill)
+    shutdown_task(task)
     data = %{data | admission_task: nil}
 
     error =
@@ -895,8 +894,7 @@ defmodule Jido.AgentServer do
         :directing,
         %State{directive_task: %{task: %Task{ref: ref}} = pending} = data
       ) do
-    Process.demonitor(ref, [:flush])
-    cancel_directive_timer(pending.timer)
+    release_task_result(pending)
     data = %{data | directive_task: nil}
 
     directive_result =
@@ -915,7 +913,7 @@ defmodule Jido.AgentServer do
         :directing,
         %State{directive_task: %{task: %Task{ref: ref}} = pending} = data
       ) do
-    cancel_directive_timer(pending.timer)
+    cancel_task_timer(pending.timer)
     data = %{data | directive_task: nil}
 
     error =
@@ -934,7 +932,7 @@ defmodule Jido.AgentServer do
           directive_task: %{task: %Task{ref: task_ref} = task, timer: timer} = pending
         } = data
       ) do
-    _result = Task.shutdown(task, :brutal_kill)
+    shutdown_task(task)
     data = %{data | directive_task: nil}
 
     error =
@@ -963,12 +961,8 @@ defmodule Jido.AgentServer do
     :keep_state_and_data
   end
 
-  def handle_event(:info, message, :running, %State{active: %ActiveTurn{} = active} = data) do
-    case data.exec_module.handle_message(active.exec_handle, message) do
-      {:done, result} -> finish_turn(result, data)
-      :ignore -> :keep_state_and_data
-      {:error, error} -> fail_turn(error, :execute, data)
-    end
+  def handle_event(:info, message, :running, %State{active: %ActiveTurn{}} = data) do
+    handle_exec_message(message, data)
   end
 
   def handle_event(:info, _message, phase, %State{})
@@ -1016,8 +1010,8 @@ defmodule Jido.AgentServer do
     end
 
     stop_plugin_readiness(data.plugin_bootstrap)
-    stop_admission_task(data.admission_task)
-    stop_directive_task(data.directive_task)
+    stop_task(data.admission_task)
+    stop_task(data.directive_task)
 
     if data.directive_task do
       finish_span_error(data.directive_task.span, {:agent_stopped, reason})
@@ -1093,21 +1087,22 @@ defmodule Jido.AgentServer do
 
   defp stop_plugin_readiness(nil), do: :ok
 
-  defp stop_admission_task(%{task: %Task{} = task} = pending) do
+  defp release_task_result(%{task: %Task{ref: ref}, timer: timer}) do
+    Process.demonitor(ref, [:flush])
+    cancel_task_timer(timer)
+  end
+
+  defp stop_task(%{task: %Task{} = task} = pending) do
     cancel_task_timer(Map.get(pending, :timer))
+    shutdown_task(task)
+  end
+
+  defp stop_task(nil), do: :ok
+
+  defp shutdown_task(%Task{} = task) do
     _result = Task.shutdown(task, :brutal_kill)
     :ok
   end
-
-  defp stop_admission_task(nil), do: :ok
-
-  defp stop_directive_task(%{task: %Task{} = task} = pending) do
-    cancel_directive_timer(Map.get(pending, :timer))
-    _result = Task.shutdown(task, :brutal_kill)
-    :ok
-  end
-
-  defp stop_directive_task(nil), do: :ok
 
   defp initial_command(%Signal{} = signal, context, %State{} = data) do
     context = Map.merge(context, %{jido: data.jido, partition: data.partition})
@@ -1350,7 +1345,7 @@ defmodule Jido.AgentServer do
   end
 
   defp cancel_admission(cancel_from, %State{active: %ActiveTurn{} = active} = data) do
-    stop_admission_task(data.admission_task)
+    stop_task(data.admission_task)
     finish_span_error(active.span, :cancelled)
     TraceContext.clear()
     outcome = turn_outcome(data, :cancelled, :prepare, :cancelled)
@@ -1560,8 +1555,6 @@ defmodule Jido.AgentServer do
   defp start_task_timer(timeout, tag, task_ref) do
     :erlang.start_timer(timeout, self(), {tag, task_ref})
   end
-
-  defp cancel_directive_timer(timer), do: cancel_task_timer(timer)
 
   defp cancel_task_timer(nil), do: :ok
 

--- a/test/jido/agent_server_context_test.exs
+++ b/test/jido/agent_server_context_test.exs
@@ -9,6 +9,14 @@ defmodule Jido.AgentServerContextTest do
 
     @impl true
     def admit(_runtime, command, _opts) do
+      if gate = Map.get(command.context, :gate) do
+        send(command.context.observer, {:admission_blocked, gate, self()})
+
+        receive do
+          {:release, ^gate} -> :ok
+        end
+      end
+
       send(command.context.observer, {:context_admitted, command.context, command.signal})
       {:ok, %{command | context: Map.put(command.context, :admitted, true)}}
     end
@@ -53,6 +61,117 @@ defmodule Jido.AgentServerContextTest do
       schema: Zoi.object(%{value: Zoi.integer() |> Zoi.default(0)}),
       routes: [{"context.input", Emit}],
       plugins: [ContextPlugin]
+  end
+
+  for failure <- [:exit, :timeout] do
+    @failure failure
+    test "admission #{@failure} preserves state and releases the worker", %{jido: jido} do
+      test = self()
+
+      policy = fn error, outcome ->
+        send(test, {:admission_failed, error, outcome})
+        :continue
+      end
+
+      {:ok, server} =
+        Jido.start_agent(jido, Agent, directive_timeout: 10_000, error_policy: policy)
+
+      before = Server.snapshot(server)
+      gate = make_ref()
+
+      caller =
+        Task.async(fn ->
+          Server.call(server, signal("context.input", %{value: 7}),
+            context: %{observer: test, gate: gate}
+          )
+        end)
+
+      assert_receive {:admission_blocked, ^gate, worker}, 2_000
+      monitor = Process.monitor(worker)
+      {:admitting, state} = :sys.get_state(server)
+      %{task: task, timer: timer} = state.admission_task
+
+      send(server, {:timeout, make_ref(), {:admission_timeout, task.ref}})
+      send(server, {:timeout, timer, {:admission_timeout, make_ref()}})
+      assert Server.status(server).phase == :admitting
+
+      if @failure == :exit do
+        Process.exit(worker, :kill)
+      else
+        send(server, {:timeout, timer, {:admission_timeout, task.ref}})
+      end
+
+      assert {:error, error} = Task.await(caller)
+      assert_receive {:DOWN, ^monitor, :process, ^worker, :killed}, 2_000
+      assert_receive {:admission_failed, ^error, outcome}, 2_000
+      assert outcome.stage == :prepare
+      assert outcome.status == if(@failure == :exit, do: :failed, else: :timed_out)
+      refute outcome.committed?
+      assert Server.snapshot(server) == before
+      assert Server.status(server).phase == :idle
+      refute_received {:context_executed, _}
+
+      send(server, {task.ref, {:error, :stale}})
+      send(server, {:timeout, timer, {:admission_timeout, task.ref}})
+      assert Server.status(server).phase == :idle
+
+      assert {:ok, committed} =
+               Server.call(server, signal("context.input", %{value: 8}),
+                 context: %{observer: test}
+               )
+
+      assert committed.state == %{value: 8, context_plugin: 1}
+    end
+  end
+
+  test "admission cancellation stops its worker before the reply", %{jido: jido} do
+    {:ok, server} = Jido.start_agent(jido, Agent, directive_timeout: 10_000)
+    before = Server.snapshot(server)
+    test = self()
+    gate = make_ref()
+
+    caller =
+      Task.async(fn ->
+        Server.call(server, signal("context.input", %{value: 7}),
+          context: %{observer: test, gate: gate}
+        )
+      end)
+
+    assert_receive {:admission_blocked, ^gate, worker}, 2_000
+    monitor = Process.monitor(worker)
+    {:admitting, state} = :sys.get_state(server)
+    assert :ok = Server.cancel(server)
+    refute Process.alive?(worker)
+    assert_receive {:DOWN, ^monitor, :process, ^worker, :killed}, 2_000
+    assert {:error, :cancelled} = Task.await(caller)
+    assert Process.read_timer(state.admission_task.timer) == false
+    assert Server.snapshot(server) == before
+    assert Server.status(server).phase == :idle
+  end
+
+  test "admission result releases its monitor and timer", %{jido: jido} do
+    {:ok, server} = Jido.start_agent(jido, Agent, directive_timeout: 10_000)
+    test = self()
+    gate = make_ref()
+
+    caller =
+      Task.async(fn ->
+        Server.call(server, signal("context.input", %{value: 7}),
+          context: %{observer: test, gate: gate}
+        )
+      end)
+
+    assert_receive {:admission_blocked, ^gate, worker}, 2_000
+    {:admitting, state} = :sys.get_state(server)
+    %{task: task, timer: timer} = state.admission_task
+    send(worker, {:release, gate})
+    assert {:ok, _} = Task.await(caller)
+    eventually(fn -> Server.status(server).phase == :idle end)
+    assert Process.read_timer(timer) == false
+    {:monitors, monitors} = Process.info(server, :monitors)
+    refute {:process, worker} in monitors
+    send(server, {task.ref, {:error, :stale}})
+    assert Server.status(server).state_version == 1
   end
 
   test "context crosses Plugin admission and execution but is not copied to state or Signals", %{

--- a/test/jido/agent_server_runtime_test.exs
+++ b/test/jido/agent_server_runtime_test.exs
@@ -43,6 +43,21 @@ defmodule Jido.AgentServerRuntimeTest do
       ]
   end
 
+  defmodule ObservedExec do
+    def run_async(executable, input, context, opts) do
+      test = Map.get(input, :test) || get_in(input, [:signal, Access.key(:data), :test])
+      Process.put(__MODULE__, test)
+      Jido.Exec.run_async(executable, input, context, opts)
+    end
+
+    def handle_message(handle, message) do
+      send(Process.get(__MODULE__), {:exec_message, message})
+      Jido.Exec.handle_message(handle, message)
+    end
+
+    defdelegate cancel(handle), to: Jido.Exec
+  end
+
   defmodule CountedDirective do
     defstruct [:test]
   end
@@ -361,6 +376,40 @@ defmodule Jido.AgentServerRuntimeTest do
     end
   end
 
+  test "Exec receives general messages and unowned DOWN events after attachment handling", %{
+    jido: jido
+  } do
+    {:ok, server} = Jido.start_agent(jido, OwnedExecutionAgent, exec_module: ObservedExec)
+    owner = start_supervised!({Elixir.Agent, fn -> nil end})
+    assert :ok = Server.attach(server, owner)
+    gate = make_ref()
+    test = self()
+
+    caller =
+      Task.async(fn ->
+        Server.call(server, signal("owned.action", %{test: test, gate: gate, label: :routing}))
+      end)
+
+    assert_receive {:owned_execution, :routing, worker}, 2_000
+    {:running, state} = :sys.get_state(server)
+    owner_ref = Map.fetch!(state.attachments, owner)
+    Elixir.Agent.stop(owner)
+    eventually(fn -> Server.status(server).runtime.lifecycle.attached == 0 end)
+    refute_received {:exec_message, {:DOWN, ^owner_ref, :process, ^owner, _}}
+
+    unknown = make_ref()
+    down = {:DOWN, unknown, :process, owner, :normal}
+    send(server, down)
+    send(server, {:exec_probe, gate})
+    assert Server.status(server).phase == :running
+    assert_receive {:exec_message, ^down}
+    assert_receive {:exec_message, {:exec_probe, ^gate}}
+    send(worker, {:release, gate})
+    assert {:ok, _} = Task.await(caller)
+    eventually(fn -> Server.status(server).phase == :idle end)
+    assert Server.status(server).state_version == 1
+  end
+
   test "Agent death stops its linked Exec and Action work", %{jido: jido} do
     id = unique_id("owned-exec-stop")
     {:ok, agent} = Jido.start_agent(jido, OwnedExecutionAgent, id: id)
@@ -582,6 +631,59 @@ defmodule Jido.AgentServerRuntimeTest do
 
     send(worker, {:release, gate})
     eventually(fn -> Server.status(pid).phase == :idle end)
+  end
+
+  test "Directive task exit retains the commit and ignores stale timeouts", %{jido: jido} do
+    test = self()
+
+    policy = fn error, outcome ->
+      send(test, {:dispatch_failed, error, outcome})
+      :continue
+    end
+
+    {:ok, pid} =
+      Jido.start_agent(jido, SlowDirectiveAgent, directive_timeout: 10_000, error_policy: policy)
+
+    gate = make_ref()
+
+    assert {:ok, committed} =
+             Server.call(pid, signal("directive.slow", %{test: test, gate: gate}))
+
+    assert_receive {:plugin_directive_blocked, ^gate, worker}
+    monitor = Process.monitor(worker)
+    {:directing, state} = :sys.get_state(pid)
+    %{task: task, timer: timer} = state.directive_task
+    send(pid, {:timeout, make_ref(), {:directive_timeout, task.ref}})
+    send(pid, {:timeout, timer, {:directive_timeout, make_ref()}})
+    assert Server.status(pid).phase == :directing
+    Process.exit(worker, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^worker, :killed}
+
+    assert_receive {:dispatch_failed, %Jido.Error.ExecutionError{},
+                    %Outcome{
+                      status: :failed,
+                      stage: :directive,
+                      committed?: true,
+                      directives: %{failed: 1, failed_index: 0}
+                    }}
+
+    eventually(fn -> Server.status(pid).phase == :idle end)
+    assert Server.snapshot(pid) == %{agent: committed, state_version: 1}
+    assert Process.read_timer(timer) == false
+
+    next_gate = make_ref()
+    assert {:ok, _} = Server.call(pid, signal("directive.slow", %{test: test, gate: next_gate}))
+    assert_receive {:plugin_directive_blocked, ^next_gate, next_worker}
+    {:directing, next_state} = :sys.get_state(pid)
+    send(pid, {task.ref, {:error, :stale}})
+    send(pid, {:timeout, timer, {:directive_timeout, task.ref}})
+    assert Server.status(pid).phase == :directing
+    send(next_worker, {:release, next_gate})
+    eventually(fn -> Server.status(pid).phase == :idle end)
+    assert Process.read_timer(next_state.directive_task.timer) == false
+    {:monitors, monitors} = Process.info(pid, :monitors)
+    refute {:process, next_worker} in monitors
+    assert Server.status(pid).state_version == 2
   end
 
   test "times out owned Plugin Directive work and records exact progress", %{jido: jido} do


### PR DESCRIPTION
Share admission and directive task result cleanup, timer cancellation and explicit shutdown helpers. Both phases keep their own fields and outcomes. Cleanup order and matching timer/task guards stay the same. Route general running messages through the existing Exec result handler, after the earlier DOWN ownership clauses.

Scope: S02-02 and S02-03. Production changes only in `lib/jido/agent_server.ex`. Exec cancellation and Plugin readiness handling remain separate. The startup reply-alias race fix remains intact.

New tests cover admission exit, timeout and cancellation, result monitor and timer cleanup, directive worker exit after commit, stale timer and result events, and Exec routing after attachment DOWN handling. Public APIs, persistence, encoding, outcomes, and telemetry stay the same.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `991b5d08e28723b7965f6bdc2ed59bb123346766`.

- 97 focused tests passed for the combined G03 patch.
- The combined G03 head passed 1,049 full-suite tests with one approved DIST-03 exclusion. Its coverage repeat passed the same selection: 83.5% total, AgentServer 84.3%, and State 100%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all five combined changed files returned exit 16 for four Logger metadata warnings. Exact baseline files produced the same warnings. The foundation now adds those Logger keys.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer checked parent #355 at `20d2f39bb5e7b81c3f0454188ac2b49a99f55c74` and this child at `991b5d08e28723b7965f6bdc2ed59bb123346766` against their exact bases. No actionable finding or required source fix was found.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `141219dc2be1684aa5e0d86d740b6ba4cce03318`.
Target: `v3-spike`. CI test base: `07c5cd9843c23ca2b978b2598ea0fc3d1d045ac5`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33992058453).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #340. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
