### PR TITLE
fix(ci): keep example tests out of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
       runner: blacksmith-2vcpu-ubuntu-2404
       credo_command: mix credo --strict --only warning
       docs_command: mix docs --no-open -f html --warnings-as-errors
-      test_command: mix test --include integration --include example --include flaky --seed 0
+      # Examples run separately. Select paths so integration tags cannot include them.
+      test_command: mix test test/jido test/jido_test test/integration --include integration --include flaky --seed 0
       # The V3 integration branch retains an unreleased Git dependency. Check
       # Hex publication when changes reach main, including its merge queue.
       validate_hex_package: ${{ github.base_ref == 'main' || github.ref == 'refs/heads/main' || github.event.merge_group.base_ref == 'refs/heads/main' }}

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -8,6 +8,8 @@ post-commit effects, persistence faults, remote lifecycle and resource cleanup.
 Use deterministic model adapters or local HTTP/SSE for required examples.
 
 Run `mix test --include example --include integration --include flaky --seed 0`.
+CI runs `mix test test/jido test/jido_test test/integration --include integration --include flaky --seed 0`.
+Keep `test/examples` outside CI. Run the full example selection separately.
 Only the DIST-03 test `one logical identity has at most one live cluster owner`
 in `test/jido/agent/distributed_authority_test.exs` can be skipped. Keep its
 assertion and reason. Do not exclude a group to hide a failure. A missing or empty


### PR DESCRIPTION
Keep example tests out of CI, as requested. Select `test/jido`, `test/jido_test`, and `test/integration` explicitly. Keep integration and flaky core tests enabled with seed 0. Selecting paths prevents overlapping integration tags from including files under `test/examples`.

The CI selection covers all current non-example test files. The local full-suite and manual example commands remain available. Test instructions now state the CI policy. No test code, release workflow, dependency, or publication setting changes.

This follows merged PR #362 and targets `v3-spike`. Refs #361. The user has approved the merge after checks. Do not publish to Hex.

Validation: the selected suite passed locally: 804 passed and one approved DIST-03 exclusion. Independent Astra xhigh review verified that all 88 non-example test files are selected and all 50 example files are excluded. No findings remain. [GitHub CI](https://github.com/agentjido/jido/actions/runs/33991528650) passed all 18 applicable jobs on commit `6f792655b57199b5f0c2028179995809b7273af8`, including all four runtime pairs. Merged into `v3-spike` as `17f13317274c` after user approval.
