### PR TITLE
refactor(observe): simplify span error completion

### DIFF
--- a/lib/jido/observe.ex
+++ b/lib/jido/observe.ex
@@ -235,13 +235,14 @@ defmodule Jido.Observe do
   """
   @spec finish_span_error(span_ctx(), atom(), term(), list()) :: :ok
   def finish_span_error(%SpanCtx{} = span_ctx, kind, reason, stacktrace) do
+    emit_exception_event(span_ctx, kind, reason)
+
     invoke_tracer_callback(
       span_ctx,
       :span_exception,
       [span_ctx.tracer_ctx, kind, reason, stacktrace],
       :ok,
-      "span_exception/4",
-      fn -> emit_exception_event(span_ctx, kind, reason, stacktrace) end
+      "span_exception/4"
     )
 
     :ok
@@ -600,13 +601,13 @@ defmodule Jido.Observe do
     rescue
       e ->
         stacktrace = __STACKTRACE__
-        emit_exception_event(span_ctx, :error, e, stacktrace)
+        emit_exception_event(span_ctx, :error, e)
         Process.put(key, %{count: 1, outcome: {:raised, :error, e, stacktrace}})
         reraise e, stacktrace
     catch
       kind, reason ->
         stacktrace = __STACKTRACE__
-        emit_exception_event(span_ctx, kind, reason, stacktrace)
+        emit_exception_event(span_ctx, kind, reason)
         Process.put(key, %{count: 1, outcome: {:raised, kind, reason, stacktrace}})
         :erlang.raise(kind, reason, stacktrace)
     end
@@ -658,7 +659,7 @@ defmodule Jido.Observe do
     measurements
   end
 
-  defp emit_exception_event(%SpanCtx{} = span_ctx, kind, reason, _stacktrace) do
+  defp emit_exception_event(%SpanCtx{} = span_ctx, kind, reason) do
     duration = System.monotonic_time(:nanosecond) - span_ctx.start_time
 
     error_metadata =
@@ -672,13 +673,8 @@ defmodule Jido.Observe do
          callback,
          args,
          fallback,
-         callback_name,
-         before_fun \\ nil
+         callback_name
        ) do
-    if is_function(before_fun, 0) do
-      before_fun.()
-    end
-
     try do
       apply(span_ctx.tracer_module || tracer(span_ctx.metadata), callback, args)
     rescue

--- a/lib/jido/telemetry/agent.ex
+++ b/lib/jido/telemetry/agent.ex
@@ -160,8 +160,10 @@ defmodule Jido.Telemetry.Agent do
   defp interruption_kind({:shutdown, _reason}), do: nil
   defp interruption_kind(_reason), do: :exit
 
-  def result_metadata({:error, reason}),
-    do: Map.put(error_metadata(reason), :status, error_status(reason))
+  def result_metadata({:error, reason}) do
+    metadata = error_metadata(reason)
+    Map.put(metadata, :status, result_error_status(reason, metadata))
+  end
 
   def result_metadata(_result), do: %{status: :ok}
 
@@ -170,7 +172,18 @@ defmodule Jido.Telemetry.Agent do
   def error_status({:child_spawn_indeterminate, _, _, _, _}), do: :indeterminate
 
   def error_status(reason),
-    do: if(error_metadata(reason).error_type == :timeout, do: :timed_out, else: :error)
+    do: metadata_error_status(error_metadata(reason))
+
+  defp result_error_status(:cancelled, _metadata), do: :cancelled
+  defp result_error_status({:parent_down, :cancelled}, _metadata), do: :cancelled
+
+  defp result_error_status({:child_spawn_indeterminate, _, _, _, _}, _metadata),
+    do: :indeterminate
+
+  defp result_error_status(_reason, metadata), do: metadata_error_status(metadata)
+
+  defp metadata_error_status(%{error_type: :timeout}), do: :timed_out
+  defp metadata_error_status(_metadata), do: :error
 
   def error_metadata(reason) do
     public = Error.to_map(reason)

--- a/test/jido/observe/completion_contract_test.exs
+++ b/test/jido/observe/completion_contract_test.exs
@@ -1,0 +1,148 @@
+defmodule JidoTest.Observe.CompletionContractTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.Observe
+  alias Jido.Telemetry.Agent, as: AgentTelemetry
+
+  defmodule CountingError do
+    defexception [:failure, type: :timeout, retryable?: true]
+
+    @impl true
+    def message(error) do
+      send(self(), :error_projected)
+
+      case error.failure do
+        :throw -> throw(:projection_failed)
+        :exit -> exit(:projection_failed)
+        _ -> "counted error"
+      end
+    end
+  end
+
+  defmodule OrderedTracer do
+    @behaviour Jido.Observe.Tracer
+
+    @impl true
+    def span_start(_event, metadata), do: metadata
+
+    @impl true
+    def span_stop(_ctx, _measurements), do: :ok
+
+    @impl true
+    def span_exception(ctx, kind, reason, stacktrace) do
+      send(self(), {:completion, :tracer, kind, reason, stacktrace})
+
+      case ctx.failure do
+        :raise -> raise "tracer failed"
+        :throw -> throw(:tracer_failed)
+        :exit -> exit(:tracer_failed)
+        nil -> :ok
+      end
+    end
+  end
+
+  test "result metadata projects a custom error once and uses the projected timeout type" do
+    assert AgentTelemetry.result_metadata({:error, %CountingError{}}) ==
+             %{status: :timed_out, error_type: :timeout, retryable?: true}
+
+    assert_received :error_projected
+    refute_received :error_projected
+
+    assert AgentTelemetry.error_status(%CountingError{}) == :timed_out
+    assert_received :error_projected
+    refute_received :error_projected
+  end
+
+  test "projection failure retains safe metadata and status" do
+    for failure <- [:throw, :exit] do
+      error = %CountingError{failure: failure}
+
+      assert AgentTelemetry.result_metadata({:error, error}) ==
+               %{status: :error, error_type: :internal, retryable?: false}
+
+      assert_received :error_projected
+      refute_received :error_projected
+      assert AgentTelemetry.error_status(error) == :error
+      assert_received :error_projected
+      refute_received :error_projected
+    end
+  end
+
+  test "raw special statuses and public error status stay consistent" do
+    for {reason, status} <- [
+          {:cancelled, :cancelled},
+          {{:parent_down, :cancelled}, :cancelled},
+          {{:child_spawn_indeterminate, :worker, :node, :id, :timeout}, :indeterminate},
+          {Jido.Error.timeout_error("expired"), :timed_out},
+          {Jido.Error.validation_error("invalid"), :error},
+          {:other, :error}
+        ] do
+      assert AgentTelemetry.result_metadata({:error, reason}) ==
+               Map.put(AgentTelemetry.error_metadata(reason), :status, status)
+
+      assert AgentTelemetry.error_status(reason) == status
+    end
+
+    assert AgentTelemetry.result_metadata({:ok, :value}) == %{status: :ok}
+  end
+
+  test "exception event precedes tracer completion and preserves raw arguments in both modes" do
+    saved = Application.fetch_env(:jido, :observability)
+    event = [:jido, :completion_contract, :exception]
+    handler = {__MODULE__, make_ref()}
+
+    :ok = :telemetry.attach(handler, event, &__MODULE__.capture_event/4, self())
+
+    on_exit(fn ->
+      :telemetry.detach(handler)
+
+      case saved do
+        {:ok, value} -> Application.put_env(:jido, :observability, value)
+        :error -> Application.delete_env(:jido, :observability)
+      end
+    end)
+
+    stacktrace = [{__MODULE__, :raw_frame, 2, [file: ~c"private/source.ex", line: 31]}]
+    reason = %{password: "raw secret", reason: :failed}
+
+    for mode <- [:warn, :strict],
+        failure <- [nil, :raise, :throw, :exit],
+        kind <- [:error, :throw, :exit] do
+      Application.put_env(:jido, :observability,
+        tracer: OrderedTracer,
+        tracer_failure_mode: mode
+      )
+
+      span = Observe.start_span([:jido, :completion_contract], %{failure: failure})
+
+      log =
+        capture_log(fn ->
+          if mode == :strict and failure != nil do
+            assert_raise RuntimeError, fn ->
+              Observe.finish_span_error(span, kind, reason, stacktrace)
+            end
+          else
+            assert Observe.finish_span_error(span, kind, reason, stacktrace) == :ok
+          end
+        end)
+
+      if mode == :warn and failure != nil, do: assert(log =~ "span_exception/4 failed")
+
+      # The same mailbox pattern must consume the event before the tracer call.
+      assert_received {:completion, source, first, second, metadata}
+      assert source == :event
+      assert first == event
+      assert %{duration: duration} = second
+      assert is_integer(duration)
+      assert metadata.kind == kind
+      assert_received {:completion, :tracer, ^kind, ^reason, ^stacktrace}
+      refute_received {:completion, _, _, _, _}
+    end
+  end
+
+  def capture_event(event, measurements, metadata, pid) do
+    send(pid, {:completion, :event, event, measurements, metadata})
+  end
+end


### PR DESCRIPTION
Error result metadata previously converted the same error twice to derive its type and status. Convert it once and use that metadata for status. Keep the three raw-reason statuses and the exported error_status/1 behavior, including safe fallback if conversion fails.

Emit the exception event directly before the tracer callback. Remove the optional private pre-hook and the unused private stacktrace argument. Pass the public raw stacktrace and reason unchanged to the tracer. Keep warn/strict behavior and event names.

Implements S07-02 and S07-03. One error conversion per result is intentional because custom formatting can execute user code. Tests cover conversion count, projection fallback, special statuses, exception event order, raw tracer arguments, and warn/strict modes for raise, throw, and exit. PR #351 has an independent configuration patch. The duration-unit issue remains outside scope.

Historical local validation used the shared runner. Full test and coverage commands included `--include integration --include example --include flaky --seed 0`. Tested source head: `dea4615a5d950be144225a60b238153e3f08c401`.

- 209 focused observation, debug, telemetry, and error transport tests passed.
- 1,046 full-suite tests passed, with one approved DIST-03 exclusion. Coverage was 83.3%.
- Format, compilation with warnings as errors, and Dialyzer passed.
- 30 active warning checks on all three changed files found no issues.

Independent `gpt-6-astra` review with `xhigh` effort is complete. The independent reviewer found no actionable finding on the historical head.

PR #362 supplies the shared CI repair: ExUnit-owned cleanup, the supported GitOps installer option, real warning lint, and docs with warnings treated as errors. It replaces the earlier zero-check lint command and fixes the eight baseline guide warnings. Historical issue test results remain valid evidence for the unchanged issue patch; the rebase review verified its complete diff byte for byte. They are not new test runs on this head.

Reviewed issue patch at head: `56224dec411b1a10a7cc40a20c351b96d8935196`.
Target: `v3-spike`. CI test base: `17f13317274c127a5506c82e74c6ddc00fa0dbf7`.
GitHub CI: all 18 applicable jobs passed on this head. [Verified run](https://github.com/agentjido/jido/actions/runs/33991773761).

The required `jido_action` Flow fix remains Git-pinned. Hex publication is deferred for the V3 integration stack. The package check remains required for PRs to `main`, pushes to `main`, and the `main` merge queue. Multi-seed tests, soak, and the separate beta runtime campaign remain outside this issue.

Foundation #362 and CI correction #363 are merged. This PR now targets `v3-spike`. The exact issue diff is unchanged after rebase. Each dependent PR is rebased after its parent merge.

Refs #345. The user approved this merge into `v3-spike`. `CHANGELOG.md` is unchanged.


CI selects `test/jido`, `test/jido_test`, and `test/integration` with integration and flaky tags enabled and seed 0. It excludes `test/examples` by path. Earlier local full-suite evidence above includes manual example checks. Do not publish to Hex.
