### PR TITLE
refactor(plugin): share result checks and remove unused Bus field

### DIFF
--- a/lib/jido/plugin.ex
+++ b/lib/jido/plugin.ex
@@ -365,18 +365,7 @@ defmodule Jido.Plugin do
       [runtime_ref, directive, context, spec.options],
       "Agent Plugin Directive dispatch failed"
     )
-    |> case do
-      :ok ->
-        :ok
-
-      {:error, _reason} = error ->
-        error
-
-      result ->
-        plugin_invalid("Agent Plugin dispatch/4 returned an invalid result", spec.module, %{
-          result: result
-        })
-    end
+    |> validate_status_result(spec.module, "Agent Plugin dispatch/4 returned an invalid result")
   end
 
   @doc false
@@ -390,20 +379,10 @@ defmodule Jido.Plugin do
         [runtime_ref, spec.options],
         "Agent Plugin readiness check failed"
       )
-      |> case do
-        :ok ->
-          :ok
-
-        {:error, _reason} = error ->
-          error
-
-        result ->
-          plugin_invalid(
-            "Agent Plugin await_ready/2 returned an invalid result",
-            spec.module,
-            %{result: result}
-          )
-      end
+      |> validate_status_result(
+        spec.module,
+        "Agent Plugin await_ready/2 returned an invalid result"
+      )
     else
       :ok
     end
@@ -667,16 +646,7 @@ defmodule Jido.Plugin do
       safe_apply(module, :prepare, [command, opts], "Agent Plugin prepare/2 failed")
       |> case do
         {:ok, %Command{} = prepared} ->
-          with {:ok, prepared} <- Command.validate(prepared),
-               true <- prepared.agent == command.agent do
-            {:ok, prepared}
-          else
-            false ->
-              plugin_invalid("Agent Plugin cannot replace the Agent", module, %{})
-
-            {:error, _reason} = error ->
-              error
-          end
+          validate_command_agent(prepared, command, module, %{})
 
         {:error, _reason} = error ->
           error
@@ -735,16 +705,7 @@ defmodule Jido.Plugin do
   defp validate_admission_result(result, original, module) do
     case result do
       {:ok, %Command{} = command} ->
-        with {:ok, command} <- Command.validate(command),
-             true <- command.agent == original.agent do
-          {:ok, command}
-        else
-          false ->
-            plugin_invalid("Agent Plugin cannot replace the Agent", module, %{callback: :admit})
-
-          {:error, _reason} = error ->
-            error
-        end
+        validate_command_agent(command, original, module, %{callback: :admit})
 
       {:error, _reason} = error ->
         error
@@ -756,6 +717,26 @@ defmodule Jido.Plugin do
           %{result: invalid_result}
         )
     end
+  end
+
+  defp validate_command_agent(command, original, module, replacement_details) do
+    with {:ok, command} <- Command.validate(command),
+         true <- command.agent == original.agent do
+      {:ok, command}
+    else
+      false ->
+        plugin_invalid("Agent Plugin cannot replace the Agent", module, replacement_details)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp validate_status_result(:ok, _module, _message), do: :ok
+  defp validate_status_result({:error, _reason} = error, _module, _message), do: error
+
+  defp validate_status_result(result, module, message) do
+    plugin_invalid(message, module, %{result: result})
   end
 
   defp callback_modules(specs, function, arity) do

--- a/lib/jido/plugin/bus/client/runtime.ex
+++ b/lib/jido/plugin/bus/client/runtime.ex
@@ -24,7 +24,6 @@ defmodule Jido.Plugin.Bus.Client.Runtime do
          bus_ref: nil,
          config: config,
          pending: nil,
-         reconnect_timer: nil,
          reconnect_token: nil,
          retry_timer: nil,
          subscription_id: nil
@@ -83,7 +82,7 @@ defmodule Jido.Plugin.Bus.Client.Runtime do
   end
 
   def handle_info({:reconnect, token}, %{reconnect_token: token} = state) do
-    state = %{state | reconnect_timer: nil, reconnect_token: nil}
+    state = %{state | reconnect_token: nil}
 
     case connect(state) do
       {:ok, state} -> {:noreply, state}
@@ -132,8 +131,8 @@ defmodule Jido.Plugin.Bus.Client.Runtime do
 
   defp schedule_reconnect(state) do
     token = make_ref()
