### PR TITLE
refactor(topology): keep timeout state in active jobs

### DIFF
--- a/lib/jido/topology/controller/runtime.ex
+++ b/lib/jido/topology/controller/runtime.ex
@@ -20,8 +20,7 @@ defmodule Jido.Topology.Controller.Runtime do
       waiters: %{},
       phase: :starting,
       pending: MapSet.new(),
-      active: %{},
-      timed_out: MapSet.new()
+      active: %{}
     }
 
     {:ok, state, {:continue, :reconcile}}
@@ -33,37 +32,11 @@ defmodule Jido.Topology.Controller.Runtime do
   @impl true
   def handle_info(:reconcile, state), do: {:noreply, begin_pass(state)}
 
-  def handle_info({ref, result}, state) when is_reference(ref) do
-    case Map.pop(state.active, ref) do
-      {nil, _} ->
-        {:noreply, state}
+  def handle_info({ref, result}, state) when is_reference(ref),
+    do: {:noreply, complete(state, ref, result)}
 
-      {job, active} ->
-        Process.demonitor(ref, [:flush])
-        Process.cancel_timer(job.timer)
-
-        result =
-          if MapSet.member?(state.timed_out, ref),
-            do: {:error, :startup_task_timeout},
-            else: result
-
-        state = %{state | active: active, timed_out: MapSet.delete(state.timed_out, ref)}
-        {:noreply, state |> record(job.key, result) |> drive()}
-    end
-  end
-
-  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
-    case Map.pop(state.active, ref) do
-      {nil, _} ->
-        {:noreply, state}
-
-      {job, active} ->
-        Process.cancel_timer(job.timer)
-        reason = if MapSet.member?(state.timed_out, ref), do: :startup_task_timeout, else: reason
-        state = %{state | active: active, timed_out: MapSet.delete(state.timed_out, ref)}
-        {:noreply, state |> record(job.key, {:error, reason}) |> drive()}
-    end
-  end
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state),
+    do: {:noreply, complete(state, ref, {:error, reason})}
 
   def handle_info({:task_timeout, ref}, state) do
     case Map.get(state.active, ref) do
@@ -72,7 +45,7 @@ defmodule Jido.Topology.Controller.Runtime do
 
       job ->
         Process.exit(job.task.pid, :kill)
-        {:noreply, %{state | timed_out: MapSet.put(state.timed_out, ref)}}
+        {:noreply, %{state | active: Map.put(state.active, ref, %{job | timed_out?: true})}}
     end
   end
 
@@ -226,13 +199,26 @@ defmodule Jido.Topology.Controller.Runtime do
         state.instance.definition.startup.task_timeout
       )
 
-    job = %{key: key, task: task, timer: timer}
+    job = %{key: key, task: task, timer: timer, timed_out?: false}
 
     %{
       state
       | pending: MapSet.delete(state.pending, key),
         active: Map.put(state.active, task.ref, job)
     }
+  end
+
+  defp complete(state, ref, result) do
+    case Map.pop(state.active, ref) do
+      {nil, _} ->
+        state
+
+      {job, active} ->
+        Process.demonitor(ref, [:flush])
+        Process.cancel_timer(job.timer)
+        result = if job.timed_out?, do: {:error, :startup_task_timeout}, else: result
+        %{state | active: active} |> record(job.key, result) |> drive()
+    end
   end
 
   defp record(state, key, {:ok, pid}), do: %{state | ready: Map.put(state.ready, key, pid)}

--- a/test/jido/topology/controller_job_test.exs
+++ b/test/jido/topology/controller_job_test.exs
@@ -1,0 +1,126 @@
+defmodule Jido.Topology.ControllerJobTest do
+  use JidoTest.Case, async: true
+
+  alias Jido.Examples.Topology.Cell
+  alias Jido.Topology.Builder
+  alias Jido.Topology.Controller.Runtime
+
+  test "timeout retains capacity until DOWN and blocks dependents", %{jido: jido} do
+    {state, task} = active_job(jido)
+    ref = task.ref
+    monitor = Process.monitor(task.pid)
+    assert {:noreply, timed_out} = Runtime.handle_info({:task_timeout, ref}, state)
+    assert map_size(timed_out.active) == 1
+    assert timed_out.pending == state.pending
+    assert timed_out.errors == %{}
+    assert {:noreply, ^timed_out} = Runtime.handle_info({:task_timeout, ref}, timed_out)
+    assert_receive {:DOWN, ^monitor, :process, _, :killed}, 1_000
+    assert_receive {:DOWN, ^ref, :process, pid, :killed}, 1_000
+
+    assert {:noreply, finished} =
+             Runtime.handle_info({:DOWN, ref, :process, pid, :killed}, timed_out)
+
+    assert finished.active == %{}
+
+    assert finished.errors == %{
+             "agent/parent" => :startup_task_timeout,
+             "agent/child" => {:dependencies_unavailable, ["agent/parent"]}
+           }
+
+    assert finished.phase == :degraded
+    assert_stale_messages(finished, task)
+  end
+
+  for result <- [{:ok, :late_pid}, {:error, :late_error}] do
+    @result result
+    test "timeout takes precedence over queued result #{inspect(result)}", %{jido: jido} do
+      {state, task} = active_job(jido)
+      assert {:noreply, timed_out} = Runtime.handle_info({:task_timeout, task.ref}, state)
+      assert {:noreply, finished} = Runtime.handle_info({task.ref, @result}, timed_out)
+      assert finished.errors["agent/parent"] == :startup_task_timeout
+      assert finished.ready == %{}
+      assert finished.active == %{}
+      assert_stale_messages(finished, task)
+    end
+  end
+
+  test "result releases a slot once and later timeout and DOWN are stale", %{jido: jido} do
+    {state, task} = active_job(jido)
+    state = %{state | pending: MapSet.new()}
+    assert {:noreply, finished} = Runtime.handle_info({task.ref, {:ok, self()}}, state)
+    assert finished.ready == %{"agent/parent" => self()}
+    assert finished.errors == %{}
+    assert finished.active == %{}
+    assert finished.phase == :ready
+    assert_stale_messages(finished, task)
+  end
+
+  test "DOWN without timeout keeps its reason", %{jido: jido} do
+    {state, task} = active_job(jido)
+
+    assert {:noreply, finished} =
+             Runtime.handle_info({:DOWN, task.ref, :process, task.pid, :activation_failed}, state)
+
+    assert finished.errors["agent/parent"] == :activation_failed
+    assert finished.active == %{}
+    assert_stale_messages(finished, task)
+  end
+
+  test "unknown references do not change an active job", %{jido: jido} do
+    {state, _task} = active_job(jido)
+    unknown = make_ref()
+    assert {:noreply, ^state} = Runtime.handle_info({unknown, {:ok, self()}}, state)
+    assert {:noreply, ^state} = Runtime.handle_info({:task_timeout, unknown}, state)
+
+    assert {:noreply, ^state} =
+             Runtime.handle_info({:DOWN, unknown, :process, self(), :normal}, state)
+  end
+
+  defp active_job(jido) do
+    supervisor = start_supervised!(Task.Supervisor)
+    observer = self()
+
+    task =
+      Task.Supervisor.async_nolink(supervisor, fn ->
+        send(observer, {:task_waiting, self()})
+
+        receive do
+          :release -> {:ok, self()}
+        end
+      end)
+
+    assert_receive {:task_waiting, pid}, 1_000
+    assert pid == task.pid
+    timer = Process.send_after(self(), {:task_timeout, task.ref}, 60_000)
+    on_exit(fn -> Process.cancel_timer(timer) end)
+
+    instance =
+      Builder.new(name: "job-events")
+      |> Builder.agent(:parent, Cell)
+      |> Builder.agent(:child, Cell)
+      |> Builder.owns(:parent, :child)
+      |> Builder.startup(concurrency: 1, retry_interval: 60_000)
+      |> Builder.build!(id: "job-events")
+
+    state = %{
+      jido: jido,
+      instance: instance,
+      ready: %{},
+      errors: %{},
+      waiters: %{},
+      phase: :starting,
+      pending: MapSet.new(["agent/child"]),
+      active: %{task.ref => %{key: "agent/parent", task: task, timer: timer, timed_out?: false}}
+    }
+
+    {state, task}
+  end
+
+  defp assert_stale_messages(state, task) do
+    assert {:noreply, ^state} = Runtime.handle_info({task.ref, {:ok, self()}}, state)
+    assert {:noreply, ^state} = Runtime.handle_info({:task_timeout, task.ref}, state)
+
+    assert {:noreply, ^state} =
+             Runtime.handle_info({:DOWN, task.ref, :process, task.pid, :normal}, state)
+  end
+end


### PR DESCRIPTION
The controller kept timeout references in a separate set. Store `timed_out?` in each active job and use one completion function for result and DOWN messages. A timeout kills the task but keeps its slot occupied until a terminal message is processed. Timeout precedence and stale-reference handling stay intact.

Production edits are limited to controller runtime state and completion handling. Public APIs are unchanged. Implements S05-02. No measured memory or speed gain is claimed.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `7fe5a135cdcbda6671e70337d2557369776a4a28`.

- 29 focused controller, job, composition, and topology example tests passed on the combined G06 patch.
- The combined G06 head passed 1,050 full-suite tests with one approved DIST-03 exclusion. The final coverage retry passed the same selection at 83.3%, using a private temporary directory.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all four combined changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer verified the final base and head IDs for both G06 PRs and found no actionable finding. No issue source change followed that review.

The first coverage run hit a scheduled-occurrence persistence conflict and measured 83.4%. An isolated unchanged baseline passed 1,042 tests, with one exclusion and 83.3% coverage; it did not reproduce the conflict. The final retry passed. Cross-VM temporary-path interference remains a possible cause, not a confirmed cause. The earlier failed run remains in the evidence.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `1fc60c6ea63007d5432c2ce6194726b6aaa58db9`.
Target: `v3-spike`. CI test base: `316032f67237d1dd49b0fdeec991c4f6e8a12a3d`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33992258435).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #343. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