-    timer = Process.send_after(self(), {:reconnect, token}, state.config.retry_delay_ms)
-    %{state | reconnect_timer: timer, reconnect_token: token}
+    Process.send_after(self(), {:reconnect, token}, state.config.retry_delay_ms)
+    %{state | reconnect_token: token}
   end
 
   defp connect(state) do

--- a/test/jido/plugin/bus_test.exs
+++ b/test/jido/plugin/bus_test.exs
@@ -148,6 +148,47 @@ defmodule Jido.Plugin.BusTest do
     eventually(fn -> Server.agent(agent).state.values == [11] end)
   end
 
+  test "Client ignores stale reconnect messages after reconnecting", %{jido: jido} do
+    bus = start_supervised!({Bus, name: :plugin_bus, jido: jido}, id: :reconnect_test_bus)
+
+    init = %Jido.Plugin.Init{
+      agent_server: self(),
+      agent_id: unique_id("reconnect-token"),
+      module: Client,
+      jido: jido,
+      options: [bus: :plugin_bus, retry_delay_ms: 60_000]
+    }
+
+    client = start_supervised!({Jido.Plugin.Bus.Client.Runtime, init})
+    assert :ok = GenServer.call(client, :await_ready)
+    monitor = Process.monitor(bus)
+    assert :ok = stop_supervised(:reconnect_test_bus)
+    assert_receive {:DOWN, ^monitor, :process, ^bus, :shutdown}
+
+    token = eventually(fn -> :sys.get_state(client).reconnect_token end)
+    send(client, {:reconnect, token})
+    # The call is a barrier after the failed reconnect attempt.
+    assert {:error, :not_ready} = GenServer.call(client, :await_ready)
+    next_token = :sys.get_state(client).reconnect_token
+    assert is_reference(next_token)
+    refute next_token == token
+
+    new_bus = start_supervised!({Bus, name: :plugin_bus, jido: jido}, id: :reconnect_test_bus)
+    send(client, {:reconnect, token})
+    assert {:error, :not_ready} = GenServer.call(client, :await_ready)
+    assert :sys.get_state(client).reconnect_token == next_token
+
+    send(client, {:reconnect, next_token})
+    assert :ok = GenServer.call(client, :await_ready)
+    connected = :sys.get_state(client)
+    assert connected.bus == new_bus
+    assert connected.reconnect_token == nil
+
+    send(client, {:reconnect, token})
+    send(client, {:reconnect, next_token})
+    assert :sys.get_state(client) == connected
+  end
+
   test "Client reconnects when its owned Bus restarts", %{jido: jido} do
     {:ok, agent} = Jido.start_agent(jido, OwnedBusAgent, id: unique_id("owned-restart"))
     children = Server.children(agent)

--- a/test/jido/plugin/result_contract_test.exs
+++ b/test/jido/plugin/result_contract_test.exs
@@ -1,0 +1,122 @@
+defmodule Jido.Plugin.ResultContractTest do
+  use JidoTest.Case, async: true
+
+  alias Jido.Agent.Command
+  alias Jido.Plugin
+  alias Jido.Plugin.{DirectiveContext, Spec}
+
+  defmodule Agent do
+    use Jido.Agent,
+      name: "plugin_result_contract",
+      schema: Zoi.object(%{count: Zoi.integer() |> Zoi.default(1)})
+  end
+
+  defmodule CallbackPlugin do
+    use Jido.Plugin
+
+    @impl true
+    def prepare(command, opts), do: Keyword.fetch!(opts, :callback).(command)
+    @impl true
+    def admit(_runtime, command, opts), do: prepare(command, opts)
+    @impl true
+    def dispatch(_runtime, _directive, _context, opts), do: prepare(nil, opts)
+    @impl true
+    def await_ready(_runtime, opts), do: prepare(nil, opts)
+  end
+
+  for callback <- [:prepare, :admit] do
+    test "#{callback} validates before it compares the Agent" do
+      command = command()
+      changed = %{command | agent: %{command.agent | id: "replacement"}, context: []}
+      assert {:error, expected} = Command.validate(changed)
+
+      assert {:error, actual} =
+               run_command(unquote(callback), command, fn _ -> {:ok, changed} end)
+
+      assert actual.message == expected.message
+      assert actual.details == expected.details
+    end
+
+    test "#{callback} keeps numeric Agent equality and the returned value" do
+      command = command()
+      changed = %{command | agent: %{command.agent | state: %{count: 1.0}}}
+      assert changed.agent == command.agent
+      refute changed.agent === command.agent
+      assert {:ok, actual} = run_command(unquote(callback), command, fn _ -> {:ok, changed} end)
+      assert actual === changed
+    end
+
+    test "#{callback} keeps Agent replacement error details" do
+      command = command()
+      changed = %{command | agent: %{command.agent | id: "replacement"}}
+      assert {:error, error} = run_command(unquote(callback), command, fn _ -> {:ok, changed} end)
+      assert error.message == "Agent Plugin cannot replace the Agent"
+
+      expected =
+        if unquote(callback) == :admit,
+          do: %{plugin: CallbackPlugin, callback: :admit},
+          else: %{plugin: CallbackPlugin}
+
+      assert error.details == expected
+    end
+  end
+
+  for {callback, label, failure} <- [
+        {:dispatch, "dispatch/4", "Agent Plugin Directive dispatch failed"},
+        {:await_ready, "await_ready/2", "Agent Plugin readiness check failed"}
+      ] do
+    test "#{callback} keeps success, returned errors, and invalid result details" do
+      for result <- [:ok, {:error, %{reason: :denied}}] do
+        assert run_status(unquote(callback), fn _ -> result end) === result
+      end
+
+      assert {:error, error} = run_status(unquote(callback), fn _ -> {:ok, :unexpected} end)
+      assert error.message == "Agent Plugin #{unquote(label)} returned an invalid result"
+      assert error.details == %{plugin: CallbackPlugin, result: {:ok, :unexpected}}
+    end
+
+    test "#{callback} contains raised errors, throws, and exits" do
+      assert {:error, error} = run_status(unquote(callback), fn _ -> raise "callback fault" end)
+      assert error.message == unquote(failure)
+
+      assert %{plugin: CallbackPlugin, error: %RuntimeError{message: "callback fault"}} =
+               error.details
+
+      for {kind, fun} <- [throw: fn _ -> throw(:fault) end, exit: fn _ -> exit(:fault) end] do
+        assert {:error, error} = run_status(unquote(callback), fun)
+        assert error.message == unquote(failure)
+        assert error.details == %{plugin: CallbackPlugin, kind: kind, reason: :fault}
+      end
+    end
+  end
+
+  test "readiness does not invoke runtime-free or absent callbacks" do
+    spec = spec(fn _ -> flunk("runtime-free readiness callback was invoked") end)
+    assert :ok = Plugin.await_ready(%{spec | runtime?: false}, nil)
+    assert :ok = Plugin.await_ready(%{spec | module: __MODULE__}, nil)
+  end
+
+  defp command do
+    {:ok, command} =
+      Command.new(Agent.new!(id: "original"), signal("test.input"))
+
+    command
+  end
+
+  defp spec(fun), do: %Spec{module: CallbackPlugin, options: [callback: fun], runtime?: true}
+
+  defp run_command(:prepare, command, fun) do
+    case Plugin.prepare_specs(command, [spec(fun)]) do
+      {:ok, prepared, _specs} -> {:ok, prepared}
+      error -> error
+    end
+  end
+
+  defp run_command(:admit, command, fun), do: Plugin.admit(command, [spec(fun)], %{})
+
+  defp run_status(:dispatch, fun) do
+    Plugin.dispatch(spec(fun), nil, :directive, struct(DirectiveContext))
+  end
+
+  defp run_status(:await_ready, fun), do: Plugin.await_ready(spec(fun), nil)
+end


### PR DESCRIPTION
Preparation and admission repeat the same successful Command checks. Dispatch and readiness repeat the same status checks. Share these checks in private validators. Keep validation before Agent comparison, `==` equality, callback order, exact error messages and details, and fault containment.

Remove the unused Bus `reconnect_timer` field. Keep the timer, reconnect token checks, retry cancellation, and delivery and acknowledgement stages.

Production changes are limited to `lib/jido/plugin.ex` and `lib/jido/plugin/bus/client/runtime.ex`, in separate commits. Plugin discovery-count changes remain deferred. Tests cover validation order, numeric Agent equality, replacement error details, status results, callback faults, readiness guards, failed reconnect attempts, and stale reconnect tokens. Existing timer and durable retry tests remain.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `6f5522d49a96172317a5e25f9e262423cc1c42e4`.

- 62 focused tests passed, including the new result-contract tests.
- 1,054 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.4%; Plugin 84.2% and Bus client runtime 80.2%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all four changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The reviewer checked the actual issue diff and surrounding code at the exact historical base and head. No actionable finding or required source fix was found.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `44fc082710666b82f9cbd12ff5a832f2de5dc158`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991758712).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #341. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
